### PR TITLE
Invoke Web Assembly-specific dependencies when building for Wasm.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,24 +35,25 @@ zip = { version = "0.5.8", default-features = false, features = ["deflate"] }
 getrandom = { version = "0.2.3", features = ["js"] }
 
 # # dependencies because of need to build wasm version for file i/o
-# yew = "0.18.0"
-# wasm-bindgen = "0.2.78"
-# wasm-bindgen-futures = "0.4.28"
-# js-sys = "0.3.35"
-# futures = "0.3.15"
+[target.'cfg(target_arch="wasm32")'.dependencies]
+yew = "0.18.0"
+wasm-bindgen = "0.2.78"
+wasm-bindgen-futures = "0.4.28"
+js-sys = "0.3.35"
+futures = "0.3.15"
 
-# [dependencies.web-sys]
-# version = "0.3.35"
-# features = [
-#     "HtmlInputElement",
-#     # probably not all of these are needed -- copied from an example
-#     "Headers",
-#     "Request",
-#     "RequestInit",
-#     "RequestMode",
-#     "Response",
-#     "Window",
-# ]
+[dependencies.web-sys]
+version = "0.3.35"
+features = [
+     "HtmlInputElement",
+     # probably not all of these are needed -- copied from an example
+     "Headers",
+     "Request",
+     "RequestInit",
+     "RequestMode",
+     "Response",
+     "Window",
+ ]
 
 
 


### PR DESCRIPTION
The purpose of the  proposed change is to allow MatCAT to be compiled to Web Assembly without modification.

This isn't compiling yet. Changes may be necessary before it can be merged.

On my system, at least, compiling dependencies that include C code fails, as Clang can't find the Standard C library (specifically, a file not found error is returned when opening stdlib.h).

The command line was:
cargo build --target wasm32-unknown-unknown

