### PR TITLE
Updated zip version in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,9 +38,9 @@ log = "0.4"
 env_logger = "0.11"
 cfg-if = "1.0"
 [target.'cfg(target_family = "wasm")'.dependencies]
-zip = { version = "2.5", default-features = false, features = ["deflate"] }
+zip = { version = "3.0", default-features = false, features = ["deflate"] }
 [target.'cfg(not(target_family = "wasm"))'.dependencies]
-zip = { version = "2.5", default-features = false, features = ["bzip2"] }
+zip = { version = "3.0", default-features = false, features = ["bzip2"] }
 fastrand = { version = "2.3.0" }
 
 android_logger = {version = "0.15.0", optional = true}
@@ -51,9 +51,9 @@ android_logger = {version = "0.15.0", optional = true}
 bitflags = "2.5"
 error-chain = "0.12.4"
 [target.'cfg(target_family = "wasm")'.build-dependencies]
-zip = { version = "2.5", default-features = false, features = ["deflate"] }
+zip = { version = "3.0", default-features = false, features = ["deflate"] }
 [target.'cfg(not(target_family = "wasm"))'.build-dependencies]
-zip = { version = "2.5", default-features = false, features = ["bzip2"] }
+zip = { version = "3.0", default-features = false, features = ["bzip2"] }
 
 [lib]
 name = "libmathcat"


### PR DESCRIPTION
This pull request updates the version of the `zip` dependency to 3.0. Since versions 2.5 and 2.6 seem to no longer be available on cargo, this was needed to eliminate build errors.