### PR TITLE
Improve Spanish for double symbols

### DIFF
--- a/Rules/Languages/es/unicode.yaml
+++ b/Rules/Languages/es/unicode.yaml
@@ -42,16 +42,16 @@
         then_test:
             if: "$Verbosity='Terse'"
             then: [T: "abrir paréntesis"]                	# 	(en: 'open', google translation)
-            else: [T: "paréntesis izquierdo"]   	# 	(en: 'open paren', MathPlayer: 'paréntesis', google: 'paréntesis abierto')
-        else: [T: "paréntesis izquierdo"]       	# 	(en: 'left paren', MathPlayer: 'paréntesis', google: 'paréntesis dejado')
+            else: [T: "se abren paréntesis"]   	# 	(en: 'open paren', MathPlayer: 'paréntesis', google: 'paréntesis abierto')
+        else: [T: "se abren paréntesis"]       	# 	(en: 'left paren', MathPlayer: 'paréntesis', google: 'paréntesis dejado')
  - ")":                                         	#  0x29
     - test:
         if: $SpeechStyle = 'ClearSpeak' or $SpeechStyle = 'SimpleSpeak'
         then_test:
             if: "$Verbosity='Terse'"
             then: [T: "cerrar paréntesis"]                  	# 	(en: 'close', google translation)
-            else: [T: "paréntesis derecho"]     	# 	(en: 'close paren', MathPlayer: 'cierra paréntesis', google: 'paréntesis cercana')
-        else: [T: "paréntesis derecho"]         	# 	(en: 'right paren', MathPlayer: 'cierra paréntesis')
+            else: [T: "se cierran paréntesis"]     	# 	(en: 'close paren', MathPlayer: 'cierra paréntesis', google: 'paréntesis cercana')
+        else: [T: "se cierran paréntesis"]         	# 	(en: 'right paren', MathPlayer: 'cierra paréntesis')
 
  - "*":                                         	#  0x2a
     test:
@@ -104,13 +104,13 @@
     - test:
         if: $SpeechStyle = 'ClearSpeak' or $SpeechStyle = 'SimpleSpeak'
         then: [T: "abrir corchetes"]            	# 	(en: 'open bracket', google translation)
-        else: [T: "corchete izquierdo"]         	# 	(en: 'left bracket', MathPlayer: 'abre corchetes', google: 'soporte izquierdo')
- - "\\": [T: "corchete izquierdo"]              	#  0x5c	(en: 'back slash', MathPlayer: 'abre corchetes', google: 'back slash')
+        else: [T: "se abren corchetes"]         	# 	(en: 'left bracket', MathPlayer: 'abre corchetes', google: 'soporte izquierdo')
+ - "\\": [T: "se abren corchetes"]              	#  0x5c	(en: 'back slash', MathPlayer: 'abre corchetes', google: 'back slash')
  - "]":                                         	#  0x5d
     - test:
         if: $SpeechStyle = 'ClearSpeak' or $SpeechStyle = 'SimpleSpeak'
         then: [T: "cerrar corchetes"]          	# 	(en: 'close bracket', google translation)
-        else: [T: "corchete derecho"]           	# 	(en: 'right bracket', MathPlayer: 'cierra corchetes', google: 'soporte derecho')
+        else: [T: "se cierran corchetes"]           	# 	(en: 'right bracket', MathPlayer: 'cierra corchetes', google: 'soporte derecho')
  - "^": [T: "acento circunflejo"]                      	#  0x5e	(en: 'hat')
  - "_": [T: "subrayado"]                        	#  0x5f	(en: 'under bar')
  - "`": [T: "acento grave"]                     	#  0x60	(en: 'grave')
@@ -118,7 +118,7 @@
     - test:
         if: $SpeechStyle = 'ClearSpeak' or $SpeechStyle = 'SimpleSpeak'
         then: [T: "abrir llaves"]         	# 	(en: 'open brace', google translation)
-        else: [T: "llave izquierda"]            	# 	(en: 'left brace', MathPlayer: 'abre llaves', google: 'abrazadera izquierda')
+        else: [T: "se abren llaves"]            	# 	(en: 'left brace', MathPlayer: 'abre llaves', google: 'abrazadera izquierda')
  - "|":                                         	#  0x7c
     # note: for ClearSpeak and SimpleSpeak, "|" inside of sets is handled at the mrow level, same for 'sets'
      - test:
@@ -134,7 +134,7 @@
     - test:
         if: $SpeechStyle = 'ClearSpeak' or $SpeechStyle = 'SimpleSpeak'
         then: [T: "cerrar llaves"]          	# 	(en: 'close brace', google translation)
-        else: [T: "llave derecha"]             	# 	(en: 'right brace', MathPlayer: 'cierra llaves', google: 'abrazadera derecha')
+        else: [T: "se cierran llaves"]             	# 	(en: 'right brace', MathPlayer: 'cierra llaves', google: 'abrazadera derecha')
 
  - "~": [T: "tilde"]                            	#  0x7e
  - " ":                                         	#  0xa0

--- a/tests/Languages/es.rs
+++ b/tests/Languages/es.rs
@@ -1,0 +1,19 @@
+#![allow(non_snake_case)]
+mod SimpleSpeak {
+    mod functions;
+    mod large_ops;
+    // mod menclose;
+    mod mfrac;
+    // mod mroot;
+    mod msup;
+    // mod mtable;
+    mod sets;
+    mod geometry;
+    mod linear_algebra;
+    mod multiline;
+}
+mod shared;
+mod chemistry;
+mod alphabets;
+mod intent;
+

--- a/tests/Languages/es/SimpleSpeak/functions.rs
+++ b/tests/Languages/es/SimpleSpeak/functions.rs
@@ -28,7 +28,7 @@ fn hyperbolic_trig_names() {
     <mi>csch</mi><mi>&#x03D5;</mi><mo>+</mo>
     <mi>coth</mi><mi>&#x03C6;</mi>
     </mrow></math>";
-    test("en", "SimpleSpeak", expr, "seno hipervólico de x, más \
+    test("es", "SimpleSpeak", expr, "seno hipervólico de x, más \
                                 coseno hipervólico de y, más \
                                 tangente hipervólica de z, más \
                                 secante hipervólica de alpha, más \
@@ -40,107 +40,107 @@ fn hyperbolic_trig_names() {
 #[test]
 fn inverse_trig() {
     let expr = "<math><msup><mi>sin</mi><mrow><mo>-</mo><mn>1</mn></mrow></msup><mi>x</mi></math>";
-    test("en", "SimpleSpeak", expr, "inverse sine of x");
+    test("es", "SimpleSpeak", expr, "seno inverso de x");
 }
 
 #[test]
 fn trig_squared() {
     let expr = "<math><msup><mi>sin</mi><mn>2</mn></msup><mi>x</mi></math>";
-    test("en", "SimpleSpeak", expr, "sine squared of x");
+    test("es", "SimpleSpeak", expr, "seno al cuadrado de x");
 }
 
 #[test]
 fn trig_cubed() {
     let expr = "<math><msup><mi>tan</mi><mn>3</mn></msup><mi>x</mi></math>";
-    test("en", "SimpleSpeak", expr, "tangent cubed of x");
+    test("es", "SimpleSpeak", expr, "tangente al cubo de x");
 }
 
 #[test]
 fn trig_fourth() {
     let expr = "<math><msup><mi>sec</mi><mn>4</mn></msup><mi>x</mi></math>";
-    test("en", "SimpleSpeak", expr, "the fourth power of, secant of x");
+    test("es", "SimpleSpeak", expr, "la cuarta potencia de, secante de x");
 }
 
 
 #[test]
 fn trig_power_other() {
     let expr = "<math><msup><mi>sinh</mi><mrow>><mi>n</mi><mo>-</mo><mn>1</mn></mrow></msup><mi>x</mi></math>";
-    test("en", "SimpleSpeak", expr, "the n minus 1 power of, hyperbolic sine of x");
+    test("es", "SimpleSpeak", expr, "la potencia n menos 1 , seno hipervólico de x");
 }
 
 #[test]
 fn simple_log() {
     let expr = "<math> <mrow>  <mi>log</mi><mi>x</mi></mrow> </math>";
-    test("en", "SimpleSpeak", expr, "log x");
+    test("es", "SimpleSpeak", expr, "logaritmo de x");
 }
 
 #[test]
 fn normal_log() {
     let expr = "<math><mrow><mi>log</mi><mrow><mo>(</mo><mrow><mi>x</mi><mo>+</mo><mi>y</mi></mrow><mo>)</mo></mrow></mrow></math>";
-    test("en", "SimpleSpeak", expr, "the log of, open paren x plus y, close paren");
+    test("es", "SimpleSpeak", expr, "el logaritmo de, se abren paréntesis x más y, se cierran paréntesis");
 }
 
 #[test]
 fn simple_log_with_base() {
     let expr = "<math> <mrow>  <msub><mi>log</mi><mi>b</mi></msub><mi>x</mi></mrow> </math>";
-    test("en", "SimpleSpeak", expr, "the log base b of x");
+    test("es", "SimpleSpeak", expr, "el logaritmo en base b de x");
 }
 
 #[test]
 fn normal_log_with_base() {
     let expr = "<math><mrow><msub><mi>log</mi><mi>b</mi></msub><mrow><mo>(</mo><mrow><mi>x</mi><mo>+</mo><mi>y</mi></mrow><mo>)</mo></mrow></mrow></math>";
-    test("en", "SimpleSpeak", expr, "the log base b of, open paren x plus y, close paren");
+    test("es", "SimpleSpeak", expr, "el logaritmo en base b de, se abren paréntesis x más y, se cierran paréntesis");
 }
 
 #[test]
 fn simple_ln() {
     let expr = "<math> <mrow>  <mi>ln</mi><mi>x</mi></mrow> </math>";
-    test("en", "SimpleSpeak", expr, "natural log x");
+    test("es", "SimpleSpeak", expr, "logaritmo natural de x");
 }
 
 #[test]
 fn normal_ln() {
     let expr = "<math><mrow><mi>ln</mi><mrow><mo>(</mo><mrow><mi>x</mi><mo>+</mo><mi>y</mi></mrow><mo>)</mo></mrow></mrow></math>";
-    test("en", "SimpleSpeak", expr, "the natural log of, open paren x plus y, close paren");
+    test("es", "SimpleSpeak", expr, "el logaritmo natural de, se abren paréntesis x más y, se cierran paréntesis");
 }
 
 #[test]
 fn normal_ln_terse() {
     let expr = "<math><mrow><mi>ln</mi><mrow><mo>(</mo><mrow><mi>x</mi><mo>+</mo><mi>y</mi></mrow><mo>)</mo></mrow></mrow></math>";
-    test_prefs("en", "SimpleSpeak", vec![("Verbosity", "Terse")],
-                expr, "l n of, open x plus y close");
+    test_prefs("es", "SimpleSpeak", vec![("Verbosity", "Terse")],
+                expr, "l n de x, apertura x más y cierre");
 }
 
 #[test]
 fn simple_ln_terse() {
     let expr = "<math> <mrow>  <mi>ln</mi><mi>x</mi></mrow> </math>";
-    test_prefs("en", "SimpleSpeak", vec![("Verbosity", "Terse")],
-                expr, "l n x");
+    test_prefs("es", "SimpleSpeak", vec![("Verbosity", "Terse")],
+                expr, "l n de x");
 }
 
 #[test]
 fn explicit_function_call_with_parens() {
     let expr = "<math><mrow><mi>t</mi><mo>&#x2061;</mo><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>";
-    test("en", "SimpleSpeak", expr, "t of x");
+    test("es", "SimpleSpeak", expr, "t de x");
 }
 
 
 #[test]
 fn explicit_times_with_parens() {
     let expr = "<math><mrow><mi>t</mi><mo>&#x2062;</mo><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>";
-    test("en", "SimpleSpeak", expr, "t times x");
+    test("es", "SimpleSpeak", expr, "t veces x");
 }
 
 #[test]
 fn explicit_function_call() {
     let expr = "<math><mrow><mi>t</mi><mo>&#x2061;</mo><mrow><mi>x</mi></mrow></mrow></math>";
-    test("en", "SimpleSpeak", expr, "t of x");
+    test("es", "SimpleSpeak", expr, "t de x");
 }
 
 #[test]
 fn explicit_times() {
     let expr = "<math><mrow><mi>t</mi><mo>&#x2062;</mo><mrow><mi>x</mi></mrow></mrow></math>";
-    test("en", "SimpleSpeak", expr, "t x");
+    test("es", "SimpleSpeak", expr, "t x");
 }
 
 
@@ -150,7 +150,7 @@ fn explicit_times() {
 #[test]
 fn no_times_binomial() {
     let expr = "<math><mrow><mi>x</mi> <mo>&#x2062;</mo> <mi>y</mi></mrow></math>";
-    test("en", "SimpleSpeak", expr, "x y");
+    test("es", "SimpleSpeak", expr, "x y");
 }
 
 #[test]
@@ -159,7 +159,7 @@ fn times_following_paren() {
         <mn>2</mn>
         <mrow>  <mo>(</mo> <mn>3</mn>  <mo>)</mo> </mrow>
         </mrow></math>";
-    test("en", "SimpleSpeak", expr, "2 times 3");
+    test("es", "SimpleSpeak", expr, "2 veces 3");
 }
 
 #[test]
@@ -168,7 +168,7 @@ fn times_preceding_paren() {
         <mrow>  <mo>(</mo> <mn>2</mn>  <mo>)</mo> </mrow>
         <mn>3</mn>
         </mrow></math>";
-    test("en", "SimpleSpeak", expr, "2 times 3");
+    test("es", "SimpleSpeak", expr, "2 veces 3");
 }
 
 #[test]
@@ -179,8 +179,8 @@ fn no_times_sqrt() {
         <mo>=</mo>
         <msqrt> <mrow>  <mi>a</mi><mi>b</mi></mrow> </msqrt>
         </mrow></math>";
-    test("en", "SimpleSpeak", expr, 
-            "the square root of eigh; the square root of b; is equal to, the square root of eigh b end root,");
+    test("es", "SimpleSpeak", expr, 
+            "la raíz cuadrada de 8; la raíz cuadrada de b; es igual a, la raíz cuadrada de 8 b fin de raíz");
 }
 
 /*
@@ -194,7 +194,7 @@ fn no_times_sqrt() {
         <mo>)</mo></mrow>
         <mi>x</mi>
         </mrow></math>";
-        test("en", "SimpleSpeak", expr, "25 times x");
+        test("es", "SimpleSpeak", expr, "25 veces x");
     }
 
     #[test]
@@ -205,7 +205,7 @@ fn no_times_sqrt() {
         <mrow><mi>x</mi><mi>y</mi></mrow>
         <mo>)</mo></mrow>
         </mrow></math>";
-        test("en", "SimpleSpeak", expr, "b x y");
+        test("es", "SimpleSpeak", expr, "b x y");
     }
 
     #[test]
@@ -216,7 +216,7 @@ fn no_times_sqrt() {
         <mrow><mo>&#x2212;</mo><mn>2</mn></mrow>
         <mo>)</mo></mrow>
         </mrow></math>";
-        test("en", "SimpleSpeak", expr, "2 plus negative 2");
+        test("es", "SimpleSpeak", expr, "2 más menos 2");
     }
 
 
@@ -228,7 +228,7 @@ fn no_times_sqrt() {
         <mo>)</mo></mrow>
         <mo>+</mo><mn>1</mn>
         </mrow></math>";
-        test("en", "SimpleSpeak", expr, "negative 2 x, plus 1");
+        test("es", "SimpleSpeak", expr, "menos 2 x, más 1");
     }
 
     #[test]
@@ -244,7 +244,7 @@ fn no_times_sqrt() {
         </msup>
         </mrow>
     </mrow></math>";
-        test("en", "SimpleSpeak", expr, "open paren 2 x close paren squared");
+        test("es", "SimpleSpeak", expr, "se abren paréntesis 2 x se cierran paréntesis al cuadrado");
     }
 
     #[test]
@@ -257,7 +257,7 @@ fn no_times_sqrt() {
             <mfrac> <mn>1</mn><mn>2</mn></mfrac>
             <mo>)</mo></mrow></mrow>
     </mrow></math>";
-        test("en", "SimpleSpeak", expr, "2 plus 1 half");
+        test("es", "SimpleSpeak", expr, "2 más 1 partido por 2");
     }
 
 
@@ -269,7 +269,7 @@ fn no_times_sqrt() {
         <mrow> <mo arg='open'>(</mo><mi arg='start'>c</mi><mo>,</mo><mi arg='end'>d</mi></mrow><mo arg='close'>)</mo>
         <mo>)</mo></mrow>
     </math>";
-    test("en", "SimpleSpeak",expr, "the open interval from c to d");
+    test("es", "SimpleSpeak",expr, "el intervalo abierto de c a d");
 }
 
 #[test]
@@ -279,7 +279,7 @@ fn no_times_sqrt() {
             <mrow> <mo arg='open'>[(]</mo><mi arg='start'>c</mi><mo>,</mo><mi arg='end'>d</mi></mrow><mo arg='close'>)</mo>
             <mo>)</mo></mrow>
         </math>";
-    test("en", "SimpleSpeak",expr, "the closed open interval from c to d");
+    test("en", "SimpleSpeak",expr, "el intervalo cerrado abierto de c a d");
 }
 
 
@@ -290,7 +290,7 @@ fn parens_interval_open_closed() {
         <mrow> <mo arg='open'>(</mo><mi arg='start'>c</mi><mo>,</mo><mi arg='end'>d</mi></mrow><mo arg='close'>]</mo>
         <mo>]</mo></mrow>
     </math>";
-    test("en", "SimpleSpeak",expr,"the open closed interval from c to d");
+    test("es", "SimpleSpeak",expr,"el intervalo abierto cerrado de c a d");
 }
 
 
@@ -301,7 +301,7 @@ fn parens_interval_closed_closed() {
             <mrow> <mo arg='open'>[(]</mo><mi arg='start'>c</mi><mo>,</mo><mi arg='end'>d</mi></mrow><mo arg='close'>]</mo>
             <mo>]</mo></mrow>
     </math>";
-    test("en", "SimpleSpeak",expr, "the closed interval from c to d");
+    test("es", "SimpleSpeak",expr, "el intervalo cerrado de c a d");
 }
 
     #[test]
@@ -311,8 +311,8 @@ fn parens_interval_closed_closed() {
         <mrow><mrow arg='start'><mo>-</mo> <mi>∞</mi></mrow><mo>,</mo><mi arg='end'>d</mi></mrow><mo arg='close'>)</mo>
         <mo>)</mo></mrow>
     </math>";
-    test("en", "SimpleSpeak",expr,
-    "the open interval from negative infinity to d");
+    test("es", "SimpleSpeak",expr,
+    "el intervalo abierto de menos infinito a d");
 }
 
     #[test]
@@ -322,7 +322,7 @@ fn parens_interval_closed_closed() {
         <mrow><mrow arg='start'><mo>-</mo> <mi>∞</mi></mrow><mo>,</mo><mi arg='end'>d</mi></mrow><mo arg='close'>]</mo>
         <mo>]</mo></mrow>
     </math>";
-    test("en", "SimpleSpeak",expr,
-    "the open closed interval from negative infinity to d");
+    test("es", "SimpleSpeak",expr,
+    "el intervalo abierto cerrado de menos infinito a d");
 }
 

--- a/tests/Languages/es/SimpleSpeak/functions.rs
+++ b/tests/Languages/es/SimpleSpeak/functions.rs
@@ -1,0 +1,328 @@
+/// Tests for:
+/// *  functions including trig functions, logs, and functions to powers
+/// *  implied times/functional call and explicit times/function call
+/// *  parens
+/// These are all intertwined, so they are in one file
+use crate::common::*;
+
+#[test]
+fn trig_names() {
+    let expr = "<math><mrow>
+    <mi>sin</mi><mi>x</mi><mo>+</mo>
+    <mi>cos</mi><mi>y</mi><mo>+</mo>
+    <mi>tan</mi><mi>z</mi><mo>+</mo>
+    <mi>sec</mi><mi>&#x03B1;</mi><mo>+</mo>
+    <mi>csc</mi><mi>&#x03D5;</mi><mo>+</mo>
+    <mi>cot</mi><mi>&#x03C6;</mi>
+    </mrow></math>";
+    test("es", "SimpleSpeak", expr, "seno de x más coseno de y más tangente de z más secante de alpha, más cosecante de phi, más cotangente de phi");
+}
+
+#[test]
+fn hyperbolic_trig_names() {
+    let expr = "<math><mrow>
+    <mi>sinh</mi><mi>x</mi><mo>+</mo>
+    <mi>cosh</mi><mi>y</mi><mo>+</mo>
+    <mi>tanh</mi><mi>z</mi><mo>+</mo>
+    <mi>sech</mi><mi>&#x03B1;</mi><mo>+</mo>
+    <mi>csch</mi><mi>&#x03D5;</mi><mo>+</mo>
+    <mi>coth</mi><mi>&#x03C6;</mi>
+    </mrow></math>";
+    test("en", "SimpleSpeak", expr, "seno hipervólico de x, más \
+                                coseno hipervólico de y, más \
+                                tangente hipervólica de z, más \
+                                secante hipervólica de alpha, más \
+                                cosecante hipervólica de phi, más \
+                                cotangente hipervólica de phi");
+}
+
+
+#[test]
+fn inverse_trig() {
+    let expr = "<math><msup><mi>sin</mi><mrow><mo>-</mo><mn>1</mn></mrow></msup><mi>x</mi></math>";
+    test("en", "SimpleSpeak", expr, "inverse sine of x");
+}
+
+#[test]
+fn trig_squared() {
+    let expr = "<math><msup><mi>sin</mi><mn>2</mn></msup><mi>x</mi></math>";
+    test("en", "SimpleSpeak", expr, "sine squared of x");
+}
+
+#[test]
+fn trig_cubed() {
+    let expr = "<math><msup><mi>tan</mi><mn>3</mn></msup><mi>x</mi></math>";
+    test("en", "SimpleSpeak", expr, "tangent cubed of x");
+}
+
+#[test]
+fn trig_fourth() {
+    let expr = "<math><msup><mi>sec</mi><mn>4</mn></msup><mi>x</mi></math>";
+    test("en", "SimpleSpeak", expr, "the fourth power of, secant of x");
+}
+
+
+#[test]
+fn trig_power_other() {
+    let expr = "<math><msup><mi>sinh</mi><mrow>><mi>n</mi><mo>-</mo><mn>1</mn></mrow></msup><mi>x</mi></math>";
+    test("en", "SimpleSpeak", expr, "the n minus 1 power of, hyperbolic sine of x");
+}
+
+#[test]
+fn simple_log() {
+    let expr = "<math> <mrow>  <mi>log</mi><mi>x</mi></mrow> </math>";
+    test("en", "SimpleSpeak", expr, "log x");
+}
+
+#[test]
+fn normal_log() {
+    let expr = "<math><mrow><mi>log</mi><mrow><mo>(</mo><mrow><mi>x</mi><mo>+</mo><mi>y</mi></mrow><mo>)</mo></mrow></mrow></math>";
+    test("en", "SimpleSpeak", expr, "the log of, open paren x plus y, close paren");
+}
+
+#[test]
+fn simple_log_with_base() {
+    let expr = "<math> <mrow>  <msub><mi>log</mi><mi>b</mi></msub><mi>x</mi></mrow> </math>";
+    test("en", "SimpleSpeak", expr, "the log base b of x");
+}
+
+#[test]
+fn normal_log_with_base() {
+    let expr = "<math><mrow><msub><mi>log</mi><mi>b</mi></msub><mrow><mo>(</mo><mrow><mi>x</mi><mo>+</mo><mi>y</mi></mrow><mo>)</mo></mrow></mrow></math>";
+    test("en", "SimpleSpeak", expr, "the log base b of, open paren x plus y, close paren");
+}
+
+#[test]
+fn simple_ln() {
+    let expr = "<math> <mrow>  <mi>ln</mi><mi>x</mi></mrow> </math>";
+    test("en", "SimpleSpeak", expr, "natural log x");
+}
+
+#[test]
+fn normal_ln() {
+    let expr = "<math><mrow><mi>ln</mi><mrow><mo>(</mo><mrow><mi>x</mi><mo>+</mo><mi>y</mi></mrow><mo>)</mo></mrow></mrow></math>";
+    test("en", "SimpleSpeak", expr, "the natural log of, open paren x plus y, close paren");
+}
+
+#[test]
+fn normal_ln_terse() {
+    let expr = "<math><mrow><mi>ln</mi><mrow><mo>(</mo><mrow><mi>x</mi><mo>+</mo><mi>y</mi></mrow><mo>)</mo></mrow></mrow></math>";
+    test_prefs("en", "SimpleSpeak", vec![("Verbosity", "Terse")],
+                expr, "l n of, open x plus y close");
+}
+
+#[test]
+fn simple_ln_terse() {
+    let expr = "<math> <mrow>  <mi>ln</mi><mi>x</mi></mrow> </math>";
+    test_prefs("en", "SimpleSpeak", vec![("Verbosity", "Terse")],
+                expr, "l n x");
+}
+
+#[test]
+fn explicit_function_call_with_parens() {
+    let expr = "<math><mrow><mi>t</mi><mo>&#x2061;</mo><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>";
+    test("en", "SimpleSpeak", expr, "t of x");
+}
+
+
+#[test]
+fn explicit_times_with_parens() {
+    let expr = "<math><mrow><mi>t</mi><mo>&#x2062;</mo><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>";
+    test("en", "SimpleSpeak", expr, "t times x");
+}
+
+#[test]
+fn explicit_function_call() {
+    let expr = "<math><mrow><mi>t</mi><mo>&#x2061;</mo><mrow><mi>x</mi></mrow></mrow></math>";
+    test("en", "SimpleSpeak", expr, "t of x");
+}
+
+#[test]
+fn explicit_times() {
+    let expr = "<math><mrow><mi>t</mi><mo>&#x2062;</mo><mrow><mi>x</mi></mrow></mrow></math>";
+    test("en", "SimpleSpeak", expr, "t x");
+}
+
+
+/*
+    * Tests for times
+    */
+#[test]
+fn no_times_binomial() {
+    let expr = "<math><mrow><mi>x</mi> <mo>&#x2062;</mo> <mi>y</mi></mrow></math>";
+    test("en", "SimpleSpeak", expr, "x y");
+}
+
+#[test]
+fn times_following_paren() {
+    let expr = "<math><mrow>
+        <mn>2</mn>
+        <mrow>  <mo>(</mo> <mn>3</mn>  <mo>)</mo> </mrow>
+        </mrow></math>";
+    test("en", "SimpleSpeak", expr, "2 times 3");
+}
+
+#[test]
+fn times_preceding_paren() {
+    let expr = "<math><mrow>
+        <mrow>  <mo>(</mo> <mn>2</mn>  <mo>)</mo> </mrow>
+        <mn>3</mn>
+        </mrow></math>";
+    test("en", "SimpleSpeak", expr, "2 times 3");
+}
+
+#[test]
+fn no_times_sqrt() {
+    let expr = "<math><mrow>
+        <msqrt> <mi>a</mi>  </msqrt>
+        <msqrt> <mi>b</mi>  </msqrt>
+        <mo>=</mo>
+        <msqrt> <mrow>  <mi>a</mi><mi>b</mi></mrow> </msqrt>
+        </mrow></math>";
+    test("en", "SimpleSpeak", expr, 
+            "the square root of eigh; the square root of b; is equal to, the square root of eigh b end root,");
+}
+
+/*
+    * Tests for parens
+    */
+    #[test]
+    fn no_parens_number() {
+        let expr = "<math><mrow>
+        <mrow><mo>(</mo>
+        <mn>25</mn>
+        <mo>)</mo></mrow>
+        <mi>x</mi>
+        </mrow></math>";
+        test("en", "SimpleSpeak", expr, "25 times x");
+    }
+
+    #[test]
+    fn no_parens_monomial() {
+        let expr = "<math><mrow>
+        <mi>b</mi>
+        <mrow><mo>(</mo>
+        <mrow><mi>x</mi><mi>y</mi></mrow>
+        <mo>)</mo></mrow>
+        </mrow></math>";
+        test("en", "SimpleSpeak", expr, "b x y");
+    }
+
+    #[test]
+    fn no_parens_negative_number() {
+        let expr = "<math><mrow>
+        <mn>2</mn><mo>+</mo>
+        <mrow><mo>(</mo>
+        <mrow><mo>&#x2212;</mo><mn>2</mn></mrow>
+        <mo>)</mo></mrow>
+        </mrow></math>";
+        test("en", "SimpleSpeak", expr, "2 plus negative 2");
+    }
+
+
+    #[test]
+    fn no_parens_negative_number_with_var() {
+        let expr = "<math><mrow>
+        <mrow><mo>(</mo>
+        <mrow><mo>&#x2212;</mo><mn>2</mn></mrow><mi>x</mi>
+        <mo>)</mo></mrow>
+        <mo>+</mo><mn>1</mn>
+        </mrow></math>";
+        test("en", "SimpleSpeak", expr, "negative 2 x, plus 1");
+    }
+
+    #[test]
+    fn parens_superscript() {
+        let expr = "<math><mrow>
+        <mrow>
+        <msup>
+        <mrow>
+            <mrow><mo>(</mo>
+            <mrow> <mn>2</mn><mi>x</mi></mrow>
+            <mo>)</mo></mrow></mrow>
+        <mn>2</mn>
+        </msup>
+        </mrow>
+    </mrow></math>";
+        test("en", "SimpleSpeak", expr, "open paren 2 x close paren squared");
+    }
+
+    #[test]
+    fn no_parens_fraction() {
+        let expr = "<math><mrow>
+        <mn>2</mn>
+        <mo>+</mo>
+        <mrow>
+            <mrow><mo>(</mo>
+            <mfrac> <mn>1</mn><mn>2</mn></mfrac>
+            <mo>)</mo></mrow></mrow>
+    </mrow></math>";
+        test("en", "SimpleSpeak", expr, "2 plus 1 half");
+    }
+
+
+    // Tests for the four types of intervals in SimpleSpeak
+    #[test]
+    fn parens_interval_open_open() {
+        let expr = "<math> 
+        <mrow intent='open-interval($start, $end)'><mo>(</mo>
+        <mrow> <mo arg='open'>(</mo><mi arg='start'>c</mi><mo>,</mo><mi arg='end'>d</mi></mrow><mo arg='close'>)</mo>
+        <mo>)</mo></mrow>
+    </math>";
+    test("en", "SimpleSpeak",expr, "the open interval from c to d");
+}
+
+#[test]
+    fn parens_interval_closed_open() {
+        let expr = "<math> 
+        <mrow intent='closed-open-interval($start, $end)'><mo>[</mo>
+            <mrow> <mo arg='open'>[(]</mo><mi arg='start'>c</mi><mo>,</mo><mi arg='end'>d</mi></mrow><mo arg='close'>)</mo>
+            <mo>)</mo></mrow>
+        </math>";
+    test("en", "SimpleSpeak",expr, "the closed open interval from c to d");
+}
+
+
+#[test]
+fn parens_interval_open_closed() {
+    let expr = "<math> 
+    <mrow intent='open-closed-interval($start, $end)'><mo>(</mo>
+        <mrow> <mo arg='open'>(</mo><mi arg='start'>c</mi><mo>,</mo><mi arg='end'>d</mi></mrow><mo arg='close'>]</mo>
+        <mo>]</mo></mrow>
+    </math>";
+    test("en", "SimpleSpeak",expr,"the open closed interval from c to d");
+}
+
+
+#[test]
+fn parens_interval_closed_closed() {
+    let expr = "<math> 
+        <mrow intent='closed-interval($start, $end)'><mo>[</mo>
+            <mrow> <mo arg='open'>[(]</mo><mi arg='start'>c</mi><mo>,</mo><mi arg='end'>d</mi></mrow><mo arg='close'>]</mo>
+            <mo>]</mo></mrow>
+    </math>";
+    test("en", "SimpleSpeak",expr, "the closed interval from c to d");
+}
+
+    #[test]
+    fn parens_interval_neg_infinity_open_open() {
+        let expr = "<math> 
+        <mrow intent='open-interval($start, $end)'><mo arg='open'>(</mo>
+        <mrow><mrow arg='start'><mo>-</mo> <mi>∞</mi></mrow><mo>,</mo><mi arg='end'>d</mi></mrow><mo arg='close'>)</mo>
+        <mo>)</mo></mrow>
+    </math>";
+    test("en", "SimpleSpeak",expr,
+    "the open interval from negative infinity to d");
+}
+
+    #[test]
+    fn parens_interval_neg_infinity_open_closed() {
+        let expr = "<math> 
+        <mrow intent='open-closed-interval($start, $end)'><mo arg='open'>(</mo>
+        <mrow><mrow arg='start'><mo>-</mo> <mi>∞</mi></mrow><mo>,</mo><mi arg='end'>d</mi></mrow><mo arg='close'>]</mo>
+        <mo>]</mo></mrow>
+    </math>";
+    test("en", "SimpleSpeak",expr,
+    "the open closed interval from negative infinity to d");
+}
+

--- a/tests/Languages/es/SimpleSpeak/geometry.rs
+++ b/tests/Languages/es/SimpleSpeak/geometry.rs
@@ -1,0 +1,27 @@
+/// Tests for geometry listed in intent
+///   ABC as mtext and as separated letters
+use crate::common::*;
+
+#[test]
+fn arc() {
+  let expr = "<math>  <mover><mrow><mi>B</mi><mi>C</mi></mrow><mo>⌒</mo></mover> </math>";
+  test("en", "SimpleSpeak", expr, "arc cap b cap c");
+}
+
+#[test]
+fn ray() {
+  let expr = "<math> <mover><mrow><mi>X</mi><mi>Y</mi></mrow><mo>&#xAF;</mo></mover> </math>";
+  test("en", "SimpleSpeak", expr, "line segment cap x cap y");
+}
+
+#[test]
+fn arc_mtext() {
+  let expr = "<math> <mover><mtext>BC</mtext><mo>⌒</mo></mover> </math>";
+  test("en", "SimpleSpeak", expr, "arc cap b cap c");
+}
+
+#[test]
+fn ray_mtext() {
+  let expr = "<math> <mover><mtext>XY</mtext><mo>→</mo></mover> </math>";
+  test("en", "SimpleSpeak", expr, "ray cap x cap y");
+}

--- a/tests/Languages/es/SimpleSpeak/large_ops.rs
+++ b/tests/Languages/es/SimpleSpeak/large_ops.rs
@@ -1,0 +1,200 @@
+use crate::common::*;
+
+#[test]
+fn sum_both() {
+    let expr = "<math>
+        <munderover>
+            <mo>∑</mo>
+            <mrow><mi>n</mi><mo>=</mo><mn>1</mn></mrow>
+            <mrow><mn>10</mn></mrow>
+        </munderover>
+        <mi>n</mi>
+    </math>";
+    test("en", "SimpleSpeak", expr, "the sum from n is equal to 1 to 10 of n");
+}
+
+#[test]
+fn sum_under() {
+    let expr = "<math>
+        <munder>
+            <mo>∑</mo>
+            <mi>S</mi>
+        </munder>
+        <mi>i</mi>
+    </math>";
+    test("en", "SimpleSpeak", expr, "the sum over cap s of i");
+}
+#[test]
+fn sum_both_msubsup() {
+    let expr = "<math>
+        <msubsup>
+            <mo>∑</mo>
+            <mrow><mi>n</mi><mo>=</mo><mn>1</mn></mrow>
+            <mrow><mn>10</mn></mrow>
+        </msubsup>
+        <mi>n</mi>
+    </math>";
+    test("en", "SimpleSpeak", expr, "the sum from n is equal to 1 to 10 of n");
+}
+
+#[test]
+fn sum_sub() {
+    let expr = "<math>
+        <msub>
+            <mo>∑</mo>
+            <mi>S</mi>
+        </msub>
+        <mi>i</mi>
+    </math>";
+    test("en", "SimpleSpeak", expr, "the sum over cap s of i");
+}
+
+#[test]
+fn sum() {
+    let expr = "<math>
+            <mo>∑</mo>
+            <msub><mi>a</mi><mi>i</mi></msub>
+    </math>";
+    test("en", "SimpleSpeak", expr, "the sum of eigh sub i");
+}
+
+#[test]
+fn product_both() {
+    let expr = "<math>
+        <munderover>
+            <mo>∏</mo>
+            <mrow><mi>n</mi><mo>=</mo><mn>1</mn></mrow>
+            <mrow><mn>10</mn></mrow>
+        </munderover>
+        <mi>n</mi>
+    </math>";
+    test("en", "SimpleSpeak", expr, "the product from n is equal to 1 to 10 of n");
+}
+
+#[test]
+fn product_under() {
+    let expr = "<math>
+        <munder>
+            <mo>∏</mo>
+            <mi>S</mi>
+        </munder>
+        <mi>i</mi>
+    </math>";
+    test("en", "SimpleSpeak", expr, "the product over cap s of i");
+}
+
+#[test]
+fn product() {
+    let expr = "<math>
+            <mo>∏</mo>
+            <msub><mi>a</mi><mi>i</mi></msub>
+    </math>";
+    test("en", "SimpleSpeak", expr, "the product of eigh sub i");
+}
+
+#[test]
+fn intersection_both() {
+    let expr = "<math>
+        <munderover>
+            <mo>⋂</mo>
+            <mrow><mi>i</mi><mo>=</mo><mn>1</mn> </mrow>
+            <mn>10</mn>
+        </munderover>
+        <msub><mi>S</mi><mi>i</mi></msub>
+    </math>";
+    test("en", "SimpleSpeak", expr, "the intersection from i is equal to 1 to 10 of; cap s sub i");
+}
+
+#[test]
+fn intersection_under() {
+    let expr = "<math>
+        <munder>
+            <mo>⋂</mo>
+            <mi>C</mi>
+        </munder>
+        <msub><mi>S</mi><mi>i</mi></msub>
+    </math>";
+    test("en", "SimpleSpeak", expr, "the intersection over cap c of, cap s sub i");
+}
+
+#[test]
+fn intersection() {
+    let expr = "<math>
+            <mo>⋂</mo>
+            <msub><mi>S</mi><mi>i</mi></msub>
+            </math>";
+    test("en", "SimpleSpeak", expr, "the intersection of cap s sub i");
+}
+
+#[test]
+fn union_both() {
+    let expr = "<math>
+        <munderover>
+            <mo>⋃</mo>
+            <mrow><mi>i</mi><mo>=</mo><mn>1</mn> </mrow>
+            <mn>10</mn>
+        </munderover>
+        <msub><mi>S</mi><mi>i</mi></msub>
+    </math>";
+    test("en", "SimpleSpeak", expr, "the union from i is equal to 1 to 10 of; cap s sub i");
+}
+
+#[test]
+fn union_under() {
+    let expr = "<math>
+        <munder>
+            <mo>⋃</mo>
+            <mi>C</mi>
+        </munder>
+        <msub><mi>S</mi><mi>i</mi></msub>
+    </math>";
+    test("en", "SimpleSpeak", expr, "the union over cap c of, cap s sub i");
+}
+
+#[test]
+fn union() {
+    let expr = "<math>
+            <mo>⋃</mo>
+            <msub><mi>S</mi><mi>i</mi></msub>
+            </math>";
+    test("en", "SimpleSpeak", expr, "the union of cap s sub i");
+}
+
+#[test]
+fn integral_both() {
+    let expr = "<math>
+            <mrow>
+                <msubsup>
+                    <mo>∫</mo>
+                    <mn>0</mn>
+                    <mn>1</mn>
+                </msubsup>
+                <mrow><mi>f</mi><mrow><mo>(</mo><mi>x</mi> <mo>)</mo></mrow></mrow>
+            </mrow>
+            <mtext>&#x2009;</mtext><mi>d</mi><mi>x</mi>
+        </math>";
+    test("en", "SimpleSpeak", expr, "the integral from 0 to 1 of, f of x; d x");
+}
+
+#[test]
+fn integral_under() {
+    let expr = "<math>
+        <munder>
+            <mo>∫</mo>
+            <mi>ℝ</mi>
+        </munder>
+        <mrow><mi>f</mi><mrow><mo>(</mo><mi>x</mi> <mo>)</mo></mrow></mrow>
+        <mi>d</mi><mi>x</mi>
+        </math>";
+    test("en", "SimpleSpeak", expr, "the integral over the real numbers of; f of x d x");
+}
+
+#[test]
+fn integral() {
+    let expr = "<math>
+            <mo>∫</mo>
+            <mrow><mi>f</mi><mrow><mo>(</mo><mi>x</mi> <mo>)</mo></mrow></mrow>
+            <mi>d</mi><mi>x</mi>
+            </math>";
+    test("en", "SimpleSpeak", expr, "the integral of f of x d x");
+}

--- a/tests/Languages/es/SimpleSpeak/linear_algebra.rs
+++ b/tests/Languages/es/SimpleSpeak/linear_algebra.rs
@@ -1,0 +1,60 @@
+use crate::common::*;
+
+#[test]
+fn transpose() {
+  let expr = "<math> <msup><mi>M</mi><mi>T</mi></msup> </math>";
+  test("en", "SimpleSpeak", expr, "cap m transpose");
+}
+
+#[test]
+fn trace() {
+  let expr = "<math> <mi>Tr</mi><mi>M</mi> </math>";
+  test("en", "SimpleSpeak", expr, "trace of cap m");
+}
+
+#[test]
+fn dimension() {
+  let expr = "<math> <mi>Dim</mi><mi>M</mi> </math>";
+  test("en", "SimpleSpeak", expr, "dimension of cap m");
+}
+
+#[test]
+fn homomorphism() {
+  let expr = "<math> <mi>Hom</mi><mo>(</mo><mi>M</mi><mo>)</mo> </math>";
+  test("en", "SimpleSpeak", expr, "homomorphism of cap m");
+}
+
+#[test]
+fn kernel() {
+  let expr = "<math> <mi>ker</mi><mrow><mo>(</mo><mi>L</mi><mo>)</mo></mrow> </math>";
+  test("en", "SimpleSpeak", expr, "kernel of cap l");
+}
+
+#[test]
+fn norm() {
+  let expr = "  <math>
+    <mrow>
+      <mo>∥</mo>
+      <mi>f</mi>
+      <mo>∥</mo>
+    </mrow>
+</math>
+";
+  test("en", "SimpleSpeak", expr, "norm of f");
+}
+
+#[test]
+fn norm_subscripted() {
+  let expr = "  <math>
+    <msub>
+      <mrow>
+        <mo>∥</mo>
+        <mi>f</mi>
+        <mo>∥</mo>
+      </mrow>
+      <mi>p</mi>
+    </msub>
+</math>
+";
+  test("en", "SimpleSpeak", expr, "p norm of f");
+}

--- a/tests/Languages/es/SimpleSpeak/mfrac.rs
+++ b/tests/Languages/es/SimpleSpeak/mfrac.rs
@@ -1,0 +1,216 @@
+/// Tests for fractions
+///   includes simple fractions and more complex fractions
+///   also tests mixed fractions (implicit and explicit)
+use crate::common::*;
+
+#[test]
+fn common_fraction_half() {
+    let expr = "<math>
+                    <mfrac> <mn>1</mn> <mn>2</mn> </mfrac>
+                </math>";
+    test("en", "SimpleSpeak", expr, "1 half");
+}
+
+#[test]
+fn common_fraction_thirds() {
+    let expr = "<math>
+                    <mfrac> <mn>2</mn> <mn>3</mn> </mfrac>
+                </math>";
+    test("en", "SimpleSpeak", expr, "2 thirds");
+}
+
+#[test]
+fn common_fraction_tenths() {
+    let expr = "<math>
+                    <mfrac> <mn>17</mn> <mn>10</mn> </mfrac>
+                </math>";
+    test("en", "SimpleSpeak", expr, "17 tenths");
+}
+
+#[test]
+#[allow(non_snake_case)]
+fn not_SimpleSpeak_common_fraction_tenths() {
+    let expr = "<math>
+                    <mfrac> <mn>89</mn> <mn>10</mn> </mfrac>
+                </math>";
+    test("en", "SimpleSpeak", expr, "89 over 10,");
+}
+
+#[test]
+fn non_simple_fraction() {
+    let expr = "
+    <math>
+        <mrow>
+        <mfrac>
+        <mrow> <mi>x</mi><mo>+</mo><mi>y</mi> </mrow>
+        <mrow>
+        <mi>x</mi><mo>-</mo><mi>y</mi></mrow>
+        </mfrac>
+        </mrow>
+    </math>
+                            ";
+    test("en", "SimpleSpeak", expr, "fraction, x plus y, over, x minus y, end fraction;");
+}
+
+#[test]
+fn nested_fraction() {
+    let expr = "
+    <math>
+        <mrow>
+        <mfrac>
+        <mrow> <mi>x</mi><mo>+</mo>  <mfrac><mn>1</mn><mi>y</mi></mfrac>  </mrow>
+        <mrow>
+        <mi>x</mi><mo>-</mo><mi>y</mi></mrow>
+        </mfrac>
+        </mrow>
+    </math>
+                            ";
+    test("en", "SimpleSpeak", expr, "fraction, x plus, fraction, 1 over y, end fraction; over, x minus y, end fraction;");
+}
+
+
+#[test]
+fn deeply_nested_fraction_msqrt() {
+    let expr = "
+    <math>
+        <mrow>
+        <mfrac>
+        <mrow> <mi>x</mi><mo>+</mo>  <msqrt><mrow><mfrac><mn>1</mn><mi>y</mi></mfrac></mrow> </msqrt> </mrow>
+        <mrow>
+        <mi>x</mi><mo>-</mo><mi>y</mi></mrow>
+        </mfrac>
+        </mrow>
+    </math>
+                            ";
+    test("en", "SimpleSpeak", expr, "fraction, x plus, the square root of 1 over y, end root; over, x minus y, end fraction;");
+}
+
+#[test]
+fn deeply_nested_fraction_mrow_msqrt() {
+    let expr = "
+    <math>
+        <mrow>
+        <mfrac>
+        <mrow> <mi>x</mi><mo>+</mo>  <msqrt><mrow><mn>2</mn><mo>+</mo><mfrac><mn>1</mn><mi>y</mi></mfrac></mrow> </msqrt> </mrow>
+        <mrow>
+        <mi>x</mi><mo>-</mo><mi>y</mi></mrow>
+        </mfrac>
+        </mrow>
+    </math>
+                            ";
+    test("en", "SimpleSpeak", expr, "fraction, x plus, the square root of 2 plus 1 over y, end root; over, x minus y, end fraction;");
+}
+
+#[test]
+fn numerator_simple_fraction() {
+    let expr = "
+    <math>
+        <mrow>
+        <mfrac>
+        <mrow> <mi>x</mi></mrow>
+        <mrow>
+            <mi>x</mi><mo>-</mo><mi>y</mi></mrow>
+        </mfrac>
+        </mrow>
+    </math>
+                            ";
+    test("en", "SimpleSpeak", expr, "fraction, x over, x minus y, end fraction;");
+}
+
+#[test]
+fn denominator_simple_fraction() {
+    let expr = "
+    <math>
+        <mfrac>
+            <mrow> <mi>x</mi><mo>-</mo><mi>y</mi></mrow>
+            <mrow> <mi>x</mi></mrow>
+        </mfrac>
+    </math>
+                            ";
+    test("en", "SimpleSpeak", expr, "fraction, x minus y, over x, end fraction;");
+}
+
+
+#[test]
+fn mixed_number() {
+    let expr = "<math>
+                    <mn>3</mn>
+                    <mfrac> <mn>1</mn> <mn>2</mn> </mfrac>
+                </math>";
+    test("en", "SimpleSpeak", expr, "3 and 1 half");
+}
+
+#[test]
+fn explicit_mixed_number() {
+    let expr = "<math>
+                    <mn>3</mn>
+                    <mo>&#x2064;</mo>
+                    <mfrac> <mn>1</mn> <mn>8</mn> </mfrac>
+                </math>";
+    test("en", "SimpleSpeak", expr, "3 and 1 eighth");
+}
+
+#[test]
+fn mixed_number_big() {
+    let expr = "<math>
+                    <mn>3</mn>
+                    <mfrac> <mn>7</mn> <mn>83</mn> </mfrac>
+                </math>";
+    test("en", "SimpleSpeak", expr, "3 and 7 eighty thirds");
+}
+
+#[test]
+fn simple_text() {
+    let expr = "<math>
+    <mfrac> <mi>rise</mi> <mi>run</mi> </mfrac>
+                </math>";
+    test("en", "SimpleSpeak", expr, "rise over run,");
+}
+
+#[test]
+fn number_and_text() {
+    let expr = "<math>
+            <mfrac>
+            <mrow>
+                <mn>2</mn><mtext>miles</mtext></mrow>
+            <mrow>
+                <mn>3</mn><mtext>gallons</mtext></mrow>
+            </mfrac>
+        </math>";
+    test("en", "SimpleSpeak", expr, "fraction, 2 miles, over, 3 gallons, end fraction;");
+}
+
+
+#[test]
+fn nested_simple_fractions() {
+    let expr = "<math>
+                <mrow>
+                <mfrac>
+                    <mrow>
+                    <mfrac>
+                        <mn>1</mn>
+                        <mn>2</mn>
+                    </mfrac>
+                    </mrow>
+                    <mrow>
+                    <mfrac>
+                        <mn>2</mn>
+                        <mn>3</mn>
+                    </mfrac>
+                    </mrow>
+                </mfrac>
+                </mrow>
+            </math>";
+    test("en", "SimpleSpeak", expr, "fraction, 1 half, over, 2 thirds, end fraction;");
+}
+
+#[test]
+fn binomial() {
+    let expr = "<math>
+                    <mn>2</mn>
+                    <mo>(</mo>
+                    <mfrac linethickness='0'> <mn>7</mn> <mn>3</mn> </mfrac>
+                    <mo>)</mo>
+                </math>";
+    test("en", "SimpleSpeak", expr, "2 times 7 choose 3");
+}

--- a/tests/Languages/es/SimpleSpeak/msup.rs
+++ b/tests/Languages/es/SimpleSpeak/msup.rs
@@ -1,0 +1,332 @@
+/// Tests for superscripts
+///   simple superscripts
+///   complex/nested superscripts
+use crate::common::*;
+
+#[test]
+fn squared() {
+    let expr = "<math>
+                    <msup> <mi>x</mi> <mn>2</mn> </msup>
+                </math>";
+    test("en", "SimpleSpeak", expr, "x squared");
+}
+
+#[test]
+fn cubed() {
+    let expr = "<math>
+                    <msup> <mi>x</mi> <mn>3</mn> </msup>
+                </math>";
+    test("en", "SimpleSpeak", expr, "x cubed");
+}
+
+#[test]
+    fn ordinal_power() {
+        let expr = "<math>
+                        <msup> <mi>x</mi> <mn>4</mn> </msup>
+                    </math>";
+        test("en", "SimpleSpeak", expr, "x to the fourth");
+    }
+
+#[test]
+fn simple_mi_power() {
+    let expr = "<math>
+                    <msup> <mi>x</mi> <mi>n</mi> </msup>
+                </math>";
+  test("en", "SimpleSpeak", expr, "x to the n-th");
+}
+
+#[test]
+fn zero_power() {
+    let expr = "<math>
+                    <msup> <mi>x</mi> <mn>0</mn> </msup>
+                </math>";
+    test("en", "SimpleSpeak", expr, "x to the 0");
+}
+
+
+#[test]
+fn decimal_power() {
+    let expr = "<math>
+                    <msup> <mi>x</mi> <mn>2.0</mn> </msup>
+                </math>";
+    test("en", "SimpleSpeak", expr, "x to the 2.0");
+}
+
+#[test]
+fn non_simple_power() {
+    let expr = "<math>
+      <mrow>
+      <msup>
+        <mn>3</mn>
+        <mrow>
+        <mi>y</mi><mo>+</mo><mn>2</mn></mrow>
+      </msup>
+      </mrow>
+                </math>";
+    test("en", "SimpleSpeak", expr, "3 raised to the y plus 2 power");
+}
+
+#[test]
+fn negative_power() {
+    let expr = "<math>
+                    <msup>
+                        <mi>x</mi>
+                        <mrow> <mo>-</mo> <mn>2</mn> </mrow>
+                    </msup>
+                </math>";
+    test("en", "SimpleSpeak", expr, "x to the negative 2");
+}
+
+#[test]
+fn simple_fraction_power() {
+  let expr = "<math>
+                  <msup>
+                      <mi>x</mi> 
+                      <mfrac><mn>1</mn><mn>3</mn></mfrac>
+                  </msup>
+              </math>";
+  test("en", "SimpleSpeak", expr, "x raised to the 1 third power");
+}
+
+#[test]
+fn nested_squared_power_with_coef() {
+    let expr = "<math>
+      <mrow>
+      <msup>
+        <mn>3</mn>
+        <mrow>
+        <mn>2</mn>
+        <msup>
+          <mi>x</mi>
+          <mn>2</mn>
+        </msup>
+        </mrow>
+      </msup>
+      </mrow>
+      </math>";
+  test("en", "SimpleSpeak", expr, "3 raised to the 2 x squared power");
+}
+
+#[test]
+fn nested_squared_power_with_neg_coef() {
+    let expr = "<math>
+    <mrow>
+    <msup>
+      <mn>3</mn>
+      <mrow>
+      <mo>-</mo>
+      <mn>2</mn>
+      <msup>
+        <mi>x</mi>
+        <mn>2</mn>
+      </msup>
+      </mrow>
+    </msup>
+    </mrow>
+  </math>";
+  test("en", "SimpleSpeak", expr, "3 raised to the negative 2 x squared power");
+}
+
+
+#[test]
+fn nested_cubed_power() {
+    let expr = "<math>
+      <msup>
+      <mi>y</mi> 
+      <msup>
+          <mfrac><mn>4</mn><mn>5</mn></mfrac>
+          <mn>3</mn>
+      </msup>
+    </msup>
+  </math>";
+  test("en", "SimpleSpeak", expr, "y raised to the 4 fifths cubed power");
+}
+
+#[test]
+fn nested_cubed_power_with_neg_base() {
+    let expr = "<math>
+      <msup>
+      <mi>y</mi> 
+        <mrow>
+            <mo>-</mo>
+            <msup>
+                <mfrac><mn>4</mn><mn>5</mn></mfrac>
+                <mn>3</mn>
+            </msup>
+        </mrow>
+    </msup>
+    </math>";
+  test("en", "SimpleSpeak", expr, "y raised to the negative 4 fifths cubed power");
+}
+
+#[test]
+fn nested_number_times_squared() {
+    let expr = "<math>
+        <mrow>
+        <msup>
+          <mi>e</mi>
+          <mrow>
+          <mfrac>
+            <mn>1</mn>
+            <mn>2</mn>
+            </mfrac>
+            <msup>
+            <mi>x</mi>
+            <mn>2</mn>
+            </msup>
+          </mrow>
+        </msup>
+        </mrow>
+        </math>";
+  test("en", "SimpleSpeak", expr, "e raised to the 1 half x squared power");
+}
+
+#[test]
+fn nested_negative_number_times_squared() {
+  let expr = "<math>
+    <mrow>
+    <msup>
+      <mi>e</mi>
+      <mrow>
+      <mo>&#x2212;</mo><mfrac>
+        <mn>1</mn>
+        <mn>2</mn>
+      </mfrac>
+      <msup>
+        <mi>x</mi>
+        <mn>2</mn>
+      </msup>
+      </mrow>
+    </msup>
+    </mrow>
+    </math>";
+  test("en", "SimpleSpeak", expr, "e raised to the negative 1 half x squared power");
+}
+
+#[test]
+fn nested_expr_to_tenth() {
+    let expr = "<math>
+      <mrow>
+      <msup>
+        <mn>3</mn>
+        <mrow>
+        <msup>
+          <mn>3</mn>
+          <mrow>
+          <mn>10</mn></mrow>
+        </msup>
+        </mrow>
+      </msup>
+      </mrow>
+      </math>";
+  test("en", "SimpleSpeak", expr, "3 raised to the 3 to the tenth power");
+}
+
+#[test]
+fn nested_non_simple_squared_exp() {
+    let expr = "<math>
+      <mrow>
+      <msup>
+        <mn>3</mn>
+        <mrow>
+        <msup>
+          <mrow>
+          <mrow><mo>(</mo>
+            <mrow>
+            <mi>x</mi><mo>+</mo><mn>1</mn></mrow>
+          <mo>)</mo></mrow></mrow>
+          <mn>2</mn>
+        </msup>
+        </mrow>
+      </msup>
+      </mrow>
+      </math>";
+  test("en", "SimpleSpeak", expr, "3 raised to the open paren x plus 1, close paren squared power");
+}
+
+#[test]
+fn nested_simple_power() {
+    let expr = "<math>
+      <msup>
+      <mi>t</mi> 
+      <msup>
+          <mfrac><mn>4</mn><mn>5</mn></mfrac>
+          <mi>n</mi>
+      </msup>
+    </msup>
+  </math>";
+  test("en", "SimpleSpeak", expr, "t raised to the 4 fifths to the n-th power");
+}
+
+#[test]
+fn nested_end_exponent_power() {
+    let expr = "<math>
+      <msup>
+      <mi>t</mi> 
+      <msup>
+          <mfrac><mn>4</mn><mn>5</mn></mfrac>
+          <mrow><mi>n</mi><mo>+</mo><mn>1</mn></mrow>
+      </msup>
+    </msup>
+  </math>";
+  test("en", "SimpleSpeak", expr, "t raised to the 4 fifths raised to the n plus 1 power, end exponent");
+}
+
+#[test]
+fn nested_end_exponent_neg_power() {
+    let expr = "<math>
+      <msup>
+      <mi>t</mi> 
+      <msup>
+          <mfrac><mn>4</mn><mn>5</mn></mfrac>
+          <mrow><mo>-</mo><mn>3</mn></mrow>
+      </msup>
+    </msup>
+  </math>";
+  test("en", "SimpleSpeak", expr, "t raised to the 4 fifths to the negative 3, end exponent");
+}
+
+#[test]
+fn nested_complex_power() {
+    let expr = "<math>
+      <mrow>
+      <msup>
+        <mi>e</mi>
+        <mrow>
+        <mo>&#x2212;</mo><mfrac>
+          <mn>1</mn>
+          <mn>2</mn>
+        </mfrac>
+        <msup>
+          <mrow>
+          <mrow><mo>(</mo>
+            <mrow>
+            <mfrac>
+              <mrow>
+              <mi>x</mi><mo>&#x2212;</mo><mi>&#x03BC;</mi></mrow>
+              <mi>&#x03C3;</mi>
+            </mfrac>
+            </mrow>
+          <mo>)</mo></mrow></mrow>
+          <mn>2</mn>
+        </msup>
+        </mrow>
+      </msup>
+      </mrow>
+      </math>";
+  test("en", "SimpleSpeak", expr, "e raised to the negative 1 half times; open paren, fraction, x minus mu, over sigma, end fraction; close paren squared power");
+}
+
+#[test]
+fn default_power() {
+    let expr = "<math>
+      <msup>
+      <mi>t</mi> 
+      <mfrac>
+          <mrow><mi>b</mi><mo>+</mo><mn>1</mn></mrow>
+          <mn>3</mn>
+      </mfrac>
+    </msup>
+  </math>";
+  test("en", "SimpleSpeak", expr, "t raised to the fraction, b plus 1, over 3, end fraction; power");
+}

--- a/tests/Languages/es/SimpleSpeak/multiline.rs
+++ b/tests/Languages/es/SimpleSpeak/multiline.rs
@@ -1,0 +1,77 @@
+use crate::common::*;
+
+#[test]
+fn case_1() {
+    // init_logger();
+    let expr = "<math>
+            <mrow>
+            <mi>f</mi><mrow><mo>(</mo>
+            <mi>x</mi>
+            <mo>)</mo></mrow><mo>=</mo><mrow><mo>{</mo> <mrow>
+            <mtable>
+            <mtr>
+                <mtd>
+                <mrow>
+                <mo>&#x2212;</mo><mn>1</mn><mtext>&#x00A0;if&#x00A0;</mtext><mi>x</mi><mo>&#x003C;</mo><mn>0</mn></mrow>
+                </mtd>
+            </mtr>
+            <mtr>
+                <mtd>
+                <mrow>
+                <mn>0</mn><mtext>&#x00A0;if&#x00A0;</mtext><mi>x</mi><mo>=</mo><mn>0</mn></mrow>
+                </mtd>
+            </mtr>
+            <mtr>
+                <mtd>
+                <mrow>
+                <mn>1</mn><mtext>&#x00A0;if&#x00A0;</mtext><mi>x</mi><mo>&#x003E;</mo><mn>0</mn></mrow>
+                </mtd>
+            </mtr>
+            </mtable></mrow> </mrow></mrow>
+        </math>
+   ";
+    test("en", "SimpleSpeak", expr, "f of x is equal to; 3 cases, \
+                case 1; negative 1 if x; is less than 0; \
+                case 2; 0 if x, is equal to 0; \
+                case 3; 1 if x, is greater than 0;");
+}
+
+#[test]
+fn equation_1() {
+    // init_logger();
+    let expr = "<math>
+     <mrow>
+      <mtable>
+       <mtr>
+        <mtd>
+         <mrow>
+          <mi>x</mi><mo>+</mo><mi>y</mi></mrow>
+        </mtd>
+        <mtd>
+         <mo>=</mo>
+        </mtd>
+        <mtd>
+         <mn>7</mn>
+        </mtd>
+       </mtr>
+       <mtr>
+        <mtd>
+         <mrow>
+          <mn>2</mn><mi>x</mi><mo>+</mo><mn>3</mn><mi>y</mi></mrow>
+        </mtd>
+        <mtd>
+         <mo>=</mo>
+        </mtd>
+        <mtd>
+         <mrow>
+          <mn>17</mn></mrow>
+        </mtd>
+       </mtr>
+       
+      </mtable></mrow>
+    </math>
+   ";
+    test("en", "SimpleSpeak", expr, "2 equations, \
+                equation 1; x plus y, is equal to, 7; \
+                equation 2; 2 x plus 3 y, is equal to, 17;");
+}

--- a/tests/Languages/es/SimpleSpeak/sets.rs
+++ b/tests/Languages/es/SimpleSpeak/sets.rs
@@ -1,0 +1,238 @@
+use crate::common::*;
+
+#[test]
+fn complex() {
+    let expr = "<math>
+                    <mi>ℂ</mi>
+                </math>";
+    test("en", "SimpleSpeak", expr, "the complex numbers");
+}
+
+#[test]
+fn natural() {
+    let expr = "<math>
+                    <mi>ℕ</mi>
+                </math>";
+    test("en", "SimpleSpeak", expr, "the natural numbers");
+}
+
+#[test]
+fn rationals() {
+    let expr = "<math>
+                    <mi>ℚ</mi>
+                </math>";
+    test("en", "SimpleSpeak", expr, "the rational numbers");
+}
+
+#[test]
+fn reals() {
+    let expr = "<math>
+                    <mi>ℝ</mi>
+                </math>";
+    test("en", "SimpleSpeak", expr, "the real numbers");
+}
+
+#[test]
+fn integers() {
+    let expr = "<math>
+                    <mi>ℤ</mi>
+                </math>";
+    test("en", "SimpleSpeak", expr, "the integers");
+}
+
+
+
+#[test]
+fn msup_complex() {
+    let expr = "<math>
+                <msup>
+                    <mi>ℂ</mi>
+                    <mn>2</mn>
+                </msup>
+                </math>";
+    test("en", "SimpleSpeak", expr, "C 2");
+}
+
+#[test]
+fn msup_natural() {
+    let expr = "<math>
+                <msup>
+                    <mi>ℕ</mi>
+                    <mn>2</mn>
+                </msup>
+            </math>";
+    test("en", "SimpleSpeak", expr, "N 2");
+}
+
+#[test]
+fn msup_rationals() {
+    let expr = "<math>
+                <msup>
+                    <mi>ℚ</mi>
+                    <mn>2</mn>
+                </msup>
+            </math>";
+    test("en", "SimpleSpeak", expr, "Q 2");
+}
+
+#[test]
+fn msup_reals() {
+    let expr = "<math>
+                <msup>
+                    <mi>ℝ</mi>
+                    <mn>3</mn>
+                </msup>
+            </math>";
+    test("en", "SimpleSpeak", expr, "R 3");
+}
+
+#[test]
+fn msup_integers() {
+    let expr = "<math>
+                <msup>
+                    <mi>ℤ</mi>
+                    <mn>4</mn>
+                </msup>
+            </math>";
+    test("en", "SimpleSpeak", expr, "Z 4");
+}
+
+#[test]
+fn msup_positive_integers() {
+    let expr = "<math>
+                <msup>
+                    <mi>ℤ</mi>
+                    <mo>+</mo>
+                </msup>
+            </math>";
+    test("en", "SimpleSpeak", expr, "the positive integers");
+}
+
+#[test]
+fn msup_negative_integers() {
+    let expr = "<math>
+                <msup>
+                    <mi>ℤ</mi>
+                    <mo>-</mo>
+                </msup>
+            </math>";
+    test("en", "SimpleSpeak", expr, "the negative integers");
+}
+
+#[test]
+fn msup_positive_rationals() {
+    let expr = "<math>
+                <msup>
+                    <mi>ℚ</mi>
+                    <mo>+</mo>
+                </msup>
+            </math>";
+    test("en", "SimpleSpeak", expr, "the positive rational numbers");
+}
+
+#[test]
+fn msup_negative_rationals() {
+    let expr = "<math>
+                <msup>
+                    <mi>ℚ</mi>
+                    <mo>-</mo>
+                </msup>
+            </math>";
+    test("en", "SimpleSpeak", expr, "the negative rational numbers");
+}
+
+#[test]
+fn empty_set() {
+    let expr = "<math>
+                <mo>{</mo> <mo>}</mo>
+            </math>";
+    test("en", "SimpleSpeak", expr, "the empty set");
+}
+
+#[test]
+fn single_element_set() {
+    let expr = "<math>
+                <mo>{</mo> <mn>12</mn><mo>}</mo>
+            </math>";
+    test("en", "SimpleSpeak", expr, "the set 12");
+}
+
+#[test]
+fn multiple_element_set() {
+    let expr = "<math>
+                <mo>{</mo> <mn>5</mn> <mo>,</mo> <mn>10</mn>  <mo>,</mo> <mn>15</mn> <mo>}</mo>
+            </math>";
+    test("en", "SimpleSpeak", expr, "the set 5 comma 10 comma 15");
+}
+
+#[test]
+fn set_with_colon() {
+    let expr = "<math>
+                    <mo>{</mo> <mrow><mi>x</mi><mo>:</mo><mi>x</mi><mo>&#x003E;</mo><mn>2</mn></mrow> <mo>}</mo>
+            </math>";
+    test("en", "SimpleSpeak", expr, "the set of all x such that x is greater than 2");
+}
+
+#[test]
+fn set_with_bar() {
+    let expr = "<math>
+                    <mo>{</mo> <mrow><mi>x</mi><mo>|</mo><mi>x</mi><mo>&#x003E;</mo><mn>2</mn></mrow> <mo>}</mo>
+            </math>";
+    test("en", "SimpleSpeak", expr, "the set of all x such that x is greater than 2");
+}
+
+#[test]
+fn element_alone() {
+    let expr = "<math>
+            <mn>3</mn><mo>+</mo><mn>2</mn><mi>i</mi><mo>∉</mo><mi>ℝ</mi>
+        </math>";
+    test("en", "SimpleSpeak", expr, "3 plus 2 i, is not an element of, the real numbers");
+}
+
+#[test]
+fn element_under_sum() {
+    let expr = "<math>
+            <munder>
+                <mo>∑</mo>
+                <mrow> <mi>i</mi> <mo>∈</mo> <mi>ℤ</mi> </mrow>
+            </munder>
+            <mfrac>
+                <mn>1</mn>
+                <mrow> <msup>  <mi>i</mi> <mn>2</mn> </msup> </mrow>
+            </mfrac>
+        </math>";
+    test("en", "SimpleSpeak", expr,
+                    "the sum over i an element of the integers of; fraction, 1 over, i squared, end fraction;");
+}
+
+#[test]
+fn complicated_set_with_colon() {
+    let expr = "<math>
+            <mo>{</mo>
+            <mi>x</mi>
+            <mo>∈</mo>
+            <mi>ℤ</mi>
+            <mo>:</mo>
+            <mn>2</mn>
+            <mo>&#x003C;</mo>
+            <mi>x</mi>
+            <mo>&#x003C;</mo>
+            <mn>7</mn>
+            <mo>}</mo>
+        </math>";
+    test("en", "SimpleSpeak", expr, "the set of all x an element of the integers such that 2 is less than x is less than 7");
+}
+
+#[test]
+fn complicated_set_with_mtext() {
+    // as of 8/5/21, parsing of "|" is problematic an element of the example, so <mrows> are needed for this test
+    let expr = "<math>
+        <mo>{</mo>
+        <mrow> <mi>x</mi><mo>∈</mo><mi>ℕ</mi></mrow>
+        <mo>|</mo>
+        <mrow><mi>x</mi> <mtext>&#x00A0;is&#x00A0;an&#x00A0;even&#x00A0;number</mtext> </mrow>
+        <mo>}</mo>
+        </math>";
+    test("en", "SimpleSpeak", expr, 
+            "the set of all x an element of the natural numbers such that x is an even number");
+}

--- a/tests/Languages/es/alphabets.rs
+++ b/tests/Languages/es/alphabets.rs
@@ -1,0 +1,343 @@
+/// Tests for rules shared between various speech styles:
+/// *  this has tests focused on the various alphabets
+use crate::common::*;
+
+
+#[test]
+fn special_alphabet_chars() {
+  let expr = "<math> <mi>ℌ</mi><mo>,</mo><mi>ℭ</mi></math>";
+  test("en", "SimpleSpeak", expr, "fraktur cap h comma fraktur cap c");
+  let expr = "<math> <mi>ℍ</mi><mo>,</mo><mi>ℿ</mi></math>";
+  test("en", "SimpleSpeak", expr, "double struck cap h comma double struck cap pi");
+  let expr = "<math> <mi>ℐ</mi><mo>,</mo><mi>ℳ</mi></math>";
+  test("en", "SimpleSpeak", expr, "script cap i comma script cap m");
+}
+
+#[test]
+fn greek() {
+    let expr = "<math> <mi>Α</mi><mo>,</mo><mi>Ω</mi></math>";
+    test("en", "SimpleSpeak", expr, "cap alpha comma cap omega");
+    let expr = "<math> <mi>α</mi><mo>,</mo><mi>ω</mi></math>";
+    test("en", "SimpleSpeak", expr, "alpha comma omega");
+    // MathType private space versions
+    let expr = "<math> <mi></mi><mo>,</mo><mi></mi></math>";
+    test("en", "SimpleSpeak", expr, "double struck cap delta, comma double struck cap upsilon");
+    let expr = "<math> <mi>α</mi><mo>,</mo><mi>ω</mi></math>";
+    test("en", "SimpleSpeak", expr, "alpha comma omega");
+}
+
+#[test]
+fn cap_cyrillic() {
+    let expr = "<math> <mi>А</mi><mo>,</mo><mi>Я</mi></math>";
+    test("en", "SimpleSpeak", expr, "cap a comma cap ya");
+}
+
+#[test]
+fn parenthesized() {
+    let expr = "<math> <mi>⒜</mi><mo>,</mo><mi>⒵</mi></math>";
+    test("en", "SimpleSpeak", expr, "parenthesized eigh comma parenthesized z");
+}
+
+#[test]
+fn circled() {
+    let expr = "<math> <mi>Ⓐ</mi><mo>,</mo><mi>Ⓩ</mi></math>";
+    test("en", "SimpleSpeak", expr, "circled cap eigh comma circled cap z");
+    let expr = "<math> <mi>ⓐ</mi><mo>,</mo><mi>ⓩ</mi></math>";
+    test("en", "SimpleSpeak", expr, "circled eigh comma circled z");
+}
+
+#[test]
+fn fraktur() {
+    let expr = "<math> <mi>𝔄</mi><mo>,</mo><mi>𝔜</mi></math>";
+    test("en", "SimpleSpeak", expr, "fraktur cap eigh comma fraktur cap y");
+    let expr = "<math> <mi>𝔞</mi><mo>,</mo><mi>𝔷</mi></math>";
+    test("en", "SimpleSpeak", expr, "fraktur eigh comma fraktur z");
+    // MathType private space versions
+    let expr = "<math> <mi></mi><mo>,</mo><mi></mi></math>";
+    test("en", "SimpleSpeak", expr, "fraktur cap eigh comma fraktur cap y");
+    let expr = "<math> <mi></mi><mo>,</mo><mi></mi></math>";
+    test("en", "SimpleSpeak", expr, "fraktur eigh comma fraktur z");
+}
+
+#[test]
+fn bold_fraktur() {
+    let expr = "<math> <mi>𝕬</mi><mo>,</mo><mi>𝖅</mi></math>";
+    test("en", "SimpleSpeak", expr, "fraktur bold cap eigh, comma fraktur bold cap z");
+    let expr = "<math> <mi>𝖆</mi><mo>,</mo><mi>𝖟</mi></math>";
+    test("en", "SimpleSpeak", expr, "fraktur bold eigh comma fraktur bold z");
+    // MathType private space versions
+    let expr = "<math> <mi></mi><mo>,</mo><mi></mi></math>";
+    test("en", "SimpleSpeak", expr, "fraktur bold cap eigh, comma fraktur bold cap z");
+    let expr = "<math> <mi></mi><mo>,</mo><mi></mi></math>";
+    test("en", "SimpleSpeak", expr, "fraktur bold eigh comma fraktur bold z");
+}
+
+#[test]
+fn double_struck() {
+    let expr = "<math> <mi>𝔸</mi><mo>,</mo><mi>𝕐</mi></math>";
+    test("en", "SimpleSpeak", expr, "double struck cap eigh, comma double struck cap y");
+    let expr = "<math> <mi>𝕒</mi><mo>,</mo><mi>𝕫</mi></math>";
+    test("en", "SimpleSpeak", expr, "double struck eigh comma double struck z");
+    let expr = "<math> <mi>𝟘</mi><mo>,</mo><mi>𝟡</mi></math>";
+    test("en", "SimpleSpeak", expr, "double struck 0 comma double struck 9");
+    // MathType private space versions
+    let expr = "<math> <mi></mi><mo>,</mo><mi></mi></math>";
+    test("en", "SimpleSpeak", expr, "double struck cap eigh, comma double struck cap y");
+    let expr = "<math> <mi></mi><mo>,</mo><mi></mi></math>";
+    test("en", "SimpleSpeak", expr, "double struck eigh comma double struck z");
+    let expr = "<math> <mi></mi><mo>,</mo><mi></mi></math>";
+    test("en", "SimpleSpeak", expr, "double struck 0 comma double struck 9");
+}
+
+#[test]
+fn script() {
+    let expr = "<math> <mi>𝒜</mi><mo>,</mo><mi>𝒵</mi></math>";
+    test("en", "SimpleSpeak", expr, "script cap eigh comma script cap z");
+    let expr = "<math> <mi>𝒶</mi><mo>,</mo><mi>𝓏</mi></math>";
+    test("en", "SimpleSpeak", expr, "script eigh comma script z");
+    // MathType private space versions
+    let expr = "<math> <mi></mi><mo>,</mo><mi></mi></math>";
+    test("en", "SimpleSpeak", expr, "script cap eigh comma script cap z");
+    let expr = "<math> <mi></mi><mo>,</mo><mi></mi></math>";
+    test("en", "SimpleSpeak", expr, "script eigh comma script z");
+}
+
+#[test]
+fn bold_script() {
+    let expr = "<math> <mi>𝓐</mi><mo>,</mo><mi>𝓩</mi></math>";
+    test("en", "SimpleSpeak", expr, "script bold cap eigh comma script bold cap z");
+    let expr = "<math> <mi>𝓪</mi><mo>,</mo><mi>𝔃</mi></math>";
+    test("en", "SimpleSpeak", expr, "script bold eigh comma script bold z");
+    // MathType private space versions
+    let expr = "<math> <mi></mi><mo>,</mo><mi></mi></math>";
+    test("en", "SimpleSpeak", expr, "script bold cap eigh comma script bold cap z");
+    let expr = "<math> <mi></mi><mo>,</mo><mi></mi></math>";
+    test("en", "SimpleSpeak", expr, "script bold eigh comma script bold z");
+}
+
+#[test]
+fn bold() {
+    let expr = "<math> <mi>𝐀</mi><mo>,</mo><mi>𝐙</mi></math>";
+    test("en", "SimpleSpeak", expr, "bold cap eigh comma bold cap z");
+    let expr = "<math> <mi>𝐚</mi><mo>,</mo><mi>𝐳</mi></math>";
+    test("en", "SimpleSpeak", expr, "bold eigh comma bold z");
+    // MathType private space versions
+    let expr = "<math> <mi></mi><mo>,</mo><mi></mi></math>";
+    test("en", "SimpleSpeak", expr, "bold cap eigh comma bold cap z");
+    let expr = "<math> <mi></mi><mo>,</mo><mi></mi></math>";
+    test("en", "SimpleSpeak", expr, "bold eigh comma bold z");
+}
+
+#[test]
+fn italic() {
+    let expr = "<math> <mi>𝐴</mi><mo>,</mo><mi>𝑍</mi></math>";
+    test("en", "SimpleSpeak", expr, "cap eigh comma cap z");
+    let expr = "<math> <mi>𝑎</mi><mo>,</mo><mi>𝑧</mi></math>";
+    test("en", "SimpleSpeak", expr, "eigh comma z");
+    // MathType private space versions
+    let expr = "<math> <mi></mi><mo>,</mo><mi></mi></math>";
+    test("en", "SimpleSpeak", expr, "cap eigh comma cap z");
+    let expr = "<math> <mi></mi><mo>,</mo><mi></mi></math>";
+    test("en", "SimpleSpeak", expr, "eigh comma z");
+}
+
+#[test]
+fn sans_serif() {
+  let expr = "<math> <mi>𝖠</mi><mo>,</mo><mi>𝖹</mi></math>";
+  test("en", "SimpleSpeak", expr, "cap eigh comma cap z");
+  let expr = "<math> <mi>𝖺</mi><mo>,</mo><mi>𝗓</mi></math>";
+  test("en", "SimpleSpeak", expr, "eigh comma z");
+  // MathType private space versions
+  let expr = "<math> <mi></mi><mo>,</mo><mi></mi></math>";
+  test("en", "SimpleSpeak", expr, "cap eigh comma cap z");
+  let expr = "<math> <mi></mi><mo>,</mo><mi></mi></math>";
+  test("en", "SimpleSpeak", expr, "eigh comma z");
+}
+
+#[test]
+fn sans_serif_bold() {
+    let expr = "<math> <mi>𝗔</mi><mo>,</mo><mi>𝗭</mi></math>";
+    test("en", "SimpleSpeak", expr, "bold cap eigh comma bold cap z");
+    let expr = "<math> <mi>𝗮</mi><mo>,</mo><mi>𝘇</mi></math>";
+    test("en", "SimpleSpeak", expr, "bold eigh comma bold z");
+    // MathType private space versions
+    let expr = "<math> <mi></mi><mo>,</mo><mi></mi></math>";
+    test("en", "SimpleSpeak", expr, "bold cap eigh comma bold cap z");
+    let expr = "<math> <mi></mi><mo>,</mo><mi></mi></math>";
+    test("en", "SimpleSpeak", expr, "bold eigh comma bold z");
+}
+
+#[test]
+fn sans_serif_italic() {
+    let expr = "<math> <mi>𝘈</mi><mo>,</mo><mi>𝘡</mi></math>";
+    test("en", "SimpleSpeak", expr, "cap eigh comma cap z");
+    let expr = "<math> <mi>𝘢</mi><mo>,</mo><mi>𝘻</mi></math>";
+    test("en", "SimpleSpeak", expr, "eigh comma z");
+    // MathType private space versions
+    let expr = "<math> <mi></mi><mo>,</mo><mi></mi></math>";
+    test("en", "SimpleSpeak", expr, "cap eigh comma cap z");
+    let expr = "<math> <mi></mi><mo>,</mo><mi></mi></math>";
+    test("en", "SimpleSpeak", expr, "eigh comma z");
+}
+
+#[test]
+fn sans_serif_bold_italic() {
+    let expr = "<math> <mi>𝘼</mi><mo>,</mo><mi>𝙕</mi></math>";
+    test("en", "SimpleSpeak", expr, "bold cap eigh comma bold cap z");
+    let expr = "<math> <mi>𝙖</mi><mo>,</mo><mi>𝙯</mi></math>";
+    test("en", "SimpleSpeak", expr, "bold eigh comma bold z");
+    // MathType private space versions
+    let expr = "<math> <mi></mi><mo>,</mo><mi></mi></math>";
+    test("en", "SimpleSpeak", expr, "bold cap eigh comma bold cap z");
+    let expr = "<math> <mi></mi><mo>,</mo><mi></mi></math>";
+    test("en", "SimpleSpeak", expr, "bold eigh comma bold z");
+}
+
+#[test]
+fn monospace() {
+    let expr = "<math> <mi>𝙰</mi><mo>,</mo><mi>𝚉</mi></math>";
+    test("en", "SimpleSpeak", expr, "cap eigh comma cap z");
+    let expr = "<math> <mi>𝚊</mi><mo>,</mo><mi>𝚣</mi></math>";
+    test("en", "SimpleSpeak", expr, "eigh comma z");
+    // MathType private space versions
+    let expr = "<math> <mi></mi><mo>,</mo><mi></mi></math>";
+    test("en", "SimpleSpeak", expr, "cap eigh comma cap z");
+    let expr = "<math> <mi></mi><mo>,</mo><mi></mi></math>";
+    test("en", "SimpleSpeak", expr, "eigh comma z");
+}
+
+
+#[test]
+fn bold_greek() {
+    let expr = "<math> <mi>𝚨</mi><mo>,</mo><mi>𝛀</mi></math>";
+    test("en", "SimpleSpeak", expr, "bold cap alpha comma bold cap omega");
+    let expr = "<math> <mi>𝛂</mi><mo>,</mo><mi>𝛚</mi></math>";
+    test("en", "SimpleSpeak", expr, "bold alpha comma bold omega");
+    // MathType private space versions
+    let expr = "<math> <mi></mi><mo>,</mo><mi></mi></math>";
+    test("en", "SimpleSpeak", expr, "bold cap alpha comma bold cap omega");
+    let expr = "<math> <mi></mi><mo>,</mo><mi></mi></math>";
+    test("en", "SimpleSpeak", expr, "bold alpha comma bold omega");
+}
+
+#[test]
+fn bold_greek_others() {
+    let expr = "<math> <mi>𝛛</mi><mo>,</mo><mi>𝛡</mi></math>";
+    test("en", "SimpleSpeak", expr, "bold partial derivative, comma bold pi");
+    // MathType private space versions
+    let expr = "<math> <mi></mi><mo>,</mo><mi></mi></math>";
+    test("en", "SimpleSpeak", expr, "bold partial derivative, comma bold pi");
+}
+
+
+#[test]
+fn italic_greek() {
+    let expr = "<math> <mi>𝛢</mi><mo>,</mo><mi>𝛺</mi></math>";
+    test("en", "SimpleSpeak", expr, "cap alpha comma cap omega");
+    let expr = "<math> <mi>𝛼</mi><mo>,</mo><mi>𝜔</mi></math>";
+    test("en", "SimpleSpeak", expr, "alpha comma omega");
+    // MathType private space versions
+    let expr = "<math> <mi></mi><mo>,</mo><mi></mi></math>";
+    test("en", "SimpleSpeak", expr, "cap alpha comma cap omega");
+    let expr = "<math> <mi></mi><mo>,</mo><mi></mi></math>";
+    test("en", "SimpleSpeak", expr, "alpha comma omega");
+}
+
+#[test]
+fn italic_greek_others() {
+    let expr = "<math> <mi>𝜕</mi><mo>,</mo><mi>𝜛</mi></math>";
+    test("en", "SimpleSpeak", expr, "partial derivative comma pi");
+    // MathType private space versions
+    let expr = "<math> <mi></mi><mo>,</mo><mi></mi></math>";
+    test("en", "SimpleSpeak", expr, "partial derivative comma pi");
+}
+
+#[test]
+fn bold_italic_greek() {
+    let expr = "<math> <mi>𝜜</mi><mo>,</mo><mi>𝜴</mi></math>";
+    test("en", "SimpleSpeak", expr, "bold cap alpha comma bold cap omega");
+    let expr = "<math> <mi>𝜶</mi><mo>,</mo><mi>𝝎</mi></math>";
+    test("en", "SimpleSpeak", expr, "bold alpha comma bold omega");
+    // MathType private space versions
+    let expr = "<math> <mi></mi><mo>,</mo><mi></mi></math>";
+    test("en", "SimpleSpeak", expr, "bold cap alpha comma bold cap omega");
+    let expr = "<math> <mi></mi><mo>,</mo><mi></mi></math>";
+    test("en", "SimpleSpeak", expr, "bold alpha comma bold omega");
+}
+
+#[test]
+fn bold_italic_greek_others() {
+    let expr = "<math> <mi>𝝏</mi><mo>,</mo><mi>𝝕</mi></math>";
+    test("en", "SimpleSpeak", expr, "bold partial derivative, comma bold pi");
+    // MathType private space versions
+    let expr = "<math> <mi></mi><mo>,</mo><mi></mi></math>";
+    test("en", "SimpleSpeak", expr, "bold partial derivative, comma bold pi");
+}
+
+#[test]
+fn sans_serif_bold_greek() {
+    let expr = "<math> <mi>𝝖</mi><mo>,</mo><mi>𝝮</mi></math>";
+    test("en", "SimpleSpeak", expr, "bold cap alpha comma bold cap omega");
+    let expr = "<math> <mi>𝝰</mi><mo>,</mo><mi>𝞈</mi></math>";
+    test("en", "SimpleSpeak", expr, "bold alpha comma bold omega");
+    // MathType private space versions
+    let expr = "<math> <mi></mi><mo>,</mo><mi></mi></math>";
+    test("en", "SimpleSpeak", expr, "bold cap alpha comma bold cap omega");
+    let expr = "<math> <mi></mi><mo>,</mo><mi></mi></math>";
+    test("en", "SimpleSpeak", expr, "bold alpha comma bold omega");
+}
+
+#[test]
+fn sans_serif_bold_greek_others() {
+    let expr = "<math> <mi>𝞉</mi><mo>,</mo><mi>𝞏</mi></math>";
+    test("en", "SimpleSpeak", expr, "bold partial derivative, comma bold pi");
+    // MathType private space versions
+    let expr = "<math> <mi></mi><mo>,</mo><mi></mi></math>";
+    test("en", "SimpleSpeak", expr, "bold partial derivative, comma bold pi");
+}
+
+#[test]
+fn sans_serif_bold_italic_greek() {
+    let expr = "<math> <mi>𝞐</mi><mo>,</mo><mi>𝞨</mi></math>";
+    test("en", "SimpleSpeak", expr, "bold cap alpha comma bold cap omega");
+    let expr = "<math> <mi>𝞪</mi><mo>,</mo><mi>𝟂</mi></math>";
+    test("en", "SimpleSpeak", expr, "bold alpha comma bold omega");
+    // MathType private space versions
+    let expr = "<math> <mi></mi><mo>,</mo><mi></mi></math>";
+    test("en", "SimpleSpeak", expr, "bold cap alpha comma bold cap omega");
+    let expr = "<math> <mi></mi><mo>,</mo><mi></mi></math>";
+    test("en", "SimpleSpeak", expr, "bold alpha comma bold omega");
+}
+
+#[test]
+fn sans_serif_bold_italic_greek_others() {
+    let expr = "<math> <mi>𝟃</mi><mo>,</mo><mi>𝟉</mi></math>";
+    test("en", "SimpleSpeak", expr, "bold partial derivative, comma bold pi");
+    // MathType private space versions
+    let expr = "<math> <mi></mi><mo>,</mo><mi></mi></math>";
+    test("en", "SimpleSpeak", expr, "bold partial derivative, comma bold pi");
+}
+
+#[test]
+fn pua_regular() {
+  let expr = "<math> <mi></mi><mo>,</mo><mi></mi></math>";
+  test("en", "SimpleSpeak", expr, "cap eigh comma cap z");
+}
+
+#[test]
+fn turned() {
+    let expr = "<math> <mi>Ⅎ</mi><mo>,</mo><mi>⅄</mi></math>";
+    test("en", "SimpleSpeak", expr, "turned cap f comma turned sans-serif cap y");
+  }
+
+#[test]
+fn enclosed_numbers() {
+  let expr = "<math> <mi>①</mi><mo>,</mo><mi>⑨</mi></math>";
+  test("en", "SimpleSpeak", expr, "circled 1 comma circled 9");
+  let expr = "<math> <mi>⑴</mi><mo>,</mo><mi>⑼</mi></math>";
+  test("en", "SimpleSpeak", expr, "parenthesized 1 comma parenthesized 9");
+  let expr = "<math> <mi>⒈</mi><mo>,</mo><mi>⒐</mi></math>";
+  test("en", "SimpleSpeak", expr, "1 with period comma 9 with period");
+  let expr = "<math> <mi>⓵</mi><mo>,</mo><mi>⓽</mi></math>";
+  test("en", "SimpleSpeak", expr, "double circled 1 comma double circled 9");
+}

--- a/tests/Languages/es/chemistry.rs
+++ b/tests/Languages/es/chemistry.rs
@@ -1,0 +1,657 @@
+/// Tests for rules shared between various speech styles:
+/// *  modified var
+use crate::common::*;
+
+#[test]
+fn salt() {
+  let expr = "<math><mi>Na</mi><mi>Cl</mi></math>";
+  test_prefs("en", "SimpleSpeak", vec![("Verbosity", "Terse")], expr, "cap n eigh, cap c l,");
+}
+
+#[test]
+fn water() {
+  let expr = "<math><msub><mi>H</mi><mn>2</mn></msub><mi>O</mi></math>";
+  test_prefs("en", "ClearSpeak", vec![("Verbosity", "Terse")], expr, "cap h, 2 cap o,");
+  test_prefs("en", "ClearSpeak", vec![("Verbosity", "Medium")], expr, "cap h, sub 2 cap o,");
+  test_prefs("en", "ClearSpeak", vec![("Verbosity", "Verbose")], expr, "cap h, subscript 2, cap o,");
+}
+
+#[test]
+fn carbon() {
+  let expr = "<math><mi>C</mi></math>";     // not enough to trigger recognition
+  test_prefs("en", "SimpleSpeak", vec![("Verbosity", "Terse")], expr, "cap c");
+}
+
+#[test]
+fn sulfate() {
+  let expr = "<math><mrow><msup>
+          <mrow><mo>[</mo><mi>S</mi><msub><mi>O</mi><mn>4</mn></msub><mo>]</mo></mrow>
+          <mrow><mn>2</mn><mo>&#x2212;</mo></mrow>
+      </msup></mrow></math>";
+  test_prefs("en", "ClearSpeak", vec![("Verbosity", "Medium")], expr, "open bracket, cap s, cap o, sub 4; close bracket super 2 minus");
+}
+
+#[test]
+fn aluminum_sulfate() {
+  let expr = "<math><mrow><msub><mi>Al</mi><mn>2</mn></msub>
+          <msub><mrow><mo>(</mo><mi>S</mi><msub><mi>O</mi><mn>4</mn></msub><mo>)</mo></mrow><mn>3</mn></msub></mrow></math>";
+  test_prefs("en", "ClearSpeak", vec![("Verbosity", "Terse")], expr, "cap eigh l, 2, open cap s, cap o, 4, close 3");
+  test_prefs("en", "ClearSpeak", vec![("Verbosity", "Medium")], expr, "cap eigh l, sub 2; open paren, cap s, cap o, sub 4; close paren sub 3");
+  test_prefs("en", "ClearSpeak", vec![("Verbosity", "Verbose")], expr, "cap eigh l, subscript 2; open paren, cap s, cap o, subscript 4; close paren subscript 3");
+}
+
+#[test]
+fn ethanol_bonds() {
+  let expr = "<math>
+          <mrow>
+              <mi>C</mi>
+              <msub>  <mi>H</mi> <mn>3</mn> </msub>
+              <mo>&#x2212;</mo>
+              <mi>C</mi>
+              <msub>  <mi>H</mi> <mn>2</mn> </msub>
+              <mo>&#x2212;</mo>
+              <mi>O</mi>
+              <mi>H</mi>
+          </mrow>
+      </math>";
+  test_prefs("en", "ClearSpeak", vec![("Verbosity", "Terse")], expr, "cap c, cap h, 3 single bond cap c, cap h, 2 single bond cap o, cap h,");
+
+}
+
+#[test]
+fn dichlorine_hexoxide() {
+  let expr = "<math><mrow>
+      <msup>
+        <mrow><mo>[</mo><mi>Cl</mi><msub><mi>O</mi><mn>2</mn></msub><mo>]</mo></mrow>
+        <mo>+</mo>
+      </msup>
+      <msup>
+        <mrow><mo>[</mo><mi>Cl</mi><msub><mi>O</mi><mn>4</mn></msub><mo>]</mo></mrow>
+        <mo>-</mo>
+      </msup>
+    </mrow></math>";
+  test_prefs("en", "SimpleSpeak", vec![("Verbosity", "Terse")], 
+    expr, "open bracket, cap c l, cap o, 2, close bracket plus; \
+                          open bracket, cap c l, cap o, 4, close bracket minus");
+  test_prefs("en", "SimpleSpeak", vec![("Verbosity", "Medium")], 
+    expr, "open bracket, cap c l, cap o, sub 2; close bracket super plus; \
+                          open bracket, cap c l, cap o, sub 4; close bracket super minus");
+  test_prefs("en", "SimpleSpeak", vec![("Verbosity", "Verbose")], 
+    expr, "open bracket, cap c l, cap o, subscript 2; close bracket superscript plus; \
+                          open bracket, cap c l, cap o, subscript 4; close bracket superscript minus");
+}
+
+
+#[test]
+fn ethylene_with_bond() {
+  let expr = "<math><mrow>
+          <msub><mi>H</mi><mn>2</mn></msub><mi>C</mi>
+          <mo>=</mo>
+          <mi>C</mi><msub><mi>H</mi><mn>2</mn></msub>
+      </mrow></math>";
+  test_prefs("en", "SimpleSpeak", vec![("Verbosity", "Terse")], expr, "cap h, 2 cap c, double bond cap c, cap h, 2");
+}
+
+#[test]
+fn ferric_chloride_aq() {
+  let expr = "<math><mrow>
+        <mi>Fe</mi>
+        <msub><mi>Cl</mi><mn>3</mn></msub>
+        <mrow><mo>(</mo><mrow><mi>aq</mi></mrow><mo>)</mo></mrow>
+    </mrow></math>";
+  test_prefs("en", "SimpleSpeak", vec![("Verbosity", "Terse")], expr, "cap f e, cap c l, 3 aqueous,");
+  }
+
+#[test]
+fn ethylene_with_colon_bond() {
+  let expr = "<math><mrow>
+          <msub><mi>H</mi><mn>2</mn></msub><mi>C</mi>
+          <mo>::</mo>
+          <mi>C</mi><msub><mi>H</mi><mn>2</mn></msub>
+      </mrow></math>";
+  test_prefs("en", "SimpleSpeak", vec![("Verbosity", "Terse")], expr, "cap h, 2 cap c, double bond cap c, cap h, 2");
+}
+
+#[test]
+fn beta_decay() {
+  let expr = "<math>
+      <mmultiscripts>
+        <mtext>C</mtext>
+        <mprescripts />
+        <mn>6</mn>
+        <mn>14</mn>
+      </mmultiscripts>
+      <mo>&#x2192;</mo>
+      <mmultiscripts>
+        <mtext>N</mtext>
+        <mprescripts />
+        <mn>7</mn>
+        <mn>14</mn>
+      </mmultiscripts>
+      <mo>+</mo>
+      <mmultiscripts>
+        <mtext>e</mtext>
+        <mprescripts />
+        <mrow>
+          <mo>&#x2212;</mo>
+          <mn>1</mn>
+        </mrow>
+        <mn>0</mn>
+      </mmultiscripts>
+    </math>";
+    test_prefs("en", "ClearSpeak", vec![("Verbosity", "Terse")], expr,
+      "14, 6, cap c; forms, 14, 7, cap n; plus 0, negative 1, e,");
+    test_prefs("en", "ClearSpeak", vec![("Verbosity", "Medium")], expr,
+      "super 14, sub 6, cap c; reacts to form; super 14, sub 7, cap n; plus super 0, sub negative 1, e,");
+    test_prefs("en", "ClearSpeak", vec![("Verbosity", "Verbose")], expr,
+      "superscript 14, subscript 6, cap c; reacts to form; superscript 14, subscript 7, cap n; plus, superscript 0, subscript negative 1, e,");
+}
+
+#[test]
+fn mhchem_beta_decay() {
+  let expr = "<math>
+      <mrow>
+        <msubsup>
+          <mrow>
+            <mrow>
+              <mpadded width='0'>
+                <mphantom>
+                  <mi>A</mi>
+                </mphantom>
+              </mpadded>
+            </mrow>
+          </mrow>
+          <mrow>
+            <mrow>
+              <mpadded height='0' depth='0'>
+                <mphantom>
+                  <mn>6</mn>
+                </mphantom>
+              </mpadded>
+            </mrow>
+          </mrow>
+          <mrow>
+            <mrow>
+              <mpadded height='0' depth='0'>
+                <mphantom>
+                  <mn>14</mn>
+                </mphantom>
+              </mpadded>
+            </mrow>
+          </mrow>
+        </msubsup>
+        <mspace width='-0.083em'></mspace>
+        <msubsup>
+          <mrow>
+            <mrow>
+              <mpadded width='0'>
+                <mphantom>
+                  <mi>A</mi>
+                </mphantom>
+              </mpadded>
+            </mrow>
+          </mrow>
+          <mrow>
+            <mrow>
+              <mpadded width='0'>
+                <mphantom>
+                  <mn>2</mn>
+                </mphantom>
+              </mpadded>
+            </mrow>
+            <mrow>
+              <mpadded width='0' lspace='-1width'>
+                <mrow>
+                  <mpadded height='0'>
+                    <mn>6</mn>
+                  </mpadded>
+                </mrow>
+              </mpadded>
+            </mrow>
+          </mrow>
+          <mrow>
+            <mrow>
+              <mpadded height='0'>
+                <mrow>
+                  <mpadded width='0'>
+                    <mphantom>
+                      <mn>2</mn>
+                    </mphantom>
+                  </mpadded>
+                </mrow>
+              </mpadded>
+            </mrow>
+            <mrow>
+              <mpadded width='0' lspace='-1width'>
+                <mn>14</mn>
+              </mpadded>
+            </mrow>
+          </mrow>
+        </msubsup>
+        <mrow>
+          <mi mathvariant='normal'>C</mi>
+        </mrow>
+        <mrow></mrow>
+        <mrow>
+          <mo stretchy='false'>&#x27F6;</mo>
+        </mrow>
+        <mrow></mrow>
+        <msubsup>
+          <mrow>
+            <mrow>
+              <mpadded width='0'>
+                <mphantom>
+                  <mi>A</mi>
+                </mphantom>
+              </mpadded>
+            </mrow>
+          </mrow>
+          <mrow>
+            <mrow>
+              <mpadded height='0' depth='0'>
+                <mphantom>
+                  <mn>7</mn>
+                </mphantom>
+              </mpadded>
+            </mrow>
+          </mrow>
+          <mrow>
+            <mrow>
+              <mpadded height='0' depth='0'>
+                <mphantom>
+                  <mn>14</mn>
+                </mphantom>
+              </mpadded>
+            </mrow>
+          </mrow>
+        </msubsup>
+        <mspace width='-0.083em'></mspace>
+        <msubsup>
+          <mrow>
+            <mrow>
+              <mpadded width='0'>
+                <mphantom>
+                  <mi>A</mi>
+                </mphantom>
+              </mpadded>
+            </mrow>
+          </mrow>
+          <mrow>
+            <mrow>
+              <mpadded width='0'>
+                <mphantom>
+                  <mn>2</mn>
+                </mphantom>
+              </mpadded>
+            </mrow>
+            <mrow>
+              <mpadded width='0' lspace='-1width'>
+                <mrow>
+                  <mpadded height='0'>
+                    <mn>7</mn>
+                  </mpadded>
+                </mrow>
+              </mpadded>
+            </mrow>
+          </mrow>
+          <mrow>
+            <mrow>
+              <mpadded height='0'>
+                <mrow>
+                  <mpadded width='0'>
+                    <mphantom>
+                      <mn>2</mn>
+                    </mphantom>
+                  </mpadded>
+                </mrow>
+              </mpadded>
+            </mrow>
+            <mrow>
+              <mpadded width='0' lspace='-1width'>
+                <mn>14</mn>
+              </mpadded>
+            </mrow>
+          </mrow>
+        </msubsup>
+        <mrow>
+          <mi mathvariant='normal'>N</mi>
+        </mrow>
+        <mrow></mrow>
+        <mo>+</mo>
+        <mrow></mrow>
+        <msubsup>
+          <mrow>
+            <mrow>
+              <mpadded width='0'>
+                <mphantom>
+                  <mi>A</mi>
+                </mphantom>
+              </mpadded>
+            </mrow>
+          </mrow>
+          <mrow>
+            <mrow>
+              <mpadded height='0' depth='0'>
+                <mphantom>
+                  <mo>&#x2212;</mo>
+                  <mn>1</mn>
+                </mphantom>
+              </mpadded>
+            </mrow>
+          </mrow>
+          <mrow>
+            <mrow>
+              <mpadded height='0' depth='0'>
+                <mphantom>
+                  <mn>0</mn>
+                </mphantom>
+              </mpadded>
+            </mrow>
+          </mrow>
+        </msubsup>
+        <mspace width='-0.083em'></mspace>
+        <msubsup>
+          <mrow>
+            <mrow>
+              <mpadded width='0'>
+                <mphantom>
+                  <mi>A</mi>
+                </mphantom>
+              </mpadded>
+            </mrow>
+          </mrow>
+          <mrow>
+            <mrow>
+              <mpadded width='0'>
+                <mphantom>
+                  <mn>2</mn>
+                </mphantom>
+              </mpadded>
+            </mrow>
+            <mrow>
+              <mpadded width='0' lspace='-1width'>
+                <mrow>
+                  <mpadded height='0'>
+                    <mo>&#x2212;</mo>
+                    <mn>1</mn>
+                  </mpadded>
+                </mrow>
+              </mpadded>
+            </mrow>
+          </mrow>
+          <mrow>
+            <mrow>
+              <mpadded height='0'>
+                <mrow>
+                  <mpadded width='0'>
+                    <mphantom>
+                      <mn>2</mn>
+                    </mphantom>
+                  </mpadded>
+                </mrow>
+              </mpadded>
+            </mrow>
+            <mrow>
+              <mpadded width='0' lspace='-1width'>
+                <mn>0</mn>
+              </mpadded>
+            </mrow>
+          </mrow>
+        </msubsup>
+        <mrow>
+          <mi mathvariant='normal'>e</mi>
+        </mrow>
+      </mrow>
+    </math>";
+    test_prefs("en", "ClearSpeak", vec![("Verbosity", "Terse")], expr,
+      "14, 6, cap c; forms, 14, 7, cap n; plus 0, negative 1, e,");
+    test_prefs("en", "ClearSpeak", vec![("Verbosity", "Medium")], expr,
+      "super 14, sub 6, cap c; reacts to form; super 14, sub 7, cap n; plus super 0, sub negative 1, e,");
+    test_prefs("en", "ClearSpeak", vec![("Verbosity", "Verbose")], expr,
+      "superscript 14, subscript 6, cap c; reacts to form; superscript 14, subscript 7, cap n; plus, superscript 0, subscript negative 1, e,");
+}
+
+#[test]
+fn hcl_na_yields() {
+    let expr = "<math> <mrow>
+      <mn>2</mn><mi>H</mi><mi>Cl</mi><mo>+</mo><mn>2</mn><mtext>Na</mtext>
+      <mo>&#x2192;</mo>
+      <mn>2</mn><mtext>Na</mtext><mi>Cl</mi><mo>+</mo>
+      <msub> <mi>H</mi> <mn>2</mn> </msub>
+      </mrow>
+    </math>";
+    test_prefs("en", "SimpleSpeak", vec![("Verbosity", "Verbose")], expr,
+        "2, cap h, cap c l; plus 2 cap n eigh; reacts to form; 2, cap n eigh, cap c l; plus cap h, subscript 2");
+}
+
+#[test]
+fn mhchem_so4_2plus() {
+  let expr = "<math>
+    <mrow>
+      <mrow>
+        <mi>SO</mi>
+      </mrow>
+      <msub>
+        <mrow>
+          <mrow>
+            <mpadded width='0'>
+              <mphantom>
+                <mi>A</mi>
+              </mphantom>
+            </mpadded>
+          </mrow>
+        </mrow>
+        <mrow>
+          <mrow>
+            <mpadded height='0'>
+              <mn>4</mn>
+            </mpadded>
+          </mrow>
+        </mrow>
+      </msub>
+      <msup>
+        <mrow>
+          <mrow>
+            <mpadded width='0'>
+              <mphantom>
+                <mi>A</mi>
+              </mphantom>
+            </mpadded>
+          </mrow>
+        </mrow>
+        <mrow>
+          <mn>2</mn>
+          <mo>+</mo>
+        </mrow>
+      </msup>
+    </mrow>
+  </math>";
+  test_prefs("en", "SimpleSpeak", vec![("Verbosity", "Terse")], expr, "cap s; cap o, 4, 2 plus,");
+  test_prefs("en", "SimpleSpeak", vec![("Verbosity", "Medium")], expr, "cap s; cap o, sub 4, super 2 plus,");
+  test_prefs("en", "SimpleSpeak", vec![("Verbosity", "Verbose")], expr, "cap s; cap o, subscript 4, superscript 2 plus,");
+}
+
+
+#[test]
+fn mhchem_hcl_aq_etc() {
+  let expr = "<math>
+    <mrow>
+      <mn>2</mn>
+      <mstyle scriptlevel='0'>
+        <mspace width='0.167em'></mspace>
+      </mstyle>
+      <mrow>
+        <mi>HCl</mi>
+      </mrow>
+      <mspace width='0.111em'></mspace>
+      <mo stretchy='false'>(</mo>
+      <mrow>
+        <mi>aq</mi>
+      </mrow>
+      <mo stretchy='false'>)</mo>
+      <mrow></mrow>
+      <mo>+</mo>
+      <mrow></mrow>
+      <mn>2</mn>
+      <mstyle scriptlevel='0'>
+        <mspace width='0.167em'></mspace>
+      </mstyle>
+      <mrow>
+        <mi>Na</mi>
+      </mrow>
+      <mspace width='0.111em'></mspace>
+      <mo stretchy='false'>(</mo>
+      <mrow>
+        <mi mathvariant='normal'>s</mi>
+      </mrow>
+      <mo stretchy='false'>)</mo>
+      <mrow></mrow>
+      <mrow>
+        <mo stretchy='false'>&#x27F6;</mo>
+      </mrow>
+      <mrow></mrow>
+      <mn>2</mn>
+      <mstyle scriptlevel='0'>
+        <mspace width='0.167em'></mspace>
+      </mstyle>
+      <mrow>
+        <mi>NaCl</mi>
+      </mrow>
+      <mspace width='0.111em'></mspace>
+      <mo stretchy='false'>(</mo>
+      <mrow>
+        <mi>aq</mi>
+      </mrow>
+      <mo stretchy='false'>)</mo>
+      <mrow></mrow>
+      <mo>+</mo>
+      <mrow></mrow>
+      <mrow>
+        <mi mathvariant='normal'>H</mi>
+      </mrow>
+      <msub>
+        <mrow>
+          <mrow>
+            <mpadded width='0'>
+              <mphantom>
+                <mi>A</mi>
+              </mphantom>
+            </mpadded>
+          </mrow>
+        </mrow>
+        <mrow>
+          <mrow>
+            <mpadded height='0'>
+              <mn>2</mn>
+            </mpadded>
+          </mrow>
+        </mrow>
+      </msub>
+      <mspace width='0.111em'></mspace>
+      <mo stretchy='false'>(</mo>
+      <mrow>
+        <mi mathvariant='normal'>g</mi>
+      </mrow>
+      <mo stretchy='false'>)</mo>
+    </mrow>
+  </math>";
+  test_prefs("en", "SimpleSpeak", vec![("Verbosity", "Terse")],
+      expr, "2, cap h, cap c l, aqueous; plus, 2, cap n eigh, solid; forms; 2, cap n eigh, cap c l, aqueous; plus, cap h, 2, gas,");
+
+}
+
+
+#[test]
+fn mhchem_barbed_equilibrium() {
+  let expr = "<math>
+    <mrow data-mjx-texclass='ORD' data-chem-equation='14'>
+      <mrow data-changed='added' data-chem-equation='3'>
+        <mmultiscripts data-chem-formula='1'>
+          <mi data-mjx-texclass='ORD' mathvariant='normal' data-chem-element='1'>H</mi>
+          <mn data-mjx-texclass='ORD'>2</mn>
+          <none></none>
+        </mmultiscripts>
+        <mo data-changed='added' data-function-guess='true'>&#x2063;</mo>
+        <mrow data-changed='added' data-chem-equation='1'>
+          <mo stretchy='false'>(</mo>
+          <mi data-mjx-texclass='ORD' mathvariant='normal'>g</mi>
+          <mo stretchy='false'>)</mo>
+        </mrow>
+      </mrow>
+      <mo data-chem-equation-op='1'>+</mo>
+      <mrow data-changed='added' data-chem-equation='10'>
+        <mrow data-changed='added' data-chem-equation='3'>
+          <mmultiscripts data-chem-formula='1'>
+            <mi data-mjx-texclass='ORD' mathvariant='normal' data-chem-element='1'>I</mi>
+            <mn data-mjx-texclass='ORD'>2</mn>
+            <none></none>
+          </mmultiscripts>
+          <mo data-changed='added' data-function-guess='true'>&#x2063;</mo>
+          <mrow data-changed='added' data-chem-equation='1'>
+            <mo stretchy='false'>(</mo>
+            <mi data-mjx-texclass='ORD' mathvariant='normal'>g</mi>
+            <mo stretchy='false'>)</mo>
+          </mrow>
+        </mrow>
+        <mo data-changed='added'>&#x2062;</mo>
+        <mover data-mjx-texclass='REL'>
+          <mrow data-mjx-texclass='ORD' depth='0' height='0' data-changed='added'>
+            <mo data-mjx-texclass='ORD' stretchy='false'>↽</mo>
+            <mo data-mjx-texclass='ORD'>-</mo>
+          </mrow>
+          <mrow data-mjx-texclass='ORD' displaystyle='false' scriptlevel='0' data-changed='added'>
+            <mo data-mjx-texclass='ORD'>-</mo>
+            <mo data-mjx-texclass='ORD' stretchy='false'>⇀</mo>
+          </mrow>
+        </mover>
+        <mo data-changed='added'>&#x2062;</mo>
+        <mn>2</mn>
+        <mo data-changed='added'>&#x2062;</mo>
+        <mrow data-changed='added' data-chem-equation='5'>
+          <mi mathvariant='normal' data-chem-element='1'>H</mi>
+          <mo data-changed='added'>&#x2063;</mo>
+          <mi mathvariant='normal' data-chem-element='1'>I</mi>
+          <mo data-changed='added' data-function-guess='true'>&#x2063;</mo>
+          <mrow data-changed='added' data-chem-equation='1'>
+            <mo stretchy='false'>(</mo>
+            <mi data-mjx-texclass='ORD' mathvariant='normal'>g</mi>
+            <mo stretchy='false'>)</mo>
+          </mrow>
+        </mrow>
+      </mrow>
+    </mrow>
+  </math>";
+  test_prefs("en", "SimpleSpeak", vec![("Verbosity", "Terse")],
+      expr, "cap h, 2, gas; plus; cap i, 2, gas; is in equilibrium with, 2, cap h, cap i, gas,");
+}
+
+
+
+#[test]
+fn mhchem_roman_in_superscript() {
+      let expr = " <math>
+      <mrow>
+        <mmultiscripts>
+          <mi>Fe</mi>
+          <none></none>
+          <mi>II</mi>
+        </mmultiscripts>
+        <mo>&#x2063;</mo>
+        <mmultiscripts>
+          <mi>Fe</mi>
+          <none></none>
+          <mi data-number='3'>III</mi>
+        </mmultiscripts>
+        <mo>&#x2063;</mo>
+        <mmultiscripts>
+          <mi mathvariant='normal' >O</mi>
+          <mn>4</mn>
+          <none></none>
+        </mmultiscripts>
+      </mrow>
+    </math>";
+  test_prefs("en", "SimpleSpeak", vec![("Verbosity", "Terse")],
+      expr, "cap f e, 2; cap f e, 3; cap o, 4,");
+}
+
+

--- a/tests/Languages/es/intent.rs
+++ b/tests/Languages/es/intent.rs
@@ -1,0 +1,43 @@
+/// Tests for rules shared between various speech styles:
+/// *  this has tests focused on the various alphabets
+use crate::common::*;
+
+
+#[test]
+fn silent_intent_mi() {
+    let expr = "<math> <mn>2</mn> <mi intent=':silent'>x</mi></math>";
+    test("en", "SimpleSpeak", expr, "2");
+    test("en", "ClearSpeak", expr, "2");
+}
+
+#[test]
+fn silent_intent_msup() {
+    let expr = "<math>
+        <msup intent='index:silent($H,$n)'>
+            <mi arg='H' mathvariant='normal'>H</mi>
+            <mn arg='n'>2</mn>
+        </msup></math>";
+    test("en", "SimpleSpeak", expr, "cap h 2");
+    test("en", "ClearSpeak", expr, "cap h 2");
+}
+
+#[test]
+fn silent_intent_underscore() {
+    let expr = "<math>
+        <msup intent='_($H,$n)'>
+            <mi arg='H' mathvariant='normal'>H</mi>
+            <mn arg='n'>2</mn>
+        </msup></math>";
+    test("en", "SimpleSpeak", expr, "cap h 2");
+    test("en", "ClearSpeak", expr, "cap h 2");
+}
+
+#[test]
+fn intent_prob_x() {
+    let expr = "<math>
+    <msup intent='$op($arg)'>
+        <mi arg='arg'>x</mi>
+        <mi arg='op' intent='probability' mathvariant='normal'>P</mi>
+    </msup></math>";
+    test("en", "ClearSpeak", expr, "probability of, x");
+}

--- a/tests/Languages/es/shared.rs
+++ b/tests/Languages/es/shared.rs
@@ -1,0 +1,288 @@
+/// Tests for rules shared between various speech styles:
+/// *  modified var
+use crate::common::*;
+
+#[test]
+fn modified_vars() {
+    let expr = "<math> <mrow>
+        <mover> <mi>a</mi> <mo>`</mo> </mover>
+        <mover> <mi>b</mi> <mo>~</mo> </mover>
+        <mover> <mi>c</mi> <mo>&#x0306;</mo> </mover>
+        <mover> <mi>b</mi> <mo>&#x030c;</mo> </mover>
+        <mover> <mi>c</mi> <mo>`</mo> </mover>  <mo>+</mo>
+        <mover> <mi>x</mi> <mo>.</mo> </mover>
+        <mover> <mi>y</mi> <mo>&#x2D9;</mo> </mover>
+        <mover> <mi>z</mi> <mo>&#x00A8;</mo> </mover>
+        <mover> <mi>u</mi> <mo>&#x20DB;</mo> </mover>
+        <mover> <mi>v</mi> <mo>&#x20DC;</mo> </mover> <mo>+</mo>
+        <mover> <mi>x</mi> <mo>^</mo> </mover> <mo>+</mo>
+        <mover> <mi>t</mi> <mo>→</mo> </mover>
+        </mrow> </math>";
+    test("en", "SimpleSpeak", expr, 
+        "eigh grave, b tilde, c breve, b check, c grave; plus; \
+            x dot, y dot, z double dot, u triple dot, v quadruple dot; plus x hat, plus vector t");
+}
+
+#[test]
+fn limit() {
+    let expr = "<math>
+            <munder>
+            <mo>lim</mo>
+            <mrow>  <mi>x</mi> <mo>&#x2192;</mo>  <mn>0</mn>  </mrow>
+            </munder>
+            <mrow>
+            <mfrac>
+                <mrow>  <mi>sin</mi>  <mo>&#x2061;</mo> <mi>x</mi> </mrow>
+                <mi>x</mi>
+            </mfrac>
+            </mrow>
+        </math>";
+    test("en", "SimpleSpeak", expr, "the limit as x approaches 0, of, fraction, sine of x, over x, end fraction;");
+}
+
+#[test]
+fn limit_from_below() {
+    let expr = "<math>
+            <munder>
+            <mo>lim</mo>
+            <mrow>  <mi>x</mi> <mo>↗</mo>  <mn>0</mn>  </mrow>
+            </munder>
+            <mrow>
+                <mrow>  <mi>sin</mi>  <mo>&#x2061;</mo> <mi>x</mi> </mrow>
+            </mrow>
+        </math>";
+    test("en", "SimpleSpeak", expr, "the limit as x approaches from below 0, of sine of x");
+}
+
+
+#[test]
+fn binomial_mmultiscripts() {
+    let expr = "<math><mmultiscripts><mi>C</mi><mi>m</mi><none/><mprescripts/><mi>n</mi><none/></mmultiscripts></math>";
+    test("en", "SimpleSpeak", expr, "n choose m");
+}
+
+
+#[test]
+fn permutation_mmultiscripts() {
+    let expr = "<math><mmultiscripts><mi>P</mi><mi>k</mi><none/><mprescripts/><mi>n</mi><none/></mmultiscripts></math>";
+    test("en", "SimpleSpeak", expr, "k permutations of n");
+}
+
+#[test]
+fn permutation_mmultiscripts_sup() {
+    let expr = "<math><mmultiscripts><mi>P</mi><mi>k</mi><none/><mprescripts/><none/><mi>n</mi></mmultiscripts></math>";
+    test("en", "SimpleSpeak", expr, "k permutations of n");
+}
+
+#[test]
+fn permutation_msubsup() {
+    let expr = "<math><msubsup><mi>P</mi><mi>k</mi><mi>n</mi></msubsup></math>";
+    test("en", "SimpleSpeak", expr, "k permutations of n");
+}
+
+#[test]
+fn tensor_mmultiscripts() {
+    let expr = "<math><mmultiscripts>
+            <mi>R</mi> <mi>i</mi><none/> <none/><mi>j</mi> <mi>k</mi><none/> <mi>l</mi><none/> 
+        </mmultiscripts></math>";
+    test_prefs("en", "SimpleSpeak", vec![("Verbosity", "Verbose")], expr,
+            "cap r with 4 postscripts, subscript i superscript j subscript k subscript l");
+    test_prefs("en", "SimpleSpeak", vec![("Verbosity", "Medium")], expr,
+            "cap r with 4 postscripts, sub i super j sub k sub l");
+}
+
+#[test]
+fn huge_num_mmultiscripts() {
+    let expr = "<math><mmultiscripts>
+            <mi>R</mi> <mi>i</mi><none/> <none/><mi>j</mi> <mi>k</mi><none/> <mi>l</mi><none/> <mi>m</mi><none/>
+            <mprescripts/> <mi>I</mi><none/> <none/><mi>J</mi> <mi>K</mi><none/> <mi>L</mi><none/>
+        </mmultiscripts></math>";
+    test_prefs("en", "SimpleSpeak", vec![("Verbosity", "Verbose")], expr,
+            "cap r with 4 prescripts, pre subscript cap i, pre superscript cap j and alternating prescripts cap k none cap l none end prescripts and with 5 postscripts, subscript i superscript j subscript k subscript l and alternating scripts m none end scripts");
+}
+
+#[test]
+fn prime() {
+    let expr = "<math> <msup><mi>x</mi><mo >&#x2032;</mo></msup> </math>";
+    test("en", "SimpleSpeak", expr, "x prime,");
+}
+
+#[test]
+fn given() {
+    let expr = "<math><mi>P</mi><mo>(</mo><mi>A</mi><mo>|</mo><mi>B</mi><mo>)</mo></math>";
+    test("en", "SimpleSpeak", expr, "cap p, open paren, cap eigh vertical line cap b; close paren");
+    test("en", "ClearSpeak", expr,  "cap p, open paren, cap eigh divides cap b, close paren");  // not good, but follows the spec
+}
+
+#[test]
+fn simple_msubsup() {
+    let expr = "<math>
+            <mstyle displaystyle='true' scriptlevel='0'>
+            <msubsup>
+                <mi>x</mi>
+                <mrow>
+                <mi>k</mi>
+                </mrow>
+                <mrow>
+                <mi>i</mi>
+                </mrow>
+            </msubsup>
+            </mstyle>
+        </math>";
+    test("en", "ClearSpeak", expr, "x sub k to the i-th power");
+}
+
+#[test]
+fn presentation_mathml_in_semantics() {
+    let expr = "<math>
+        <semantics>
+            <annotation encoding='application/x-tex'>{\\displaystyle x_k^i}</annotation>
+            <annotation-xml encoding='MathML-Presentation'>
+                <msubsup>
+                    <mi>x</mi>
+                    <mrow>
+                    <mi>k</mi>
+                    </mrow>
+                    <mrow>
+                    <mi>i</mi>
+                    </mrow>
+                </msubsup>
+            </annotation-xml>
+        </semantics>
+    </math>";
+    test("en", "ClearSpeak", expr, "x sub k to the i-th power");
+}
+
+#[test]
+fn ignore_period() {
+    // from https://en.wikipedia.org/wiki/Probability
+    let expr = "<math>
+    <semantics>
+    <annotation encoding='application/x-tex'>{\\displaystyle x_k^i}</annotation>
+    <annotation-xml encoding='MathML-Presentation'>
+      <mrow>
+        <mstyle displaystyle='true' scriptlevel='0'>
+          <mi>P</mi>
+          <mo stretchy='false'>(</mo>
+          <mi>A</mi>
+          <mrow>
+            <mstyle displaystyle='false' scriptlevel='0'>
+              <mtext>&nbsp;and&nbsp;</mtext>
+            </mstyle>
+          </mrow>
+          <mi>B</mi>
+          <mo stretchy='false'>)</mo>
+          <mo>=</mo>
+          <mi>P</mi>
+          <mo stretchy='false'>(</mo>
+          <mi>A</mi>
+          <mo>∩<!-- ∩ --></mo>
+          <mi>B</mi>
+          <mo stretchy='false'>)</mo>
+          <mo>=</mo>
+          <mi>P</mi>
+          <mo stretchy='false'>(</mo>
+          <mi>A</mi>
+          <mo stretchy='false'>)</mo>
+          <mi>P</mi>
+          <mo stretchy='false'>(</mo>
+          <mi>B</mi>
+          <mo stretchy='false'>)</mo>
+          <mo>.</mo>
+        </mstyle>
+      </mrow>
+      </annotation-xml>
+    </semantics>  
+  </math>";
+    test("en", "SimpleSpeak", expr, "cap p; open paren, cap eigh and cap b; close paren; is equal to; cap p, open paren, cap eigh intersection cap b; close paren; is equal to, cap p of cap eigh, cap p of cap b");
+}
+
+#[test]
+fn ignore_mtext_period() {
+    let expr = "<math><mrow><mrow><mo>{</mo><mn>2</mn><mo>}</mo></mrow><mtext>.</mtext></mrow></math>";
+    test("en", "SimpleSpeak", expr, "the set 2");
+}
+
+#[test]
+fn ignore_comma() {
+    // from https://en.wikipedia.org/wiki/Probability
+    let expr = "<math>
+    <mrow>
+      <mstyle displaystyle='true' scriptlevel='0'>
+        <mi>ϕ<!-- ϕ --></mi>
+        <mo stretchy='false'>(</mo>
+        <mi>x</mi>
+        <mo stretchy='false'>)</mo>
+        <mo>=</mo>
+        <mi>c</mi>
+        <msup>
+          <mi>e</mi>
+          <mrow>
+            <mo>−<!-- − --></mo>
+            <msup>
+              <mi>h</mi>
+              <mrow>
+                <mn>2</mn>
+              </mrow>
+            </msup>
+            <msup>
+              <mi>x</mi>
+              <mrow>
+                <mn>2</mn>
+              </mrow>
+            </msup>
+          </mrow>
+        </msup>
+        <mo>,</mo>
+      </mstyle>
+    </mrow>
+</math>";
+    test("en", "SimpleSpeak", expr, "phi of x is equal to; c, e raised to the negative h squared x squared power");
+}
+
+#[test]
+#[ignore] // issue #14
+fn ignore_period_and_space() {
+    // from https://en.wikipedia.org/wiki/Probability
+    let expr = "<math>
+      <mrow>
+        <mstyle displaystyle='true' scriptlevel='0'>
+          <mi>P</mi>
+          <mo stretchy='false'>(</mo>
+          <mi>A</mi>
+          <mo>∣<!-- ∣ --></mo>
+          <mi>B</mi>
+          <mo stretchy='false'>)</mo>
+          <mo>=</mo>
+          <mrow>
+            <mfrac>
+              <mrow>
+                <mi>P</mi>
+                <mo stretchy='false'>(</mo>
+                <mi>A</mi>
+                <mo>∩<!-- ∩ --></mo>
+                <mi>B</mi>
+                <mo stretchy='false'>)</mo>
+              </mrow>
+              <mrow>
+                <mi>P</mi>
+                <mo stretchy='false'>(</mo>
+                <mi>B</mi>
+                <mo stretchy='false'>)</mo>
+              </mrow>
+            </mfrac>
+          </mrow>
+          <mo>.</mo>
+          <mspace width='thinmathspace'></mspace>
+        </mstyle>
+      </mrow>
+</math>";
+    test("en", "ClearSpeak", expr, "phi of x is equal to; c, e raised to the negative h squared x squared power");
+}
+
+
+#[test]
+fn mn_with_space() {
+    let expr = "<math><mn>1 234 567</mn></math>";
+    test("en", "SimpleSpeak", expr, "1234567");
+}


### PR DESCRIPTION
For the short styles, "abrir" plus the name of the double sing has been used.
For the detailed style, a grammatically correct form that explains what happens is used. In English maybe translated, for example, as "parentheses is opened". I don't find the similar form to right parent (paréntesis derecho) mentioned by RAE, and in fact this form has two words like abrir paréntesis, used for the short style.
Seems not to be a very defined criterion to determine differences between styles, and criterion may be difficult to define for different languages (for example, number of words, prosody, i.e., what sounds more long/short etc). So I'm using, for the first style, an abbreviate form used frequently; and for the longer styles, an explanatory construction.