### PR TITLE
Allow recovering from invalid call to set_rules_dir

### DIFF
--- a/src/interface.rs
+++ b/src/interface.rs
@@ -674,4 +674,10 @@ mod tests {
 
         assert!(is_same_doc(&doc1, &doc2).is_err());
     }
+    #[test]
+    fn can_recover_from_invalid_set_rules_dir() {
+        assert!(set_rules_dir("someInvalidRulesDir".to_string()).is_err());
+        assert!(set_rules_dir(super::super::abs_rules_dir_path()).is_ok());
+        assert!(set_mathml("<math><mn>1</mn></math>".to_string()).is_ok());
+    }
 }

--- a/src/prefs.rs
+++ b/src/prefs.rs
@@ -363,7 +363,10 @@ impl PreferenceManager {
             Ok(rules_dir) => {
                 let (user_prefs, pref_files) = Preferences::from_file(&rules_dir)?;
                 match self.set_all_files(&rules_dir, user_prefs, pref_files) {
-                    Ok(_) => return Ok(()),
+                    Ok(_) => {
+                        self.error = String::new();
+                        return Ok(())
+                    },
                     Err(e) => self.error = errors_to_string(&e),
                 }
             },


### PR DESCRIPTION
This fixes issue #36 by clearing PreferenceManager.error when initialisation succeeds. Also a test to demonstrate the issue and prove the fix works.