### PR TITLE
Finnish translations for units

### DIFF
--- a/Rules/Languages/fi/definitions.yaml
+++ b/Rules/Languages/fi/definitions.yaml
@@ -7,170 +7,198 @@
 
 
 - SIPrefixes: {
-    "Q": "quetta", "R": "ronna", "Y": "yotta", "Z": "zetta", "E": "exa", "P": "peta", "T": "tera", "G": "giga", "M": "mega", "k": "kilo", "h": "hecto", "da": "deka",
-    "d": "deci", "c": "centi", "m": "milli", "µ": "micro", "n": "nano", "p": "pico", "f": "femto", "a": "atto", "z": "zepto", "y": "yocto", "r": "ronto", "q": "quecto"
+    "Q": "kvetta", "R": "ronna", "Y": "jotta", "Z": "tsetta", "E": "eksa", "P": "peta", "T": "tera", "G": "giga", "M": "mega", "k": "kilo", "h": "hekto", "da": "deka",
+    "d": "desi", "c": "sentti", "m": "milli", "µ": "mikro", "n": "nano", "p": "piko", "f": "femto", "a": "atto", "z": "zepto", "y": "jokto", "r": "ronto", "q": "kvekto"
   }
 
 # this is a list of all units that accept SIPrefixes
 # from www.bipm.org/documents/20126/41483022/SI-Brochure-9-EN.pdf
 #   Prefixes may be used with any of the 29 SI units with special names
 #   The SI prefixes can be used with several of accepted units, but not, for example, with the non-SI units of time.
+
+# FI: For Finnish the default plural form is for the units to have the ending "a". PluralForms has all the other exceptions.
 - SIUnits: {
     # base units
-    "A": "amp",
-    "cd": "candela",
-    "K": "kelvin", "K": "kelvin", # U+212A
-    "g": "gram",
-    "m": "metre",     # British spelling works for US also
-    "mol": "mole",
-    "s": "second", "″": "second", "\"": "second", "sec": "second",  # "sec" not actually legal
+    # FI: plurals in comments
+    "A": "ampeeri", # ampeeria
+    "cd": "kandela", # kandelaa
+    "K": "kelvin", "K": "kelvin", # U+212A # kelviniä
+    "g": "gramma", # grammaa
+    "m": "metri",     # metriä
+    "mol": "mooli",  # moolia
+    "s": "sekunti", "″": "sekunti", "\"": "sekunti", "sec": "sekunti",  # sekuntia
 
     # derived units
-    "Bq": "becquerel",
-    "C": "coulomb",
-    "°C": "degree celsius", "℃": "degree celsius",
-    "F": "farad",
-    "Gy": "gray",
-    "H": "henry",
-    "Hz": "hertz",
-    "J": "joule",
-    "kat": "kattel",
-    "lm": "lumen",
-    "lx": "lux",
-    "N": "newton",
-    "Ω": "ohm", "Ω": "ohm",       # Greek Cap letter, U+2126 OHM SIGN
-    "Pa": "pascal",
-    "rad": "radian",
-    "S": "siemens",
-    "Sv": "sievert",
-    "sr": "sterradion",
-    "T": "tesla",
-    "V": "volt",
-    "W": "watt",
-    "Wb": "weber",
+    "Bq": "bekrel", # bekreliä
+    "C": "kolumbi", # kolumbia
+    "°C": "aste celsiusta", "℃": "aste celsiusta", # astetta celsiusta
+    "F": "faradi", # faradia
+    "Gy": "grei", # greitä
+    "H": "henry", # henryä
+    "Hz": "hertsi", # hertsiä
+    "J": "joule", # joulea
+    "kat": "kattel", # kattelia
+    "lm": "lumen", # lumenia
+    "lx": "luks", # luksia
+    "N": "newton", # newtonia
+    "Ω": "ohm", "Ω": "ohm",       # Greek Cap letter, U+2126 OHM SIGN # ohmia
+    "Pa": "pascal", # pascalia
+    "rad": "radiaani", # radiaania
+    "S": "siemens", # siemensiä
+    "Sv": "sievert", # sievertiä
+    "sr": "steradiaani", # steradiaania
+    "T": "tesla", # teslaa
+    "V": "volt", # volttia
+    "W": "watti", # wattia
+    "Wb": "weber", # weberiä"
 
     # accepted (plus a few variants) that take SI prefixes
-    "l": "litre", "L": "litre", "ℓ": "litre",               # British spelling works for US also
-    "t": "metric ton",
-    "Da": "dalton",
-    "amu": "atomic mass unit", "u": "atomic mass unit",     # 'u' is correct: https://en.wikipedia.org/wiki/Dalton_(unit)
-    "au": "astronomical unit", "AU": "astronomical unit",
-    "eV": "electronvolt",
+    "l": "litra", "L": "litra", "ℓ": "litra",               # litraa
+    "t": "tonni", # tonnia
+    "Da": "dalton", # daltonia
+    "amu": "atomimassayksikkö", "u": "atomimassayksikkö",     # atomimassayksikköä
+    "au": "astroniminen yksikkö", "AU": "astronominen yksikkö", # astronomista yksikköä
+    "eV": "elektronivoltti", # elektronivolttia
   }
 
 
 - UnitsWithoutPrefixes: {
     # time
-    "′": "minute", "'": "minute","min": "minute",
-    "h": "hour", "hr": "hour", "Hr": "hour",
-    "d": "day", "dy": "day",
-    "w": "week", "wk": "week",
-    "y": "year", "yr": "year",    
+    "′": "minuutti", "'": "minuutti","min": "minuutti", # minuuttia
+    "h": "tunti", "hr": "tunti", "Hr": "tunti", # tuntia
+    "d": "vuorokausi", "dy": "vuorokausi", # vuorokautta
+    "w": "viikko", "wk": "viikko", # viikkoa
+    "y": "vuosi", "yr": "vuosi", # vuotta    
 
     # angles (could be temperature)
-    "°": "degree", "deg": "degree",
-    "arcmin": "arcminute",
-    "amin": "arcminute",
-    "am": "arcminute",
-    "MOA": "arcminute",
-    "arcsec": "arcsecond",
-    "asec": "arcsecond",
-    "as": "arcsecond",
+    "°": "aste", "deg": "aste", # astetta
+    "arcmin": "kaariminuutti", #kaariminuuttia
+    "amin": "kaariminuutti", # kaariminuuttia
+    "am": "kaariminuutti", # kaariminuuttia
+    "MOA": "kaariminuutti", # kaariminuuttia
+    "arcsec": "kaarisekuntia", # kaarisekuntia
+    "asec": "kaarisekuntia", # kaarisekuntia
+    "as": "kaarisekuntia", # kaarisekuntia
 
     # other accepted units that don't take SI prefixes
-    "ha": "hectare",
-    "Np": "neper",
-    "B": "bel",
-    "dB": "decibel",
+    "ha": "hehtaari", # hehtaaria
+    "Np": "neper", # neperiä
+    "B": "beli", # beliä
+    "dB": "desibeli", # desibeliä
 
     # distance
-    "ltyr": "light year", "ly": "light year",
-    "pc": "parsec",
-    "Å": "angstrom", "Å": "angstrom",           # U+00C5 and U+212B
-    "fm": "fermi",
+    "ltyr": "valovuosi", "ly": "valovuosi", # valovuotta
+    "pc": "parsek", # parsekia
+    "Å": "ångström", "Å": "ångström",  # ångströmiä # U+00C5 and U+212B
+    "fm": "fermi", # fermiä
 
     # others
-    "atm": "atmosphere",
-    "bar": "bar",
-    "cal": "calorie",
-    "Ci": "curie",
-    "grad": "gradian",
-    "M": "molar",
-    "R": "roentgen",
-    "rpm": "revolution per minute",
-    "℧": "mho",
-    "dyn": "dyne",
-    "erg": "erg",
+    "atm": "normaali-ilmakehä", # normaali-ilmakehää
+    "bar": "baari", # baaria
+    "cal": "kalori", # kaloria
+    "Ci": "curie", # curieta
+    "grad": "gooni", # goonia # FI: other possible names are graadi or uusaste
+    "R": "röntgen", # röntgeniä
+    "rpm": "kierros minuutissa", # kierrosta minuutissa
+    "℧": "mho", # mhota
+    "dyn": "dyne", # dyneä
+    "erg": "ergi", # ergiä
 
   }
 
   # this will only be used if the language is English, so it can be empty for other countries
 - EnglishUnits: {
     # length
-    "in": "inch",
-    "ft": "foot",
-    "mi": "mile",
-    "rd": "rod",
-    "li": "link",
-    "ch": "chain",
+    "in": "tuuma", # tuumaa
+    "ft": "jalka", # jalkaa
+    "mi": "maili", # mailia
 
     # area
-    "sq in": "square inch", "sq. in": "square inch", "sq. in.": "square inch",
-    "sq ft": "square foot", "sq. ft": "square foot", "sq. ft.": "square foot",
-    "sq yd": "square yard", "sq. yd": "square yard", "sq. yd.": "square yard",
-    "sq mi": "square mile", "sq. mi": "square mile", "sq. mi.": "square mile",
-    "ac": "acre",
-    "FBM": "board foot",
+    "sq in": "neliötuuma", "sq. in": "neliötuuma", "sq. in.": "neliötuuma", # neliötuumaa
+    "sq ft": "neliöjalka", "sq. ft": "neliöjalka", "sq. ft.": "neliöjalka", # neliöjalkaa
+    "sq yd": "neliöjaardi", "sq. yd": "neliöjaardi", "sq. yd.": "neliöjaardi", # neliöjaardia
+    "sq mi": "neliömaili", "sq. mi": "neliömaili", "sq. mi.": "neliömaili", # neliömailia
+    "ac": "eekkeri", # eekkeriä
+    "FBM": "lautajalka", # lautajalkaa
 
     # volume
-    "cu in": "cubic inch", "cu. in": "cubic inch", "cu. in.": "cubic inch",
-    "cu ft": "cubic foot", "cu. ft": "cubic foot", "cu. ft.": "cubic foot",
-    "cu yd": "cubic yard", "cu. yd": "cubic yard", "cu. yd.": "cubic yard",
-    "bbl": "barrel", "BBL": "barrel",
-    "pk": "peck",
-    "bu": "bushel",
-    "tsp": "teaspoon",
-    "tbl": "tablespoon",
+    "cu in": "kuutiotuuma", "cu. in": "kuutiotuuma", "cu. in.": "kuutiotuuma", # kuutiotuumaa
+    "cu ft": "kuutiojalka", "cu. ft": "kuutiojalka", "cu. ft.": "kuutiojalka", # kuutiojalkaa
+    "cu yd": "kuutiojaardi", "cu. yd": "kuutiojaardi", "cu. yd.": "kuutiojaardi", # kuutiojaardia
+    "bbl": "barreli", "BBL": "barreli", # barrelia
+    "tsp": "teelusikka", # teelusikallista 
+    "tbl": "ruokalusikka", # ruokalusikallista
 
     # liquid
-    "fl dr": "fluid drams",
-    "fl oz": "fluid ounce",
-    "gi": "gill",
-    "cp": "cup", "cup": "cup",
-    "pt": "pint",
-    "qt": "quart",
-    "gal": "gallon",
+    "fl dr": "nestedrami", # nestedramia
+    "fl oz": "nesteunssi", # nesteunssia
+    "cp": "kuppi", "kuppi": "kuppi", # kuppia
+    "pt": "tuoppi", # tuoppia
+    "qt": "neljännesgallona", # neljännesgallonaa
+    "gal": "gallona", # gallonaa
 
     # weight
-    "gr": "grain",
-    "dr": "dram",
-    "oz": "ounce", "℥": "ounce",
-    "lb": "pound",
-    "cwt": "hundredweight",
-    "dwt": "pennyweight",
-    "oz t": "troy ounce",
-    "lb t": "troy pound",
+    "oz": "unssi", "℥": "unssi", # unssia
+    "lb": "pauna", # paunaa
 
     # energy
-    "hp": "horsepower",
-    "BTU": "BTU",
-    "°F": "degree fahrenheit", "℉": "degree fahrenheit",
+    "hp": "hevosvoima", # hevosvoimaa
+    "°F": "aste fahrenheitia", "℉": "aste fahrenheitia", # astetta fahrenheitia
 
     # other
-    "mph": "mile per hour",
-    "mpg": "mile per gallon",
+    "mph": "maili tunnissa", # mailia tunnissa
+    "mpg": "maili gallonalla", # mailia gallonalla
   }
 
+# FI: PluralForms has the exceptions to the rule that plural forms end in the letter "a". This is checked for exceptions before the default.
 - PluralForms: {
   # FIX: this needs to be flushed out
-    "inch": "inches", "square inch": "square inches", "cubic inch": "cubic inches",
-    "foot": "feet", "square foot": "square feet", "cubic foot": "cubic feet",
-    "board foot": "board feet",
-    "degree celsius": "degrees celsius",
-    "degree fahrenheit": "degrees fahrenheit",
-    "hertz": "hertz",
-    "siemens": "siemens",
-    "revolution per minute": "revolutions per minute",
+    "aste celsiusta": "astetta celsiusta",
+    "aste fahrenheitia": "astetta fahrenheitia",
+    "hertsi": "hertsiä",
+    "siemens": "siemensiä",
+    "kierros minuutissa": "kierrosta minuutissa",
+    "kelvin": "kelviniä",
+    "metri": "metriä",
+    "bekrel": "bekreliä",
+    "grei": "greitä",
+    "henry": "henryä",
+    "hertsi": "hertsiä",
+    "kattel": "kattelia",
+    "lumen": "lumenia",
+    "luks": "luksia",
+    "newton": "newtonia",
+    "ohm": "ohmia",
+    "pascal": "pascalia",
+    "siemens": "siemensiä",
+    "sievert": "sievertiä",
+    "volt": "volttia",
+    "watti": "wattia",
+    "weber": "weberiä"",
+    "dalton": "daltonia",
+    "atomimassayksikkö": "atomimassayksikköä",
+    "astronominen yksikkö": "astronomista yksikköä",
+    "vuorokausi": "vuorokautta",
+    "vuosi": "vuotta",
+    "aste": "astetta",
+    "neper": "neperiä",
+    "beli": "beliä",
+    "desibeli": "desibeliä",
+    "valovuosi": "valovuotta",
+    "parsek": "parsekia",
+    "ångström": "ångströmiä",
+    "fermi": "fermiä",
+    "normaali-ilmakehä": "normaali-ilmakehää",
+    "röntgen": "röntgeniä",
+    "kierros minuutissa": "kierrosta minuutissa",
+    "mho": "mhota",
+    "dyne": "dyneä",
+    "ergi": "ergiä",
+    "eekkeri": "eekkeriä",
+    "teelusikka": "teelusikallista",
+    "ruokalusikka": "ruokalusikallista",
+    "maili tunnissa": "mailia tunnissa",
+    "maili gallonalla": "mailia gallonalla"
   }
 
 

--- a/Rules/Languages/fi/definitions.yaml
+++ b/Rules/Languages/fi/definitions.yaml
@@ -98,6 +98,7 @@
     "cal": "kalori", # kaloria
     "Ci": "curie", # curieta
     "grad": "gooni", # goonia # FI: other possible names are graadi or uusaste
+    "M": "molaarinen", # FI: Has no plural form!
     "R": "röntgen", # röntgeniä
     "rpm": "kierros minuutissa", # kierrosta minuutissa
     "℧": "mho", # mhota


### PR DESCRIPTION
Default option: the letter "a" is appended to the end of the word. This change needs to be made in another file.

"PluralForm" has all the special cases.

"M" for molar has no plural form in Finnish. "Molaarinen" is used regardless of the number.

Let me know if there is something to change! Or questions.