### PR TITLE
Use roman-numerals-rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,7 +32,7 @@ dirs = "6.0"
 bitflags = "2.5"
 phf = { version = "0.11", features = ["macros"] }
 rand = "0.8"
-roman = "0.1"
+roman-numerals-rs = "3.1.0"
 radix_fmt = "1.0"
 unicode-script = "0.5"
 log = "0.4"

--- a/src/canonicalize.rs
+++ b/src/canonicalize.rs
@@ -19,6 +19,7 @@ use regex::Regex;
 use std::fmt;
 use crate::chemistry::*;
 use unicode_script::Script;
+use roman_numerals_rs::RomanNumeral;
 
 // FIX: DECIMAL_SEPARATOR should be set by env, or maybe language
 const DECIMAL_SEPARATOR: &str = ".";
@@ -708,9 +709,9 @@ impl CanonicalizeContext {
 		assert!(is_leaf(leaf));
 		set_mathml_name(leaf, "mn");
 		leaf.set_attribute_value("data-roman-numeral", "true");	// mark for easy detection
-		let as_number = match roman::from(&as_text(leaf).to_ascii_uppercase()) {
-			Some(i) => i.to_string(),
-			None => as_text(leaf).to_string(),
+		let as_number = match as_text(leaf).parse::<RomanNumeral>() {
+			Ok(roman) => roman.as_u16().to_string(),
+			Err(_) => as_text(leaf).to_string(),
 		};
 		leaf.set_attribute_value("data-number", &as_number);
 	}


### PR DESCRIPTION
The [``roman``](https://crates.io/crates/roman) crate was last updated in 2017, this PR adopts a no-std / 0BSD crate that is also faster.

A