### PR TITLE
Translation crashes in Swedish rules when you have an mtable. 

### DIFF
--- a/Rules/Languages/sv/SharedRules/default.yaml
+++ b/Rules/Languages/sv/SharedRules/default.yaml
@@ -405,7 +405,9 @@
 
 - name: default
   tag: mtable
-  variables: [IsColumnSilent: false()]
+  variables:
+  - IsColumnSilent: "false()"
+  - NumColumns: "count(*[1]/*) - IfThenElse(*/self::m:mlabeledtr, 1, 0)"
   match: "."
   replace:
   - T: "tabell med"      # phrase(the 'table with' 3 rows)


### PR DESCRIPTION
Hi Neil

I work at Textalk, and we have a close relationship with MTM and NB agencies in Sweden and Norway, and do a lot of text processing using MathCAT.

We have recently upgraded to MathCAT 0.7.0, and we got an error on one expression in the Swedish rules. Seems these have not been updated in the latest release.

The issue we get is: unknown variable  "NumColumns". We have copied the solution from the Norwegian rules, where this variable is defined.

Best regards
Daniel