### PR TITLE
Fixing the mi tag issues causing an error.

### DIFF
--- a/Rules/Languages/en/ClearSpeak_Rules.yaml
+++ b/Rules/Languages/en/ClearSpeak_Rules.yaml
@@ -610,7 +610,7 @@
   replace:
   - bookmark: "@id"
   - test:
-      if: "$Verbosity!='Terse' and not(IsNode(following-sibling::*[2],'simple'))"
+      if: "$Verbosity!='Terse' and (not(following-sibling::*[2]) or not(IsNode(following-sibling::*[2],'simple')))"
       then: [t: "the"]      # phrase('the' square root of 25)
   - test:
     - if: ".='log'"

--- a/Rules/Languages/nb/ClearSpeak_Rules.yaml
+++ b/Rules/Languages/nb/ClearSpeak_Rules.yaml
@@ -604,12 +604,12 @@
 - # handle both log and ln
   name: ClearSpeak-log
   tag: mi
-  variables: [log_is_simple: "IsNode(following-sibling::*[2],'simple')"] # skip function apply
+  variables: [log_is_simple: "following-sibling::*[2] and IsNode(following-sibling::*[2],'simple')"] # skip function apply
   match: ".='log' or .='ln' or .='lg'"
   replace:
   - bookmark: "@id"
   - test:
-      if: "IsNode(following-sibling::*[2],'simple')"
+      if: "following-sibling::*[2] and IsNode(following-sibling::*[2],'simple')"
       then:
       - test:
         - if: ".='log'"

--- a/Rules/Languages/sv/ClearSpeak_Rules.yaml
+++ b/Rules/Languages/sv/ClearSpeak_Rules.yaml
@@ -614,7 +614,7 @@
   name: ClearSpeak-log
   tag: mi
   match: ".='log' or .='lg' or .='ln'"
-  variables: [log_is_simple: "IsNode(following-sibling::*[2],'simple')"]
+  variables: [log_is_simple: "following-sibling::*[2] and IsNode(following-sibling::*[2],'simple')"]
   replace:
   - test:
       if: "$log_is_simple"


### PR DESCRIPTION
Currently, when the MathML code below runs, the rules error due to a missing element.

```
<math display="block">
  <mfrac bevelled="true">
    <mrow>
      <mi>log</mi>
    </mrow>
    <mn>2</mn>
  </mfrac>
</math>
```