### PR TITLE
Update dependency information in callers.md

### DIFF
--- a/docs/callers.md
+++ b/docs/callers.md
@@ -31,8 +31,8 @@ All functions return a potential error code.
 ## Rust Users
 MathCAT is written in Rust, so all you need to do is build MathCAT and in your project's Cargo.toml file add something like
 ```
-[dependencies.MathCAT]
-mathcat = 0.1
+[dependencies.mathcat]
+version = "0.1.22"
 ```
 
 The exact function signatures are (with comments):


### PR DESCRIPTION
For me, the current dependency information did not work. However, with this setting, I copied from an existing extension, it worked.