### PR TITLE
Translations for bits and bytes, and also fixes for typos and such

### DIFF
--- a/Rules/Languages/fi/definitions.yaml
+++ b/Rules/Languages/fi/definitions.yaml
@@ -41,7 +41,7 @@
     "lm": "lumen", # lumenia
     "lx": "luks", # luksia
     "N": "newton", # newtonia
-    "Ω": "ohm", "Ω": "ohm",       # Greek Cap letter, U+2126 OHM SIGN # ohmia
+    "Ω": "ohm", "Ω": "ohm",  # ohmia     # Greek Cap letter, U+2126 OHM SIGN 
     "Pa": "pascal", # pascalia
     "S": "siemens", # siemensiä
     "Sv": "sievert", # sievertiä
@@ -51,11 +51,11 @@
     "Wb": "weber", # weberiä"
 
     # accepted (plus a few variants) that take SI prefixes
-    "l": "litra", "L": "litra", "ℓ": "litra",               # litraa
+    "l": "litra", "L": "litra", "ℓ": "litra", # litraa
     "t": "tonni", # tonnia
     "Da": "dalton", # daltonia
     "Np": "neper", # neperiä
-    "u": "atomimassayksikkö",     # atomimassayksikköä
+    "u": "atomimassayksikkö", # atomimassayksikköä
     "eV": "elektronivoltti", # elektronivolttia
     "rad": "radiaani", # radiaania
     "sr": "steradiaani", # steradiaania

--- a/Rules/Languages/fi/definitions.yaml
+++ b/Rules/Languages/fi/definitions.yaml
@@ -182,7 +182,6 @@
     "aste celsiusta": "astetta celsiusta",
     "aste fahrenheitia": "astetta fahrenheitia",
     "bittiä": "bittiä",
-    "baudi": "baudi",
     "kelvin": "kelviniä",
     "metri": "metriä",
     "bekrel": "bekreliä",

--- a/Rules/Languages/fi/definitions.yaml
+++ b/Rules/Languages/fi/definitions.yaml
@@ -231,7 +231,8 @@
     "eksbibitti": "eksbibittiä", 
     "tsebibitti": "tsebibittiä",
     "jobibitti": "jobibittiä",
-    "annum": "annumia"
+    "annum": "annumia",
+    "curie": "curieta"
   }
 
 

--- a/Rules/Languages/fi/definitions.yaml
+++ b/Rules/Languages/fi/definitions.yaml
@@ -30,7 +30,7 @@
 
     # derived units
     "Bq": "bekrel", # bekreliä
-    "C": "kolumbi", # kolumbia
+    "C": "kulombi", # kulombia
     "°C": "aste celsiusta", "℃": "aste celsiusta", # astetta celsiusta
     "F": "faradi", # faradia
     "Gy": "grei", # greitä

--- a/Rules/Languages/fi/definitions.yaml
+++ b/Rules/Languages/fi/definitions.yaml
@@ -222,7 +222,15 @@
     "teelusikka": "teelusikallista",
     "ruokalusikka": "ruokalusikallista",
     "maili tunnissa": "mailia tunnissa",
-    "maili gallonalla": "mailia gallonalla"
+    "maili gallonalla": "mailia gallonalla",
+    "kibibitti": "kibibittiä"
+    "mebibitti": "mebibittiä", 
+    "gibibitti": "gibibittiä", 
+    "tebibitti": "tebibittiä", 
+    "pebibitti": "pebibittiä", 
+    "eksbibitti": "eksbibittiä", 
+    "tsebibitti": "tsebibittiä",
+    "jobibitti": "jobibittiä"
   }
 
 

--- a/Rules/Languages/fi/definitions.yaml
+++ b/Rules/Languages/fi/definitions.yaml
@@ -62,7 +62,7 @@
   
     # others that take a prefix
     "a": "annum",               # should only take positive powers
-    "as": "kaarisekuntia", # kaarisekuntia
+    "as": "kaarisekunti", # kaarisekuntia
 
     # technically wrong, but used in practice with SI Units
     "b": "bitti",  # bittiä              # should only take positive powers
@@ -85,8 +85,8 @@
     "amin": "kaariminuutti", # kaariminuuttia
     "am": "kaariminuutti", # kaariminuuttia
     "MOA": "kaariminuutti", # kaariminuuttia
-    "arcsec": "kaarisekuntia", # kaarisekuntia
-    "asec": "kaarisekuntia", # kaarisekuntia
+    "arcsec": "kaarisekunti", # kaarisekuntia
+    "asec": "kaarisekunti", # kaarisekuntia
 
     # distance
     "au": "astronominen yksikkö", "AU": "astronominen yksikkö", # astronomista yksikköä

--- a/Rules/Languages/fi/definitions.yaml
+++ b/Rules/Languages/fi/definitions.yaml
@@ -181,7 +181,7 @@
   # FIX: this needs to be flushed out
     "aste celsiusta": "astetta celsiusta",
     "aste fahrenheitia": "astetta fahrenheitia",
-    "bittiä": "bittiä",
+    "bitti": "bittiä",
     "kelvin": "kelviniä",
     "metri": "metriä",
     "bekrel": "bekreliä",

--- a/Rules/Languages/fi/definitions.yaml
+++ b/Rules/Languages/fi/definitions.yaml
@@ -65,9 +65,9 @@
     "as": "kaarisekuntia", # kaarisekuntia
 
     # technically wrong, but used in practice with SI Units
-    "b": "bittiä",               # should only take positive powers
-    "B": "tavu",              # should only take positive powers
-    "Bd": "baudi",             # should only take positive powers
+    "b": "bitti",  # bittiä              # should only take positive powers
+    "B": "tavu",   # tavua           # should only take positive powers
+    "Bd": "baudi", # baudia            # should only take positive powers
   }
 
 
@@ -114,8 +114,22 @@
     "erg": "ergi", # ergiä
 
     # powers of 2 used with bits and bytes
-    "Kib": "kibibittiä", "Mib": "mebibittiä", "Gib": "gibibittiä", "Tib": "tebibittiä", "Pib": "pebibittiä", "Eib": "eksbibittiä", "Zib": "tsebibittiä", "Yib": "jobibittiä",
-    "KiB": "kibitavu", "MiB": "mebitavu", "GiB": "gibitavu", "TiB": "tebitavu", "PiB": "pebitavu", "EiB": "eksbitavu", "ZiB": "tsebitavu", "YiB": "jobitavu",
+    "Kib": "kibibitti", # kibibittiä
+    "Mib": "mebibitti", # mebibittiä
+    "Gib": "gibibitti", # gibibittiä
+    "Tib": "tebibitti", # tebibittiä
+    "Pib": "pebibitti", # pebibittiä
+    "Eib": "eksbibitti", # eksbibittiä
+    "Zib": "tsebibitti", # tsebibittiä
+    "Yib": "jobibitti", # jobibittiä
+    "KiB": "kibitavu", # kibitavua
+    "MiB": "mebitavu", # mebitavua
+    "GiB": "gibitavu", # gibitavua
+    "TiB": "tebitavu", # tebitavua
+    "PiB": "pebitavu", # eksbitavua
+    "EiB": "eksbitavu", # eksbitavua
+    "ZiB": "tsebitavu", # tsebitavua
+    "YiB": "jobitavu", # jobitavua
   }
 
   # this will only be used if the language is English, so it can be empty for other countries

--- a/Rules/Languages/fi/definitions.yaml
+++ b/Rules/Languages/fi/definitions.yaml
@@ -7,7 +7,7 @@
 
 
 - SIPrefixes: {
-    "Q": "kvetta", "R": "ronna", "Y": "jotta", "Z": "tsetta", "E": "eksa", "P": "peta", "T": "tera", "G": "giga", "M": "mega", "k": "kilo", "h": "hekto", "da": "deka",
+    "Q": "kvetta", "R": "ronna", "Y": "jotta", "Z": "tsetta", "E": "eksa", "P": "peta", "T": "tera", "G": "giga", "M": "mega", "k": "kilo", "h": "hehto", "da": "deka",
     "d": "desi", "c": "sentti", "m": "milli", "µ": "mikro", "n": "nano", "p": "piko", "f": "femto", "a": "atto", "z": "zepto", "y": "jokto", "r": "ronto", "q": "kvekto"
   }
 

--- a/Rules/Languages/fi/definitions.yaml
+++ b/Rules/Languages/fi/definitions.yaml
@@ -7,170 +7,198 @@
 
 
 - SIPrefixes: {
-    "Q": "quetta", "R": "ronna", "Y": "yotta", "Z": "zetta", "E": "exa", "P": "peta", "T": "tera", "G": "giga", "M": "mega", "k": "kilo", "h": "hecto", "da": "deka",
-    "d": "deci", "c": "centi", "m": "milli", "µ": "micro", "n": "nano", "p": "pico", "f": "femto", "a": "atto", "z": "zepto", "y": "yocto", "r": "ronto", "q": "quecto"
+    "Q": "kvetta", "R": "ronna", "Y": "jotta", "Z": "tsetta", "E": "eksa", "P": "peta", "T": "tera", "G": "giga", "M": "mega", "k": "kilo", "h": "hekto", "da": "deka",
+    "d": "desi", "c": "sentti", "m": "milli", "µ": "mikro", "n": "nano", "p": "piko", "f": "femto", "a": "atto", "z": "zepto", "y": "jokto", "r": "ronto", "q": "kvekto"
   }
 
 # this is a list of all units that accept SIPrefixes
 # from www.bipm.org/documents/20126/41483022/SI-Brochure-9-EN.pdf
 #   Prefixes may be used with any of the 29 SI units with special names
 #   The SI prefixes can be used with several of accepted units, but not, for example, with the non-SI units of time.
+
+# FI: For Finnish the default plural form is for the units to have the ending "a". PluralForms has all the other exceptions.
 - SIUnits: {
     # base units
-    "A": "amp",
-    "cd": "candela",
-    "K": "kelvin", "K": "kelvin", # U+212A
-    "g": "gram",
-    "m": "metre",     # British spelling works for US also
-    "mol": "mole",
-    "s": "second", "″": "second", "\"": "second", "sec": "second",  # "sec" not actually legal
+    # FI: plurals in comments
+    "A": "ampeeri", # ampeeria
+    "cd": "kandela", # kandelaa
+    "K": "kelvin", "K": "kelvin", # U+212A # kelviniä
+    "g": "gramma", # grammaa
+    "m": "metri",     # metriä
+    "mol": "mooli",  # moolia
+    "s": "sekunti", "″": "sekunti", "\"": "sekunti", "sec": "sekunti",  # sekuntia
 
     # derived units
-    "Bq": "becquerel",
-    "C": "coulomb",
-    "°C": "degree celsius", "℃": "degree celsius",
-    "F": "farad",
-    "Gy": "gray",
-    "H": "henry",
-    "Hz": "hertz",
-    "J": "joule",
-    "kat": "kattel",
-    "lm": "lumen",
-    "lx": "lux",
-    "N": "newton",
-    "Ω": "ohm", "Ω": "ohm",       # Greek Cap letter, U+2126 OHM SIGN
-    "Pa": "pascal",
-    "rad": "radian",
-    "S": "siemens",
-    "Sv": "sievert",
-    "sr": "sterradion",
-    "T": "tesla",
-    "V": "volt",
-    "W": "watt",
-    "Wb": "weber",
+    "Bq": "bekrel", # bekreliä
+    "C": "kolumbi", # kolumbia
+    "°C": "aste celsiusta", "℃": "aste celsiusta", # astetta celsiusta
+    "F": "faradi", # faradia
+    "Gy": "grei", # greitä
+    "H": "henry", # henryä
+    "Hz": "hertsi", # hertsiä
+    "J": "joule", # joulea
+    "kat": "kattel", # kattelia
+    "lm": "lumen", # lumenia
+    "lx": "luks", # luksia
+    "N": "newton", # newtonia
+    "Ω": "ohm", "Ω": "ohm",       # Greek Cap letter, U+2126 OHM SIGN # ohmia
+    "Pa": "pascal", # pascalia
+    "rad": "radiaani", # radiaania
+    "S": "siemens", # siemensiä
+    "Sv": "sievert", # sievertiä
+    "sr": "steradiaani", # steradiaania
+    "T": "tesla", # teslaa
+    "V": "volt", # volttia
+    "W": "watti", # wattia
+    "Wb": "weber", # weberiä"
 
     # accepted (plus a few variants) that take SI prefixes
-    "l": "litre", "L": "litre", "ℓ": "litre",               # British spelling works for US also
-    "t": "metric ton",
-    "Da": "dalton",
-    "amu": "atomic mass unit", "u": "atomic mass unit",     # 'u' is correct: https://en.wikipedia.org/wiki/Dalton_(unit)
-    "au": "astronomical unit", "AU": "astronomical unit",
-    "eV": "electronvolt",
+    "l": "litra", "L": "litra", "ℓ": "litra",               # litraa
+    "t": "tonni", # tonnia
+    "Da": "dalton", # daltonia
+    "amu": "atomimassayksikkö", "u": "atomimassayksikkö",     # atomimassayksikköä
+    "au": "astroniminen yksikkö", "AU": "astronominen yksikkö", # astronomista yksikköä
+    "eV": "elektronivoltti", # elektronivolttia
   }
 
 
 - UnitsWithoutPrefixes: {
     # time
-    "′": "minute", "'": "minute","min": "minute",
-    "h": "hour", "hr": "hour", "Hr": "hour",
-    "d": "day", "dy": "day",
-    "w": "week", "wk": "week",
-    "y": "year", "yr": "year",    
+    "′": "minuutti", "'": "minuutti","min": "minuutti", # minuuttia
+    "h": "tunti", "hr": "tunti", "Hr": "tunti", # tuntia
+    "d": "vuorokausi", "dy": "vuorokausi", # vuorokautta
+    "w": "viikko", "wk": "viikko", # viikkoa
+    "y": "vuosi", "yr": "vuosi", # vuotta    
 
     # angles (could be temperature)
-    "°": "degree", "deg": "degree",
-    "arcmin": "arcminute",
-    "amin": "arcminute",
-    "am": "arcminute",
-    "MOA": "arcminute",
-    "arcsec": "arcsecond",
-    "asec": "arcsecond",
-    "as": "arcsecond",
+    "°": "aste", "deg": "aste", # astetta
+    "arcmin": "kaariminuutti", #kaariminuuttia
+    "amin": "kaariminuutti", # kaariminuuttia
+    "am": "kaariminuutti", # kaariminuuttia
+    "MOA": "kaariminuutti", # kaariminuuttia
+    "arcsec": "kaarisekuntia", # kaarisekuntia
+    "asec": "kaarisekuntia", # kaarisekuntia
+    "as": "kaarisekuntia", # kaarisekuntia
 
     # other accepted units that don't take SI prefixes
-    "ha": "hectare",
-    "Np": "neper",
-    "B": "bel",
-    "dB": "decibel",
+    "ha": "hehtaari", # hehtaaria
+    "Np": "neper", # neperiä
+    "B": "beli", # beliä
+    "dB": "desibeli", # desibeliä
 
     # distance
-    "ltyr": "light year", "ly": "light year",
-    "pc": "parsec",
-    "Å": "angstrom", "Å": "angstrom",           # U+00C5 and U+212B
-    "fm": "fermi",
+    "ltyr": "valovuosi", "ly": "valovuosi", # valovuotta
+    "pc": "parsek", # parsekia
+    "Å": "ångström", "Å": "ångström",  # ångströmiä # U+00C5 and U+212B
+    "fm": "fermi", # fermiä
 
     # others
-    "atm": "atmosphere",
-    "bar": "bar",
-    "cal": "calorie",
-    "Ci": "curie",
-    "grad": "gradian",
-    "M": "molar",
-    "R": "roentgen",
-    "rpm": "revolution per minute",
-    "℧": "mho",
-    "dyn": "dyne",
-    "erg": "erg",
+    "atm": "normaali-ilmakehä", # normaali-ilmakehää
+    "bar": "baari", # baaria
+    "cal": "kalori", # kaloria
+    "Ci": "curie", # curieta
+    "grad": "gooni", # goonia # FI: other possible names are graadi or uusaste
+    "R": "röntgen", # röntgeniä
+    "rpm": "kierros minuutissa", # kierrosta minuutissa
+    "℧": "mho", # mhota
+    "dyn": "dyne", # dyneä
+    "erg": "ergi", # ergiä
 
   }
 
   # this will only be used if the language is English, so it can be empty for other countries
 - EnglishUnits: {
     # length
-    "in": "inch",
-    "ft": "foot",
-    "mi": "mile",
-    "rd": "rod",
-    "li": "link",
-    "ch": "chain",
+    "in": "tuuma", # tuumaa
+    "ft": "jalka", # jalkaa
+    "mi": "maili", # mailia
 
     # area
-    "sq in": "square inch", "sq. in": "square inch", "sq. in.": "square inch",
-    "sq ft": "square foot", "sq. ft": "square foot", "sq. ft.": "square foot",
-    "sq yd": "square yard", "sq. yd": "square yard", "sq. yd.": "square yard",
-    "sq mi": "square mile", "sq. mi": "square mile", "sq. mi.": "square mile",
-    "ac": "acre",
-    "FBM": "board foot",
+    "sq in": "neliötuuma", "sq. in": "neliötuuma", "sq. in.": "neliötuuma", # neliötuumaa
+    "sq ft": "neliöjalka", "sq. ft": "neliöjalka", "sq. ft.": "neliöjalka", # neliöjalkaa
+    "sq yd": "neliöjaardi", "sq. yd": "neliöjaardi", "sq. yd.": "neliöjaardi", # neliöjaardia
+    "sq mi": "neliömaili", "sq. mi": "neliömaili", "sq. mi.": "neliömaili", # neliömailia
+    "ac": "eekkeri", # eekkeriä
+    "FBM": "lautajalka", # lautajalkaa
 
     # volume
-    "cu in": "cubic inch", "cu. in": "cubic inch", "cu. in.": "cubic inch",
-    "cu ft": "cubic foot", "cu. ft": "cubic foot", "cu. ft.": "cubic foot",
-    "cu yd": "cubic yard", "cu. yd": "cubic yard", "cu. yd.": "cubic yard",
-    "bbl": "barrel", "BBL": "barrel",
-    "pk": "peck",
-    "bu": "bushel",
-    "tsp": "teaspoon",
-    "tbl": "tablespoon",
+    "cu in": "kuutiotuuma", "cu. in": "kuutiotuuma", "cu. in.": "kuutiotuuma", # kuutiotuumaa
+    "cu ft": "kuutiojalka", "cu. ft": "kuutiojalka", "cu. ft.": "kuutiojalka", # kuutiojalkaa
+    "cu yd": "kuutiojaardi", "cu. yd": "kuutiojaardi", "cu. yd.": "kuutiojaardi", # kuutiojaardia
+    "bbl": "barreli", "BBL": "barreli", # barrelia
+    "tsp": "teelusikka", # teelusikallista 
+    "tbl": "ruokalusikka", # ruokalusikallista
 
     # liquid
-    "fl dr": "fluid drams",
-    "fl oz": "fluid ounce",
-    "gi": "gill",
-    "cp": "cup", "cup": "cup",
-    "pt": "pint",
-    "qt": "quart",
-    "gal": "gallon",
+    "fl dr": "nestedrami", # nestedramia
+    "fl oz": "nesteunssi", # nesteunssia
+    "cp": "kuppi", "kuppi": "kuppi", # kuppia
+    "pt": "tuoppi", # tuoppia
+    "qt": "neljännesgallona", # neljännesgallonaa
+    "gal": "gallona", # gallonaa
 
     # weight
-    "gr": "grain",
-    "dr": "dram",
-    "oz": "ounce", "℥": "ounce",
-    "lb": "pound",
-    "cwt": "hundredweight",
-    "dwt": "pennyweight",
-    "oz t": "troy ounce",
-    "lb t": "troy pound",
+    "oz": "unssi", "℥": "unssi", # unssia
+    "lb": "pauna", # paunaa
 
     # energy
-    "hp": "horsepower",
-    "BTU": "BTU",
-    "°F": "degree fahrenheit", "℉": "degree fahrenheit",
+    "hp": "hevosvoima", # hevosvoimaa
+    "°F": "aste fahrenheitia", "℉": "aste fahrenheitia", # astetta fahrenheitia
 
     # other
-    "mph": "mile per hour",
-    "mpg": "mile per gallon",
+    "mph": "maili tunnissa", # mailia tunnissa
+    "mpg": "maili gallonalla", # mailia gallonalla
   }
 
+# FI: PluralForms has the exceptions to the rule that plural forms end in the letter "a". This is checked for exceptions before the default.
 - PluralForms: {
   # FIX: this needs to be flushed out
-    "inch": "inches", "square inch": "square inches", "cubic inch": "cubic inches",
-    "foot": "feet", "square foot": "square feet", "cubic foot": "cubic feet",
-    "board foot": "board feet",
-    "degree celsius": "degrees celsius",
-    "degree fahrenheit": "degrees fahrenheit",
-    "hertz": "hertz",
-    "siemens": "siemens",
-    "revolution per minute": "revolutions per minute",
+    "aste celsiusta": "astetta celsiusta",
+    "aste fahrenheitia": "astetta fahrenheitia",
+    "hertsi": "hertsiä",
+    "siemens": "siemensiä",
+    "kierros minuutissa": "kierrosta minuutissa",
+    "kelvin": "kelviniä",
+    "metri": "metriä",
+    "bekrel": "bekreliä",
+    "grei": "greitä",
+    "henry": "henryä",
+    "hertsi": "hertsiä",
+    "kattel": "kattelia",
+    "lumen": "lumenia",
+    "luks": "luksia",
+    "newton": "newtonia",
+    "ohm": "ohmia",
+    "pascal": "pascalia",
+    "siemens": "siemensiä",
+    "sievert": "sievertiä",
+    "volt": "volttia",
+    "watti": "wattia",
+    "weber": "weberiä"",
+    "dalton": "daltonia",
+    "atomimassayksikkö": "atomimassayksikköä",
+    "astronominen yksikkö": "astronomista yksikköä",
+    "vuorokausi": "vuorokautta",
+    "vuosi": "vuotta",
+    "aste": "astetta",
+    "neper": "neperiä",
+    "beli": "beliä",
+    "desibeli": "desibeliä",
+    "valovuosi": "valovuotta",
+    "parsek": "parsekia",
+    "ångström": "ångströmiä",
+    "fermi": "fermiä",
+    "normaali-ilmakehä": "normaali-ilmakehää",
+    "röntgen": "röntgeniä",
+    "kierros minuutissa": "kierrosta minuutissa",
+    "mho": "mhota",
+    "dyne": "dyneä",
+    "ergi": "ergiä",
+    "eekkeri": "eekkeriä",
+    "teelusikka": "teelusikallista",
+    "ruokalusikka": "ruokalusikallista",
+    "maili tunnissa": "mailia tunnissa",
+    "maili gallonalla": "mailia gallonalla"
   }
 
 

--- a/Rules/Languages/fi/definitions.yaml
+++ b/Rules/Languages/fi/definitions.yaml
@@ -98,6 +98,7 @@
     "cal": "kalori", # kaloria
     "Ci": "curie", # curieta
     "grad": "gooni", # goonia # FI: other possible names are graadi or uusaste
+    "M": "molaarinen", # FI: Has no plural form!
     "R": "röntgen", # röntgeniä
     "rpm": "kierros minuutissa", # kierrosta minuutissa
     "℧": "mho", # mhota

--- a/Rules/Languages/fi/definitions.yaml
+++ b/Rules/Languages/fi/definitions.yaml
@@ -114,8 +114,8 @@
     "erg": "ergi", # ergiä
 
     # powers of 2 used with bits and bytes
-    "Kib": "kibi-bittiä", "Mib": "mebi-bittiä", "Gib": "gibi-bittiä", "Tib": "tebi-bittiä", "Pib": "pebi-bittiä", "Eib": "exbi-bittiä", "Zib": "zebi-bittiä", "Yib": "yobi-bittiä",
-    "KiB": "kibi-tavu", "MiB": "mebi-tavu", "GiB": "gibi-tavu", "TiB": "tebi-tavu", "PiB": "pebi-tavu", "EiB": "exbi-tavu", "ZiB": "zebi-tavu", "YiB": "yobi-tavu",
+    "Kib": "kibibittiä", "Mib": "mebibittiä", "Gib": "gibibittiä", "Tib": "tebibittiä", "Pib": "pebibittiä", "Eib": "eksbibittiä", "Zib": "tsebibittiä", "Yib": "jobibittiä",
+    "KiB": "kibitavu", "MiB": "mebitavu", "GiB": "gibitavu", "TiB": "tebitavu", "PiB": "pebitavu", "EiB": "eksbitavu", "ZiB": "tsebitavu", "YiB": "jobitavu",
   }
 
   # this will only be used if the language is English, so it can be empty for other countries

--- a/Rules/Languages/fi/definitions.yaml
+++ b/Rules/Languages/fi/definitions.yaml
@@ -61,7 +61,7 @@
     "sr": "steradiaani", # steradiaania
   
     # others that take a prefix
-    "a": "annum",               # should only take positive powers
+    "a": "annum", # annumia               # should only take positive powers
     "as": "kaarisekunti", # kaarisekuntia
 
     # technically wrong, but used in practice with SI Units
@@ -230,7 +230,8 @@
     "pebibitti": "pebibittiä", 
     "eksbibitti": "eksbibittiä", 
     "tsebibitti": "tsebibittiä",
-    "jobibitti": "jobibittiä"
+    "jobibitti": "jobibittiä",
+    "annum": "annumia"
   }
 
 

--- a/tests/Languages/fi/units.rs
+++ b/tests/Languages/fi/units.rs
@@ -271,7 +271,7 @@ fn si_accepted() {
                 1 kaarisekuntia, pilkku; 2 kaarisekuntia, pilkku, \
                 1 bittiä, pilkku, 2 bittiä, pilkku, \
                 1 tavu, pilkku, 2 tavua, pilkku, \
-                1 baudi, pilkku, 2 baudi");
+                1 baudi, pilkku, 2 baudia");
 }
 
 #[test]

--- a/tests/Languages/fi/units.rs
+++ b/tests/Languages/fi/units.rs
@@ -49,7 +49,7 @@ fn prefix_sweep() {
                 giga-grammaa, pilkku, \
                 mega-grammaa, pilkku, \
                 kilo-grammaa, pilkku, \
-                hekto-grammaa, pilkku, \
+                hehto-grammaa, pilkku, \
                 deka-grammaa, pilkku, \
                 desi-grammaa, pilkku; \
                 sentti-grammaa, pilkku, \
@@ -113,7 +113,7 @@ fn si_base_with_prefixes() {
                 1 eksa-kelvin, pilkku; 2 peta-kelviniä, pilkku; \
                 1 tera-kelvin, pilkku; 2 giga-kelviniä, pilkku; \
                 1 mega-gramma, pilkku; 2 kilo-grammaa, pilkku; \
-                1 hekto-metri, pilkku; 2 deka-metriä, pilkku; \
+                1 hehto-metri, pilkku; 2 deka-metriä, pilkku; \
                 1 desi-mooli, pilkku; 2 sentti-moolia, pilkku; \
                 1 milli-sekunti, pilkku; 2 mikro-sekuntia, pilkku; \
                 1 nano-sekunti, pilkku; 2 piko-sekuntia");
@@ -230,7 +230,7 @@ fn si_derived_2_with_prefixes() {
                 1 piko-pascal, pilkku; 2 nano-pascalia, pilkku; \
                 1 mikro-siemens, pilkku; 2 milli-siemensiä, pilkku; \
                 1 sentti-sievert, pilkku; 2 desi-sievertiä, pilkku; \
-                1 deka-tesla, pilkku; 2 hekto-teslaa, pilkku; \
+                1 deka-tesla, pilkku; 2 hehto-teslaa, pilkku; \
                 1 kilo-volt, pilkku; 2 mega-volttia, pilkku; \
                 1 giga-watti, pilkku; 2 tera-wattia, pilkku; \
                 1 peta-weber, pilkku; 2 eksa-weberiä");
@@ -300,7 +300,7 @@ fn si_accepted_with_prefixes() {
                 1 tera-tonni, pilkku; 2 giga-tonnia, pilkku; \
                 1 mega-dalton, pilkku; 2 kilo-daltonia, pilkku; \
                 1 desi-neper, pilkku; 2 sentti-neperiä, pilkku; \
-                1 hekto-atomimassayksikkö; pilkku; 2 deka-atomimassayksikköä; pilkku; \
+                1 hehto-atomimassayksikkö; pilkku; 2 deka-atomimassayksikköä; pilkku; \
                 1 milli-elektronivoltti; pilkku; 2 mikro-elektronivolttia; pilkku; \
                 1 nano-radiaani, pilkku; 2 piko-radiaania, pilkku; \
                 1 femto-steradiaani, pilkku; 2 atto-steradiaania; pilkku; \

--- a/tests/Languages/fi/units.rs
+++ b/tests/Languages/fi/units.rs
@@ -415,7 +415,7 @@ fn without_prefix_other() {
                 1 kalori, pilkku; 2 kaloria, pilkku, \
                 1 curie, pilkku; 2 curieta, pilkku, \
                 1 gooni, pilkku; 2 goonia, pilkku; \
-                1 molaarinen, pilkku; 2 molaarinena, pilkku, \
+                1 molaarinen, pilkku; 2 molaarinen, pilkku, \
                 1 röntgen, pilkku; 2 röntgeniä, pilkku; \
                 1 kierros minuutissa, pilkku; 2 kierrosta minuutissa, pilkku, \
                 1 mho, pilkku, 2 mhota, pilkku, \

--- a/tests/Languages/fi/units.rs
+++ b/tests/Languages/fi/units.rs
@@ -268,7 +268,7 @@ fn si_accepted() {
                 1 radiaani, pilkku; 2 radiaania, pilkku; \
                 1 steradiaani, pilkku; 2 steradiaania, pilkku, \
                 1 annum, pilkku; 2 annuma, pilkku; \
-                1 kaarisekuntia, pilkku; 2 kaarisekuntiaa, pilkku, \
+                1 kaarisekuntia, pilkku; 2 kaarisekuntia, pilkku, \
                 1 bittiä, pilkku, 2 bittiä, pilkku, \
                 1 tavu, pilkku, 2 tavua, pilkku, \
                 1 baudi, pilkku, 2 baudi");
@@ -305,7 +305,7 @@ fn si_accepted_with_prefixes() {
                 1 nano-radiaani, pilkku; 2 piko-radiaania, pilkku; \
                 1 femto-steradiaani, pilkku; 2 atto-steradiaania; pilkku; \
                 1 giga-annum, pilkku; 2 mega-annuma, pilkku; \
-                1 zepto-kaarisekuntia; pilkku; 2 jokto-kaarisekuntiaa; pilkku; \
+                1 zepto-kaarisekuntia; pilkku; 2 jokto-kaarisekuntia; pilkku; \
                 1 kilo-bittiä, pilkku; 2 mega-bittiä, pilkku; \
                 1 giga-tavu, pilkku; 2 tera-tavua, pilkku; \
                 1 tera-baudi, pilkku; 2 eksa-baudi");
@@ -365,8 +365,8 @@ fn without_prefix_angles() {
                 1 kaariminuutti, pilkku; 2 kaariminuuttia, pilkku; \
                 1 kaariminuutti, pilkku; 2 kaariminuuttia, pilkku; \
                 1 kaariminuutti, pilkku; 2 kaariminuuttia, pilkku; \
-                1 kaarisekuntia, pilkku; 2 kaarisekuntiaa, pilkku; \
-                1 kaarisekuntia, pilkku; 2 kaarisekuntiaa");
+                1 kaarisekuntia, pilkku; 2 kaarisekuntia, pilkku; \
+                1 kaarisekuntia, pilkku; 2 kaarisekuntia");
 }
 
 #[test]

--- a/tests/Languages/fi/units.rs
+++ b/tests/Languages/fi/units.rs
@@ -269,7 +269,7 @@ fn si_accepted() {
                 1 steradiaani, pilkku; 2 steradiaania, pilkku, \
                 1 annum, pilkku; 2 annumia, pilkku; \
                 1 kaarisekuntia, pilkku; 2 kaarisekuntia, pilkku, \
-                1 bittiä, pilkku, 2 bittiä, pilkku, \
+                1 bitti, pilkku, 2 bittiä, pilkku, \
                 1 tavu, pilkku, 2 tavua, pilkku, \
                 1 baudi, pilkku, 2 baudia");
 }
@@ -444,22 +444,22 @@ fn without_prefix_powers_of_2() {
         <mn>1</mn><mi intent=":unit">YiB</mi><mo>,</mo><mn>2</mn><mi intent=":unit">YiB</mi>
     </math>"#;
     test("fi", "SimpleSpeak", expr, 
-        "1 kibi-bittiä, pilkku; 2 kibi-bittiäa, pilkku; \
-                1 mebi-bittiä, pilkku; 2 mebi-bittiäa, pilkku; \
-                1 gibi-bittiä, pilkku; 2 gibi-bittiäa, pilkku; \
-                1 tebi-bittiä, pilkku; 2 tebi-bittiäa, pilkku; \
-                1 pebi-bittiä, pilkku; 2 pebi-bittiäa, pilkku; \
-                1 exbi-bittiä, pilkku; 2 exbi-bittiäa, pilkku; \
-                1 zebi-bittiä, pilkku; 2 zebi-bittiäa, pilkku; \
-                1 yobi-bittiä, pilkku; 2 yobi-bittiäa, pilkku, \
+        "1 kibi-bitti, pilkku; 2 kibi-bittiä, pilkku; \
+                1 mebi-bitti, pilkku; 2 mebi-bittiä, pilkku; \
+                1 gibi-bitti, pilkku; 2 gibi-bittiä, pilkku; \
+                1 tebi-bitti, pilkku; 2 tebi-bittiä, pilkku; \
+                1 pebi-bitti, pilkku; 2 pebi-bittiä, pilkku; \
+                1 eksbi-bitti, pilkku; 2 eksbi-bittiä, pilkku; \
+                1 tsebi-bitti, pilkku; 2 tsebi-bittiä, pilkku; \
+                1 jobi-bitti, pilkku; 2 jobi-bittiä, pilkku, \
                 1 kibi-tavu, pilkku; 2 kibi-tavua, pilkku, \
                 1 mebi-tavu, pilkku; 2 mebi-tavua, pilkku, \
                 1 gibi-tavu, pilkku; 2 gibi-tavua, pilkku, \
                 1 tebi-tavu, pilkku; 2 tebi-tavua, pilkku, \
                 1 pebi-tavu, pilkku; 2 pebi-tavua, pilkku, \
-                1 exbi-tavu, pilkku; 2 exbi-tavua, pilkku, \
-                1 zebi-tavu, pilkku; 2 zebi-tavua, pilkku, \
-                1 yobi-tavu, pilkku; 2 yobi-tavua");
+                1 eksbi-tavu, pilkku; 2 eksbi-tavua, pilkku, \
+                1 tsebi-tavu, pilkku; 2 tsebi-tavua, pilkku, \
+                1 jobi-tavu, pilkku; 2 jobi-tavua");
 }
 
 

--- a/tests/Languages/fi/units.rs
+++ b/tests/Languages/fi/units.rs
@@ -267,7 +267,7 @@ fn si_accepted() {
                 1 elektronivoltti, pilkku; 2 elektronivolttia, pilkku, \
                 1 radiaani, pilkku; 2 radiaania, pilkku; \
                 1 steradiaani, pilkku; 2 steradiaania, pilkku, \
-                1 annum, pilkku; 2 annuma, pilkku; \
+                1 annum, pilkku; 2 annumia, pilkku; \
                 1 kaarisekuntia, pilkku; 2 kaarisekuntia, pilkku, \
                 1 bittiä, pilkku, 2 bittiä, pilkku, \
                 1 tavu, pilkku, 2 tavua, pilkku, \
@@ -304,7 +304,7 @@ fn si_accepted_with_prefixes() {
                 1 milli-elektronivoltti; pilkku; 2 mikro-elektronivolttia; pilkku; \
                 1 nano-radiaani, pilkku; 2 piko-radiaania, pilkku; \
                 1 femto-steradiaani, pilkku; 2 atto-steradiaania; pilkku; \
-                1 giga-annum, pilkku; 2 mega-annuma, pilkku; \
+                1 giga-annum, pilkku; 2 mega-annumia, pilkku; \
                 1 zepto-kaarisekuntia; pilkku; 2 jokto-kaarisekuntia; pilkku; \
                 1 kilo-bittiä, pilkku; 2 mega-bittiä, pilkku; \
                 1 giga-tavu, pilkku; 2 tera-tavua, pilkku; \

--- a/tests/Languages/fi/units.rs
+++ b/tests/Languages/fi/units.rs
@@ -413,7 +413,7 @@ fn without_prefix_other() {
                 1 atomimassayksikkö, pilkku; 2 atomimassayksikköä, pilkku, \
                 1 baari, pilkku; 2 baaria, pilkku, \
                 1 kalori, pilkku; 2 kaloria, pilkku, \
-                1 curie, pilkku; 2 curiea, pilkku, \
+                1 curie, pilkku; 2 curieta, pilkku, \
                 1 gooni, pilkku; 2 goonia, pilkku; \
                 1 molaarinen, pilkku; 2 molaarinena, pilkku, \
                 1 röntgen, pilkku; 2 röntgeniä, pilkku; \

--- a/tests/Languages/fi/units.rs
+++ b/tests/Languages/fi/units.rs
@@ -138,7 +138,7 @@ fn si_derived_1() {
     </math>"#;
     test("fi", "SimpleSpeak", expr, 
         "1 bekrel, pilkku, 2 bekreliä, pilkku, \
-                1 kolumbi, pilkku; 2 kolumbia, pilkku; \
+                1 kulombi, pilkku; 2 kulombia, pilkku; \
                 1 aste celsiusta, pilkku; 2 astetta celsiusta, pilkku; \
                 1 aste celsiusta, pilkku; 2 astetta celsiusta, pilkku, \
                 1 faradi, pilkku; 2 faradia, pilkku, \
@@ -169,7 +169,7 @@ fn si_derived_1_with_prefixes() {
     </math>"#;
     test("fi", "SimpleSpeak", expr, 
         "1 kvetta-bekrel, pilkku; 2 ronna-bekreliä, pilkku; \
-                1 jotta-kolumbia, pilkku; 2 tsetta-kolumbia; pilkku; \
+                1 jotta-kulombia, pilkku; 2 tsetta-kulombia; pilkku; \
                 1 eksa-faradi, pilkku; 2 peta-faradia, pilkku; \
                 1 tera-grei, pilkku; 2 giga-greitä, pilkku; \
                 1 mega-henry, pilkku; 2 kilo-henryä, pilkku; \

--- a/tests/Languages/fi/units.rs
+++ b/tests/Languages/fi/units.rs
@@ -380,7 +380,7 @@ fn without_prefix_distance() {
         <mn>1</mn><mi intent=":unit">fm</mi><mo>,</mo><mn>2</mn><mi intent=":unit">fm</mi>
     </math>"#;
     test("fi", "SimpleSpeak", expr, 
-        "1 astroniminen yksikkö, pilkku; 2 astroniminen yksikköa, pilkku, \
+        "1 astronominen yksikkö, pilkku; 2 astronominen yksikköa, pilkku, \
                 1 valovuosi, pilkku; 2 valovuotta, pilkku, \
                 1 parsek, pilkku, 2 parsekia, pilkku; \
                 1 ångström, pilkku; 2 ångströmiä, pilkku; \


### PR DESCRIPTION
I translated the bits and bytes, and also the expected output for tests. I also fixed up some typos I found from my earlier translation and also fiexed the test output, so they should pass. At this moment I couldn't run the tests myself.

There is also a unit that doesn't have a plural form:
On the line 109 in definitions.yaml, there is a unit that has no plural form in Finnish (eng. “molar”, fin. “molaarinen”). It is used as is for plurals. This should be reflected in the rules.