### PR TITLE
Improve Italian translation

### DIFF
--- a/Rules/Languages/it/ClearSpeak_Rules.yaml
+++ b/Rules/Languages/it/ClearSpeak_Rules.yaml
@@ -10,7 +10,7 @@
   tag: mn
   match: "starts-with(text(), '-')"
   replace:
-  - t: "meno"      # phrase(10 'minus' 4 equals 6)
+  - T: "meno"      # phrase(10 'minus' 4 equals 6)
   - x: "translate(text(), '-_', '')"
 
 - name: default
@@ -19,26 +19,26 @@
   replace:
   - test:
       if: "$Verbosity!='Terse'"
-      then: [t: "la"]      # phrase('the' square root of 25)
+      then: [T: "la"]      # phrase('the' square root of 25)
   - test:
       if: $ClearSpeak_Roots = 'PosNegSqRoot' or $ClearSpeak_Roots = 'PosNegSqRootEnd'
       then:
       - bookmark: "*[1]/@id"
       - test:
           if: parent::*[self::m:negative]
-          then: [t: "negativo"]      # phrase(minus 4 is a 'negative' number)
-          else: [t: "positivo"]      # phrase(10 is a 'positive' number)
-  - t: "radice quadrata"      # phrase(8 is the 'square root' of 64)
+          then: [T: "negativo"]      # phrase(minus 4 is a 'negative' number)
+          else: [T: "positivo"]      # phrase(10 is a 'positive' number)
+  - T: "radice quadrata"      # phrase(8 is the 'square root' of 64)
   - test:
       if: "$Verbosity!='Terse'"
-      then: [t: "di"]      # phrase(the square root 'of' 5)
+      then: [T: "di"]      # phrase(the square root 'of' 5)
       else: [pause: short]
   - x: "*[1]"
   - test:
     - if: "$ClearSpeak_Roots = 'RootEnd' or $ClearSpeak_Roots = 'PosNegSqRootEnd'"
       then:
       - pause: short
-      - t: "end root"      # phrase(the square root of x 'end root')
+      - T: "fine radice"      # phrase(the square root of x 'end root')
       - pause: medium
     - else_if: "IsNode(*[1], 'simple')"
       then: [pause: short]
@@ -50,7 +50,7 @@
   replace:
   - test:
       if: "$Verbosity!='Terse'"
-      then: [t: "la"]      # phrase(6 is 'the' square root of 36)
+      then: [T: "la"]      # phrase(6 is 'the' square root of 36)
   - test:
       if: $ClearSpeak_Roots = 'PosNegSqRoot' or $ClearSpeak_Roots = 'PosNegSqRootEnd'
       then:
@@ -59,17 +59,17 @@
           then: [bookmark: "parent/@id"]
       - test:
           if: parent::m:negative
-          then: [t: "negativo"]      # phrase(minus 6 is a 'negative' number)
-          else: [t: "positivo"]      # phrase(10 is a 'positive' number)
+          then: [T: "negativo"]      # phrase(minus 6 is a 'negative' number)
+          else: [T: "positivo"]      # phrase(10 is a 'positive' number)
   - test:
       if: "*[2][self::m:mn]"
       then_test:
       - if: "*[2][text()='2']"
-        then: [t: "radice quadrata"]      # phrase(5 is the 'square root' of 25)
+        then: [T: "radice quadrata"]      # phrase(5 is the 'square root' of 25)
       - else_if: "*[2][text()='3']"
-        then: [t: "radice del cubo"]      # phrase(5 is the 'cube root' of 625)
+        then: [T: "radice cubica"]      # phrase(5 is the 'cube root' of 625)
       - else_if: "*[2][not(contains(., '.'))]"
-        then: [x: "ToOrdinal(*[2])", t: "radice"]      # phrase(the square 'root' of 25)
+        then: [x: "ToOrdinal(*[2])", T: "radice"]      # phrase(the square 'root' of 25)
       else:
       - test:
           if: "*[2][self::m:mi][string-length(.)=1]"
@@ -77,16 +77,16 @@
           - x: "*[2]"
           - pronounce: [{text: "-th"}, {ipa: "θ"}, {sapi5: "th"}, {eloquence: "T"}]
           else: {x: "*[2]"}
-      - t: "radice"      # phrase(the square 'root' of 36)
+      - T: "radice"      # phrase(the square 'root' of 36)
   - test:
       if: "$Verbosity!='Terse'"
-      then: [t: "di"]      # phrase(the square root 'of' 36)
+      then: [T: "di"]      # phrase(the square root 'of' 36)
   - x: "*[1]"
   - test:
       if: $ClearSpeak_Roots = 'RootEnd' or $ClearSpeak_Roots = 'PosNegSqRootEnd'
       then:
       - pause: short
-      - t: "end root"      # phrase(start the fifth root of x 'end root')
+      - T: "fine radice"      # phrase(start the fifth root of x 'end root')
       - pause: medium
       else_test:
         if: IsNode(*[1], 'simple')
@@ -107,8 +107,8 @@
       - bookmark: "@id"
       - test:
           if: "self::m:negative"
-          then: [t: "negativo"]      # phrase(minus 5 is a 'negative' number)
-          else: [t: "positivo"]      # phrase(7 is a 'positive' number)
+          then: [T: "negativo"]      # phrase(minus 5 is a 'negative' number)
+          else: [T: "positivo"]      # phrase(7 is a 'positive' number)
   - x: "*[1]"
 
 # Fraction rules
@@ -120,7 +120,7 @@
   match: "$ClearSpeak_Fractions='Per'"
   replace:
   - x: "*[1]"
-  - t: "5 metri"      # phrase('5 meters 'per' second)
+  - T: "al"      # phrase(5 meters 'per' second)
   - x: "*[2]"
 
 - name: common-fraction
@@ -160,16 +160,16 @@
       - test:
           if: "$Verbosity!='Terse'"
           then: [ot: "il"]
-      - t: "frazione"      # phrase(the 'fraction' with 3 over 4)
+      - T: "frazione"      # phrase(the 'fraction' with 3 over 4)
   - x: "*[1]"
-  - t: "oltre"      # phrase(the fraction 3 'over' 4)
+  - T: "fratto"      # phrase(the fraction 3 'over' 4)
   - x: "*[2]"
   - test:
       # very ugly!!! -- replicate nested ordinal fraction as they are an exception
       if: "$ClearSpeak_Fractions='OverEndFrac' or ($ClearSpeak_Fractions='EndFrac' and not( ($ClearSpeak_Fractions='Auto' or $ClearSpeak_Fractions='Ordinal' or $ClearSpeak_Fractions='EndFrac') and *[1][*[1][self::m:mn][not(contains(., '.')) and ($ClearSpeak_Fractions='Ordinal' or text()<20)]   and *[2][self::m:mn][not(contains(., '.')) and ($ClearSpeak_Fractions='Ordinal' or (2<= text() and text()<=10))] ] and *[2][*[1][self::m:mn][not(contains(., '.')) and ($ClearSpeak_Fractions='Ordinal' or text()<20)]   and *[2][self::m:mn][not(contains(., '.')) and ($ClearSpeak_Fractions='Ordinal' or (2<= text() and text()<=10))] ] ) )"
       then:
       - pause: short
-      - t: "frazione finale"      # phrase(7 over 8 'end fraction')
+      - T: "fine frazione"      # phrase(7 over 8 'end fraction')
       - pause: short
 
 - # fraction with text or numbers followed by text in both numerator and denominator
@@ -191,34 +191,34 @@
   - ")"
   replace:
   - x: "*[1]"
-  - t: "oltre"      # phrase(the fraction 3 'over' 4)
+  - T: "fratto"      # phrase(the fraction 3 'over' 4)
   - x: "*[2]"
   - test:
       if: "$ClearSpeak_Fractions='EndFrac' or $ClearSpeak_Fractions='OverEndFrac'"
       then:
       - pause: short
-      - t: "frazione finale"      # phrase(7 over 8 'end fraction')
+      - T: "fine frazione"      # phrase(7 over 8 'end fraction')
       - pause: short
 
 - name: default
   tag: fraction
   match: "."
   replace:
-  - ot: "il"      # phrase(5 is 'the' square toot of 25)
-  - t: "frazione con numeratore"      # phrase(the 'fraction with numerator' 6)
+  - ot: "la"      # phrase(5 is 'the' square toot of 25)
+  - T: "frazione con numeratore"      # phrase(the 'fraction with numerator' 6)
   - test:
       if: not(IsNode(*[1], 'simple'))
       then: [pause: medium]
   - x: "*[1]"
   - pause: medium
-  - t: "e denominatore"      # phrase(the fraction with numerator 5 'and denominator' 8)
+  - T: "e denominatore"      # phrase(the fraction with numerator 5 'and denominator' 8)
   - x: "*[2]"
   - pause: long
   - test:
       if: "$ClearSpeak_Fractions='EndFrac' or $ClearSpeak_Fractions='GeneralEndFrac'"
       then:
       - pause: short
-      - t: "frazione finale"      # phrase(the fraction with 3 over 4 'end fraction')
+      - T: "fine frazione"      # phrase(the fraction with 3 over 4 'end fraction')
       - pause: short
 
 # rules for functions raised to a power
@@ -230,11 +230,11 @@
   replace:
   - test:
       if: $ClearSpeak_Trig = 'TrigInverse'
-      then: [{x: "*[1]"}, {bookmark: "*[2]/@id"}, t: "inverso"]      # phrase(8 over 5 is the 'inverse' of 5 over 8)
+      then: [{x: "*[1]"}, {bookmark: "*[2]/@id"}, T: "inverso"]      # phrase(8 over 5 is the 'inverse' of 5 over 8)
       else_test:
         if: $ClearSpeak_Trig = 'ArcTrig'
-        then: [bookmark: "*[2]/@id", t: "arco", x: "*[1]"]      # phrase(the 'arc' of a circle)
-        else: [bookmark: "*[2]/@id", t: "inverso", x: "*[1]"] # default/Auto      # phrase(8 over 5 is the 'inverse' of 5 over 8)
+        then: [bookmark: "*[2]/@id", T: "arco", x: "*[1]"]      # phrase(the 'arc' of a circle)
+        else: [bookmark: "*[2]/@id", T: "inverso", x: "*[1]"] # default/Auto      # phrase(8 over 5 is the 'inverse' of 5 over 8)
 
 - name: function-squared-or-cubed
   tag: power
@@ -246,8 +246,8 @@
   - bookmark: "*[2]/@id"
   - test:
       if: "*[2][text()='2']"
-      then: [t: "quadrati"]      # phrase(25 equals 5 'squared')
-      else: [t: "cubi"]      # phrase(625 equals 5 'cubed')
+      then: [T: "quadrato"]      # phrase(25 equals 5 'squared')
+      else: [T: "cubo"]      # phrase(625 equals 5 'cubed')
 - name: function-power
   tag: power
   match:
@@ -255,35 +255,35 @@
   replace:
   - test:
       if: "$Verbosity!='Terse'"
-      then: [t: "il"]      # phrase('the' third power of 2)
+      then: [T: "la"]      # phrase('the' third power of 2)
   - bookmark: "*[2]/@id"
   - test:
       if: "*[2][self::m:mn][not(contains(., '.'))]"
       then: [x: "ToOrdinal(*[2])"]
       else: [x: "*[2]"]
-  - t: "potere di"      # phrase(the third 'power of' 6)
+  - T: "potenza di"      # phrase(the third 'power of' 6)
   - pause: short
   - x: "*[1]"
 
 - name: AfterPower-nested
   tag: power
-  match: # directly a superscript or an mrow that contains a superscript
+  match: # direc+tly a superscript or an mrow that contains a superscript
   - "$ClearSpeak_Exponents = 'AfterPower' and"
   - "*[2][self::m:power or self::m:power or self::m:mrow[m:power]]"
   replace:
   - x: "*[1]"
-  - t: "sollevato all"      # phrase(5 'raised to the exponent' x plus 1)
+  - T: "elevato alla"      # phrase(5 'raised to the exponent' x plus 1)
   - pause: short
   - x: "*[2]"
   - pause: short
-  - t: "esponente x più 1 "      # phrase(5 raised to the exponent x plus 1 'end exponent')
+  - T: "fine esponente"      # phrase(5 raised to the exponent x plus 1 'end exponent')
 
 - name: AfterPower-default
   tag: power
   match: "$ClearSpeak_Exponents = 'AfterPower'"
   replace:
   - x: "*[1]"
-  - t: "sollevato al potere"      # phrase(x is 'raised to the power' 4)
+  - T: "elevato alla potenza"      # phrase(x is 'raised to the power' 4)
   - x: "*[2]"
   - pause: short
 
@@ -293,7 +293,7 @@
   replace:
   - x: "*[1]"
   - bookmark: "*[2]/@id"
-  - t: "squared"      # phrase(7 'squared' equals 49)
+  - T: "al quadrato"      # phrase(7 'squared' equals 49)
 
 - name: cubed
   tag: power
@@ -301,21 +301,21 @@
   replace:
   - x: "*[1]"
   - bookmark: "*[2]/@id"
-  - t: "cubed"      # phrase(5 'cubed' equals 125)
+  - T: "al cubo"      # phrase(5 'cubed' equals 125)
 
 - name: simple-integer
   tag: power
   match: "*[2][self::m:mn][not(contains(., '.'))]"
   replace:
   - x: "*[1]"
-  - t: "al"      # phrase(2 raised 'to the' power 7)
+  - T: "alla"      # phrase(2 raised 'to the' power 7)
   - test:
       if: "*[2][.>0]"
       then: {x: "ToOrdinal(*[2])"}
       else: {x: "*[2]"}
   - test:
       if: "$ClearSpeak_Exponents != 'Ordinal'"
-      then: [t: "potere"]      # phrase(2 raised to the 'power' 7)
+      then: [T: "potenza"]      # phrase(2 raised to the 'power' 7)
 
 - name: simple-negative-integer
   tag: power
@@ -325,23 +325,23 @@
   - "    ]"
   replace:
   - x: "*[1]"
-  - t: "al"      # phrase(2 raised 'to the' power 7)
+  - T: "alla"      # phrase(2 raised 'to the' power 7)
   - x: "*[2]"
   - test:
       if: "$ClearSpeak_Exponents != 'Ordinal'"
-      then: [t: "potere"]      # phrase(2 raised to the 'power' 7)
+      then: [T: "potenza"]      # phrase(2 raised to the 'power' 7)
 
 - name: simple-var
   tag: power
   match: "*[2][self::m:mi][string-length(.)=1]"
   replace:
   - x: "*[1]"
-  - t: "al"      # phrase(3 raised 'to the' power 7)
+  - T: "alla"      # phrase(3 raised 'to the' power 7)
   - x: "*[2]"
   - pronounce: [{text: "-th"}, {ipa: "θ"}, {sapi5: "th"}, {eloquence: "T"}]
   - test:
       if: "$ClearSpeak_Exponents != 'Ordinal'"
-      then: [t: "potere"]      # phrase(2 raised to the 'power' 7)
+      then: [T: "potenza"]      # phrase(2 raised to the 'power' 7)
 
 # match nested exponent, where the nested exponent is has the power 2 or 3 (n below)
 #   [xxx]^n, - [xxx]^n, [xxx] var^n, -[xxx] var^n
@@ -366,9 +366,9 @@
   - "    ]"
   replace:
   - x: "*[1]"
-  - t: "cresciuto al"      # phrase(x 'raised to the' second power)
+  - T: "elevato alla"      # phrase(x 'raised to the' second power)
   - x: "*[2]"
-  - t: "potere"      # phrase(x raised to the second 'power')
+  - T: "potenza"      # phrase(x raised to the second 'power')
 
 - # - [xxx]^n
   name: nested-negative-squared-or-cubed
@@ -387,9 +387,9 @@
   - "     ]"
   replace:
   - x: "*[1]"
-  - t: "cresciuto al"      # phrase(x 'raised to the' second power)
+  - T: "elevato alla"      # phrase(x 'raised to the' second power)
   - x: "*[2]"
-  - t: "potere"      # phrase(x raised to the second 'power')
+  - T: "potenza"      # phrase(x raised to the second 'power')
 
 - # [xxx] var^n
   name: nested-var-squared-or-cubed
@@ -410,9 +410,9 @@
   - "      ]"
   replace:
   - x: "*[1]"
-  - t: "cresciuto al"      # phrase(x 'raised to the' second power)
+  - T: "elevato alla"      # phrase(x 'raised to the' second power)
   - x: "*[2]"
-  - t: "potere"      # phrase(x raised to the second 'power')
+  - T: "potenza"      # phrase(x raised to the second 'power')
 
 - # -[xxx] var^n
   name: nested-negative-var-squared-or-cubed
@@ -435,9 +435,9 @@
   - "      ]"
   replace:
   - x: "*[1]"
-  - t: "cresciuto al"      # phrase(x 'raised to the' second power)
+  - T: "elevato alla"      # phrase(x 'raised to the' second power)
   - x: "*[2]"
-  - t: "potere"      # phrase(x raised to the second 'power')
+  - T: "potenza"      # phrase(x raised to the second 'power')
 
 - name: default-exponent-power
   tag: power
@@ -445,20 +445,20 @@
   - "*[2][self::m:power or self::m:power or self::m:mrow[m:power]]"
   replace:
   - x: "*[1]"
-  - t: "sollevato all"      # phrase(x is 'raised to the exponent')
+  - T: "elevato alla"      # phrase(x is 'raised to the exponent')
   - pause: short
   - x: "*[2]"
   - pause: short
-  - t: "esponente finale"      # phrase(and now 'end exponent' has been reached)
+  - T: "fine esponente"      # phrase(and now 'end exponent' has been reached)
 
 - name: default
   tag: power
   match: "."
   replace:
   - x: "*[1]"
-  - t: "cresciuto al"      # phrase(x 'raised to the' second power)
+  - T: "elevato alla"      # phrase(x 'raised to the' second power)
   - x: "*[2]"
-  - t: "potere"      # phrase(x raised to the second 'power')
+  - T: "potenza"      # phrase(x raised to the second 'power')
 
 #
 # Some rules on mrows
@@ -473,13 +473,13 @@
       if: "$Verbosity!='Terse'"
       then: [t: "il "]      # phrase('the' absolute value of 25)
   - x: "$WordToSay"
-  - t: "di"      # phrase(the absolute value 'of' 25)
+  - T: "di"      # phrase(the absolute value 'of' 25)
   - x: "*[1]"
   - test:
       if: "$ClearSpeak_AbsoluteValue = 'AbsEnd'"
       then:
       - pause: short
-      - t: "fine"      # phrase('end' absolute value)
+      - T: "fine"      # phrase('end' absolute value)
       - x: "$WordToSay"
   - pause: short
 
@@ -489,24 +489,24 @@
   replace:
   - test:
     - if: "count(*)=0"
-      then: [t: "il set vuoto"]      # phrase('the empty set')
+      then: [T: "l'insieme vuoto"]      # phrase('the empty set')
     - else_if: "count(*)=2"
       then:
       - test:
           if: "$Verbosity!='Terse'"
-          then: [t: "il"]      # phrase('the' empty set)
-      - t: "set vuoto"      # phrase(the 'empty set')
+          then: [T: "l'"]      # phrase('the' empty set)
+      - T: "insieme vuoto"      # phrase(the 'empty set')
     - else_if: "count(*[1]/*)=3 and *[1]/*[2][self::m:mo][text()=':' or text()='|' or text()='∣']"
       then:
       - test:
           if: "$Verbosity!='Terse'"
-          then: [t: "l"]      # phrase('the' set of all integers)
-      - t: "insieme di"      # phrase(this is a 'set of' numbers)
+          then: [t: "l'"]      # phrase('the' set of all integers)
+      - T: "insieme di"      # phrase(this is a 'set of' numbers)
       - test:
           if: $ClearSpeak_Sets != 'woAll'
-          then: [t: "insieme di numeri interi "]      # phrase(the set of 'all' integers)
+          then: [T: "insieme dei numeri interi "]      # phrase(the set of 'all' integers)
       - x: "*[1]/*[1]"
-      - t: "tale che"      # phrase(the set S 'such that' x is less than y)
+      - T: "tale che"      # phrase(the set S 'such that' x is less than y)
       - x: "*[1]/*[3]"
       else:
       - test:
@@ -514,8 +514,8 @@
           then:
           - test:
               if: "$Verbosity!='Terse'"
-              then: [t: "l"]      # phrase('the' set of integers)
-          - t: "set"      # phrase(this is a 'set' of integers)
+              then: [T: "l'"]      # phrase('the' set of integers)
+          - T: "insieme"      # phrase(this is a 'set' of integers)
       - x: "*[1]"
 
 - # intervals are controlled by a ClearSpeak Preference -- parens/brackets don't have to match, so we avoid IsBracketed
@@ -529,9 +529,9 @@
   tag: [open-interval, open-closed-interval, closed-interval, closed-open-interval]
   match: "."
   replace:
-  - t: "l"      # phrase('the interval from' a to b)
+  - T: "l'intervallo da"      # phrase('the interval from' a to b)
   - x: "*[1]"
-  - t: "intervallo da una "      # phrase(the interval from a 'to' b)
+  - T: "a"      # phrase(the interval from a 'to' b)
   - x: "*[2]"
   - pause: short
   - test:
@@ -539,18 +539,18 @@
       then:
       - test:
           if: "starts-with(name(.), 'open')"
-          then: [t: "intervallo da a a b "]      # phrase(the interval from a to b 'not' including b)
-      - t: "intervallo da a a b non "      # phrase(the interval from a to b not 'including' b)
+          then: [T: "non"]      # phrase(the interval from a to b 'not' including b)
+      - T: "contenente"      # phrase(the interval from a to b not 'including' b)
       - x: "*[1]"
     # logic to deal with [not] arg #1
   - test:
       if: "not($is_intervals_start_infinity or $is_intervals_end_infinity)"
       then_test:
       - if: "name(.)='open-interval'"
-        then: [t: "intervallo che include a "]      # phrase(the interval including a 'or' b )
+        then: [T: "o"]      # phrase(the interval including a 'or' b )
       - else_if: "name(.)='closed-interval'"
-        then: [t: "intervallo che include a "]      # phrase(the interval including a 'and' b)
-        else: [t: "intervallo che include a "]      # phrase(the interval including a 'but' not b)
+        then: [T: "e"]      # phrase(the interval including a 'and' b)
+        else: [T: "ma"]      # phrase(the interval including a 'but' not b)
     # some ugly logic dealing with connectives: or, but, but, and (cleaner to be part of next clause?)
   - test:
       if: not($is_intervals_end_infinity)
@@ -561,8 +561,8 @@
           then:
           - test:
               if: "name(.) = 'open-interval' or name(.) = 'closed-open-interval'"
-              then: [t: "intervallo "]      # phrase(the interval 'not' including a)
-          - t: "intervallo non "      # phrase(the interval not 'including' a)
+              then: [T: "non"]      # phrase(the interval 'not' including a)
+          - T: "contenente"      # phrase(the interval not 'including' a)
       - x: "*[2]"
 
     # onto the [not] [including]... part
@@ -573,19 +573,19 @@
   - "count(*[1]/*)=1 and count(*)=2"
   replace:
   - x: "*[1]/*[1]/*" # mtable/mtr/mtd
-  - t: "scegli"      # phrase(the binomial coefficient n 'choose' m)
+  - T: "su"      # phrase(the binomial coefficient n 'choose' m)
   - x: "*[2]/*[1]/*"
 
 - name: ClearSpeak-default
   tag: [mtr, mlabeledtr]
   match: "parent::m:matrix or parent::m:determinant"
   replace:
-  - t: "riga"      # phrase(the first 'row' of a matrix)
+  - T: "riga"      # phrase(the first 'row' of a matrix)
   - x: "count(preceding-sibling::*)+1"
   - test:
       if: .[self::m:mlabeledtr]
       then:
-      - t: "con etichetta"      # phrase(the line 'with label' first equation)
+      - T: "con etichetta"      # phrase(the line 'with label' first equation)
       - x: "*[1]/*"
       - pause: short
   - pause: medium
@@ -607,21 +607,21 @@
       if: "$log_is_simple"
       then_test:
       - if: "*[1][text()='log']"
-        then: [t: "registro"]      # phrase(the 'log' of x)
+        then: [T: "log"]      # phrase(the 'log' of x)
       - else_if: $ClearSpeak_Log = 'LnAsNaturalLog'
-        then: [t: "registro naturale"]      # phrase(the 'natural log' of the product of 2 numbers)
+        then: [T: "logaritmo naturale"]      # phrase(the 'natural log' of the product of 2 numbers)
         else: [spell: "'ln'"]
       else:
       - test:
           if: "$Verbosity!='Terse' and not(log_is_simple)"
-          then: [t: "la"]      # phrase('the' square root of 25)
+          then: [T: "la"]      # phrase('the' square root of 25)
       - test:
         - if: "*[1][text()='log']"
-          then: [t: "tronco d'albero"]
+          then: [T: "log"]
         - else_if: $ClearSpeak_Log = 'LnAsNaturalLog'
-          then: [t: "registro naturale"]      # phrase(the 'natural log' of x)
+          then: [T: "logaritmo naturale"]      # phrase(the 'natural log' of x)
           else: [spell: "'ln'"]
-      - t: "di"      # phrase(the natural log 'of' x)
+      - T: "di"      # phrase(the natural log 'of' x)
       - pause: short
   - x: "*[3]"
 
@@ -635,17 +635,17 @@
       then:
       - test:
         - if: "($ClearSpeak_MultiLineLabel = 'Auto' and self::m:cases) or $ClearSpeak_MultiLineLabel = 'Case'"
-          then: [t: "caso"]      # phrase(this is the first 'case' of three cases)
+          then: [T: "caso"]      # phrase(this is the first 'case' of three cases)
         - else_if: "$ClearSpeak_MultiLineLabel = 'Auto' or $ClearSpeak_MultiLineLabel = 'Line'" # already dealt with Auto/Case
-          then: [t: "linea"]      # phrase(this is the first 'line' of three lines)
+          then: [T: "riga"]      # phrase(this is the first 'line' of three lines)
         - else_if: "$ClearSpeak_MultiLineLabel = 'Constraint'"
-          then: [t: "vincolo"]      # phrase(this is the first 'constraint' of three constraints)
+          then: [T: "vincolo"]      # phrase(this is the first 'constraint' of three constraints)
         - else_if: "$ClearSpeak_MultiLineLabel = 'Equation'"
-          then: [t: "equazione"]      # phrase(this is the first 'equation' of three equations)
+          then: [T: "equazione"]      # phrase(this is the first 'equation' of three equations)
         - else_if: "$ClearSpeak_MultiLineLabel = 'Row'"
-          then: [t: "riga"]      # phrase(this is the first 'row' of three rows)
+          then: [T: "riga"]      # phrase(this is the first 'row' of three rows)
         - else_if: "$ClearSpeak_MultiLineLabel = 'Step'"
-          then: [t: "passo"]      # phrase(this is the first 'step' of three steps)
+          then: [T: "passo"]      # phrase(this is the first 'step' of three steps)
           # else 'None -- don't say anything'
       - test:
         - if: "count(*) > 1 and $ClearSpeak_MultiLineLabel != 'None'"
@@ -659,17 +659,17 @@
   replace:
   - test:
     - if: "($ClearSpeak_MultiLineLabel = 'Auto' and parent::m:cases) or $ClearSpeak_MultiLineLabel = 'Case'"
-      then: [t: "caso"]      # phrase(in this  'case' x is not equal to y)
+      then: [T: "caso"]      # phrase(in this  'case' x is not equal to y)
     - else_if: "$ClearSpeak_MultiLineLabel = 'Auto' or $ClearSpeak_MultiLineLabel = 'Line'" # already dealt with Auto/Case
-      then: [t: "linea"]      # phrase(the straight 'line' between x and y)
+      then: [T: "linea"]      # phrase(the straight 'line' between x and y)
     - else_if: "$ClearSpeak_MultiLineLabel = 'Constraint'"
-      then: [t: "è un "]      # phrase(there is a 'constraint' on possible values)
+      then: [T: "vincolo"]      # phrase(there is a 'constraint' on possible values)
     - else_if: "$ClearSpeak_MultiLineLabel = 'Equation'"
-      then: [t: "equazione"]      # phrase(the 'equation' pi r squared gives the area of a circle)
+      then: [T: "equazione"]      # phrase(the 'equation' pi r squared gives the area of a circle)
     - else_if: "$ClearSpeak_MultiLineLabel = 'Row'"
-      then: [t: "riga"]      # phrase(the values on the top 'row' are relevant)
+      then: [T: "riga"]      # phrase(the values on the top 'row' are relevant)
     - else_if: "$ClearSpeak_MultiLineLabel = 'Step'"
-      then: [t: "passo"]      # phrase(this is a 'step' by step process)
+      then: [T: "passo"]      # phrase(this is a 'step' by step process)
       # else 'None -- don't say anything'
   - test:
       if: "$ClearSpeak_MultiLineLabel != 'None'"
@@ -678,7 +678,7 @@
       - test:
           if: .[self::m:mlabeledtr]
           then:
-          - t: "articolo "      # phrase(the item 'with label' complete)
+          - T: "con etichetta"      # phrase(the item 'with label' complete)
           - x: "*[1]/*"
       - pause: medium
   - test:
@@ -697,8 +697,8 @@
   replace:
     test:
       if: "$ClearSpeak_ImpliedTimes = 'None'"
-      then: [t: ""]
-      else: [t: "volte"]      # phrase(5 'times' 3 equals 15)
+      then: [T: ""]
+      else: [T: "per"]      # phrase(5 'times' 3 equals 15)
 
 - name: no-times
   tag: mo
@@ -706,7 +706,7 @@
   # Note: this rule is also part of the paren rule so that the parens speak
   - "text()='⁢' and $ClearSpeak_ImpliedTimes = 'None'"
   replace:
-  - t: ""
+  - T: ""
 
 - name: ClearSpeak-times
   tag: mo
@@ -730,7 +730,7 @@
   - "    IsBracketed(., '(', ')') or IsBracketed(., '[', ']') or IsBracketed(., '|', '|')]" # followed by parens
   - " )"
   replace:
-  - t: "volte"      # phrase(5 'times' 3 equals 15)
+  - T: "per"      # phrase(5 'times' 3 equals 15)
 
 - name: no-say-parens
   tag: mrow

--- a/Rules/Languages/it/SharedRules/calculus.yaml
+++ b/Rules/Languages/it/SharedRules/calculus.yaml
@@ -6,9 +6,9 @@
   replace:
   - test:
       if: "$Verbosity='Verbose'"
-      then: [t: "divergence"]      # phrase('divergence' from the mean)
-      else: [t: "div"]      # phrase('divergence' from the mean)
-  - t: "of"      # phrase(systems 'of' linear equations)
+      then: [T: "divergenza"]      # phrase('divergence' from the mean)
+      else: [T: "div"]      # phrase('divergence' from the mean)
+  - T: "di"      # phrase(systems 'of' linear equations)
   - test:
       if: "not(IsNode(*[1], 'leaf'))"
       then: [pause: short]
@@ -18,7 +18,7 @@
   tag: curl
   match: "."
   replace:
-  - t: "curl of"      # phrase(the 'curl of' a field)
+  - t: "rotore di"      # phrase(the 'curl of' a field)
   - test:
       if: "not(IsNode(*[1], 'leaf'))"
       then: [pause: short]
@@ -31,7 +31,7 @@
   - test:
       if: "$Verbosity!='Terse'"
       then: [t: "gradient of"]      # phrase('divergence' from the mean)
-      else: [t: "del"]      # phrase('divergence' from the mean)
+      else: [t: "del"]      #. phrase('divergence' from the mean)
   - test:
       if: "not(IsNode(*[1], 'leaf'))"
       then: [pause: short]

--- a/Rules/Languages/it/SharedRules/default.yaml
+++ b/Rules/Languages/it/SharedRules/default.yaml
@@ -135,17 +135,17 @@
       if: "$Verbosity!='Terse'"
       then: [T: ""]   # phrase("'the' root of x")
   - T: "simbolo di radice"
-  - T: "radice di x "      # phrase("the root of x 'with index' 5")
+  - T: "con indice"      # phrase("the root of x 'with index' 5")
   - x: "*[1]"
   - pause: short
   - test:
       if: "$Verbosity!='Terse'"
-      then: [T: "radice"]   # phrase("the root 'of' x")
+      then: [T: "di"]   # phrase("the root 'of' x")
   - x: "*[2]"
   - pause: short
   - test:
       if: "not(IsNode(*[2],'leaf'))"
-      then: [T: "radice di x "] # phrase("root of x 'end root symbol'")
+      then: [T: "fine simbolo di radice"] # phrase("root of x 'end root symbol'")
 
 
 - name: simple-sub
@@ -413,7 +413,7 @@
       if: count(*)=1
       then: [T: "riga"]      # phrase(the table with 1 'row')
       else: [T: "righe"]      # phrase(the table with 3 'rows')
-  - T: "e "      # phrase(the table with 3 rows 'and' 4 columns)
+  - T: "e"      # phrase(the table with 3 rows 'and' 4 columns)
   - x: "count(*[1]/*)"
   - test:
       if: "count(*[1]/*)=1"
@@ -484,7 +484,7 @@
       then: [T: "rettangolo", pause: short]      # phrase(the 'box' around the expression)
   - test:
       if: ".[contains(@notation,'roundedbox')]"
-      then: [T: "ellisse", pause: short]      # phrase(the 'round box' around the expression)
+      then: [T: "rettangolo arrotondato", pause: short]      # phrase(the 'round box' around the expression)
   - test:
       if: ".[contains(@notation,'circle')]"
       then: [T: "cerchio", pause: short]      # phrase(the 'circle' around the expression)
@@ -509,11 +509,11 @@
       then:
       - test:
           if: ".[contains(@notation,'updiagonalstrike') and contains(@notation,'downdiagonalstrike')]"
-          then: [spell: "'x'", pause: short] # seems better to say 'x cross out' than 'up diagonal, down diagonal cross out'
+          then: [spell: "x", pause: short] # seems better to say 'x cross out' than 'up diagonal, down diagonal cross out'
           else:
           - test:
               if: ".[contains(@notation,'updiagonalstrike')]"
-              then: [T: "diagonale", pause: short]      # phrase(the line runs 'up diagonal')
+              then: [T: "diagonale verso l'alto", pause: short]      # phrase(the line runs 'up diagonal')
           - test:
               if: ".[contains(@notation,'downdiagonalstrike')]"
               then: [T: "diagonale verso il basso", pause: short]      # phrase(the line runs 'down diagonal')
@@ -527,16 +527,16 @@
       - pause: short
   - test:
       if: ".[contains(@notation,'uparrow')]"
-      then: [T: "freccia in alto", pause: short]      # phrase(direction is shown by the 'up arrow')
+      then: [T: "freccia verso l'alto", pause: short]      # phrase(direction is shown by the 'up arrow')
   - test:
       if: ".[contains(concat(' ', normalize-space(@notation), ' '), ' downarrow ')]"
-      then: [T: "freccia in basso", pause: short]      # phrase(the trend is shown by the 'down arrow')
+      then: [T: "freccia verso il basso", pause: short]      # phrase(the trend is shown by the 'down arrow')
   - test:
       if: ".[contains(@notation,'leftarrow')]"
-      then: [T: "freccia a sinistra", pause: short]      # phrase(the 'left arrow' indicates going back)
+      then: [T: "freccia verso sinistra", pause: short]      # phrase(the 'left arrow' indicates going back)
   - test:
       if: ".[contains(concat(' ', normalize-space(@notation), ' '), ' rightarrow ')]"
-      then: [T: "freccia a destra", pause: short]      # phrase(the 'right arrow' indicates moving forward)
+      then: [T: "freccia verso destra", pause: short]      # phrase(the 'right arrow' indicates moving forward)
   - test:
       if: ".[contains(@notation,'northeastarrow')]"
       then: [T: "freccia verso nord -est", pause: short]      # phrase(direction is indicated by the 'northeast arrow')
@@ -545,22 +545,22 @@
       then: [T: "freccia verso sud -est", pause: short]      # phrase(direction is shown by the 'southeast arrow')
   - test:
       if: ".[contains(concat(' ', normalize-space(@notation), ' '), ' southwestarrow ')]"
-      then: [T: "freccia verso sud -ovest", pause: short]      # phrase(direction is shown by the 'southwest arrow')
+      then: [T: "freccia verso sud-ovest", pause: short]      # phrase(direction is shown by the 'southwest arrow')
   - test:
       if: ".[contains(@notation,'northwestarrow')]"
       then: [T: "freccia verso nord -ovest", pause: short]      # phrase(direction is shown by the 'northwest arrow')
   - test:
       if: ".[contains(@notation,'updownarrow')]"
-      then: [T: "alto è indicato dalla ", pause: short]      # phrase(upward movement is indicated by the 'double ended vertical arrow')
+      then: [T: "freccia verticale a doppia estremità", pause: short]      # phrase(upward movement is indicated by the 'double ended vertical arrow')
   - test:
       if: ".[contains(@notation,'leftrightarrow')]"
       then: [T: "freccia orizzontale a doppia estremità", pause: short]      # phrase(progress is indicated by the 'double ended horizontal arrow')
   - test:
       if: ".[contains(@notation,'northeastsouthwestarrow')]"
-      then: [T: "freccia diagonale a doppia estremità", pause: short]      # phrase(trend is indicated by the 'double ended up diagonal arrow')
+      then: [T: "freccia diagonale verso l'alto a doppia estremità", pause: short]      # phrase(trend is indicated by the 'double ended up diagonal arrow')
   - test:
       if: ".[contains(@notation,'northwestsoutheastarrow')]"
-      then: [T: "freccia diagonale a doppia estremità", pause: short]      # phrase(trend is indicated by the 'double ended down diagonal arrow')
+      then: [T: "freccia diagonale verso il basso a doppia estremità", pause: short]      # phrase(trend is indicated by the 'double ended down diagonal arrow')
   - test:
       if: ".[contains(@notation,'actuarial')]"
       then: [T: "simbolo attuariale", pause: short]      # phrase(the 'actuarial symbol' represents a specific quantity)
@@ -569,7 +569,7 @@
       then: [T: "simbolo fattoriale arabo", pause: short]      # phrase(the 'arabic factorial symbol' represents a factorial operation)
   - test:
       if: ".[contains(@notation,'phasorangle')]"
-      then: [T: "angolo di phasor", pause: short]      # phrase(the 'phasor angle' is used to measure electrical current)
+      then: [T: "angolo di fase", pause: short]      # phrase(the 'phasor angle' is used to measure electrical current)
   - test:
       if: ".[contains(@notation,'longdiv') or not(@notation) or normalize-space(@notation) ='']" # default
       then: [T: "simbolo della divisione lunga", pause: short]      # phrase(the 'long division symbol' indicates  a long division calculation)
@@ -579,7 +579,7 @@
   - T: "racchiudono"      # phrase(parentheses are 'enclosing' part of the equation)
   - test:
       if: "*[self::m:mtext and text()=' ']"
-      then: [T: "c'è uno "]     # otherwise there is complete silence      # phrase(there is a 'space' between the words)
+      then: [T: "spazio"]     # otherwise there is complete silence      # phrase(there is a 'space' between the words)
       else: [x: "*"]
   - test:
       if: "$Impairment = 'Blindness' and ( $SpeechStyle != 'SimpleSpeak' or not(IsNode(*[1], 'leaf')) )"
@@ -656,7 +656,7 @@
   - pause: short
   - insert:
       nodes: "*"
-      replace: [t: "virma", pause: auto]      # phrase(f of x 'comma' y)
+      replace: [T: "virgola", pause: auto]      # phrase(f of x 'comma' y)
 
 - name: default-text
   # unknown leaf -- just speak the text -- could be a literal intent

--- a/Rules/Languages/it/SharedRules/general.yaml
+++ b/Rules/Languages/it/SharedRules/general.yaml
@@ -17,15 +17,15 @@
   - bookmark: "*[1]/@id"
   - test:
     - if: "*[1][text()='ℂ']"
-      then: [T: "numeri complessi"]      # phrase('complex numbers' consist of two parts)
+      then: [T: "numeri complessi"]       # phrase('complex numbers' consist of two parts)
     - else_if: "*[1][text()='ℕ']"
-      then: [T: "numeri naturali"]      # phrase('natural numbers' are numbers from 1 to infinity)
+      then: [T: "numeri naturali"]        # phrase('natural numbers' are numbers from 1 to infinity)
     - else_if: "*[1][text()='ℚ']"
-      then: [T: "numeri razionali"]      # phrase('rational numbers' are the fraction of 2 integers)
+      then: [T: "numeri razionali"]       # phrase('rational numbers' are the fraction of 2 integers)
     - else_if: "*[1][text()='ℝ']"
-      then: [T: "numeri reali"]      # phrase('real numbers' can be both positive and negative)
+      then: [T: "numeri reali"]           # phrase('real numbers' can be both positive and negative)
     - else_if: "*[1][text()='ℤ']"
-      then: [T: "numeri interi"]      # phrase(positive 'integers' are natural numbers above 0)
+      then: [T: "numeri interi"]          # phrase(positive 'integers' are natural numbers above 0)
       else: [x: "*[1][text()]"] # shouldn't happen
 
 - name: dimension-number-sets
@@ -150,7 +150,7 @@
       if: "$Verbosity!='Terse'"
       then:
       - T: "la"      # phrase('the' square root of 25 equals 5)
-  - T: "punto"      # phrase(a decimal 'point' indicates the fraction component of a number)
+  - T: "punto"       # phrase(a decimal 'point' indicates the fraction component of a number)
   - x: "*[1]"
   - T: "virgola"      # phrase(use a 'comma' to divide large numbers or as a decimal point)
   - x: "*[2]"
@@ -162,12 +162,12 @@
   - test:
       if: "$Verbosity='Terse'"
       then: [T: "valore assoluto"]      # phrase(the 'absolute value' of a number represents its distance from 0)
-      else: [t: "il valore assoluto di"]      # phrase('the absolute value of' a number represents its distance from 0)
+      else: [T: "il valore assoluto di"]      # phrase('the absolute value of' a number represents its distance from 0)
   - x: "*[1]"
   - test:
       if: "IsNode(*[1], 'leaf') or $Impairment != 'Blindness'"
       then: [pause: short]
-      else: [pause: short, t: "end assolute value", pause: short]      # phrase(show 'end absolute value' position)
+      else: [pause: short, T: "fine valore assoluto", pause: short]      # phrase(show 'end absolute value' position)
 
 - name: negative
   tag: negative
@@ -261,7 +261,7 @@
       then_test:
           if: "$Verbosity='Terse'"
           then: [T: "lim inf"]
-          else: [T: "limite inferio"]
+          else: [T: "limite inferiore"]
     - else: [x: "*[1]"]
   - T: "per"                      # phrase(the limit 'as' x approaches 1)
   - x: "*[2]"
@@ -315,7 +315,7 @@
       - test:
           if: "$Verbosity='Verbose'"
           then: [T: "fine pedice"]      # phrase(this is the 'end subscript' position)
-          else: [T: "fine apice"]      # phrase(this is the 'end sub' position)
+          else: [T: "fine pedice"]      # phrase(this is the 'end sub' position)
       - pause: short
       else_test:
           if: "*[2][self::m:mi]"   # need a pause in "x sub k prime" so the prime is not associated with the 'k'
@@ -325,7 +325,7 @@
       then_test:
         if: "$Verbosity='Verbose'"
         then: [T: "apice"]      # phrase(a 'superscript' number indicates raised to a power)
-        else: [t: "super"]      # phrase(this is a 'super' set of numbers)
+        else: [T: "sopra"]      # phrase(this is a 'super' set of numbers)
   - x: "*[3]"
   - pause: short
 
@@ -351,7 +351,7 @@
   - bookmark: "@id"
   - test:
       if: "$Verbosity='Terse'"
-      then: [T: "tan è il rapporto tra l"]      # phrase(the 'tan' is the ratio of the opposite to the adjacent side of a right-angled triangle)
+      then: [T: "tan"]      # phrase(the 'tan' is the ratio of the opposite to the adjacent side of a right-angled triangle)
       else: [T: "tangente"]      # phrase(a 'tangent' is a straight line that touches a curve)
 - name: sec
   tag: mi
@@ -433,7 +433,7 @@
   - bookmark: "@id"
   - test:
       if: "$Verbosity='Terse'"
-      then: [T: "fcotangH"]      # phrase('cotanch' is shorthand for hyperbolic cotangent)
+      then: [T: "cotanH"]      # phrase('cotanch' is shorthand for hyperbolic cotangent)
       else: [T: "cotangente iperbolica"]      # phrase(the 'hyperbolic cotangent' is a mathematical function)
 - name: exponential
   tag: mi
@@ -442,7 +442,7 @@
   - bookmark: "@id"
   - test:
       if: "$Verbosity='Terse'"
-      then: [T: "esp"]      # phrase('exp' means exponential function)
+      then: [T: "exp"]      # phrase('exp' means exponential function)
       else: [T: "esponenziale"]      # phrase('exponential' function)
 - name: covariance
   tag: mi
@@ -471,7 +471,7 @@
         then: [T: "log"]      # phrase(the 'log' function is used in mathematics)
       - else_if: "$Verbosity='Terse'"
         then: [spell: "'ln'"]
-        else: [T: "log naturale"]      # phrase(the 'natural log' function is used in mathematics)
+        else: [T: "logaritmo naturale"]      # phrase(the 'natural log' function is used in mathematics)
       else:
       - test:
           if: "$Verbosity!='Terse' and not(log_is_simple)"
@@ -481,7 +481,7 @@
           then: [T: "log"]      # phrase(the 'log' function is used in mathematics)
         - else_if: "$Verbosity='Terse'"
           then: [spell: "'ln'"]
-          else: [t: "log natural"]      # phrase(the 'natural log' function is used in mathematics)
+          else: [T: "logaritmo naturale"]      # phrase(the 'natural log' function is used in mathematics)
       - T: "di"      # phrase(5 is the square root 'of' 25)
       - pause: short
   - x: "*[3]"
@@ -494,7 +494,7 @@
   - test:
       if: "$Verbosity!='Terse'"
       then: [T: "la"]      # phrase('the' square root of 25 equals 5)
-  - T: "base log"      # phrase(the 'log base' is often base 10)
+  - T: "base del logaritmo"      # phrase(the 'log base' is often base 10)
   - x: "*[1]"
 
 - name: log-base-power
@@ -505,7 +505,7 @@
   - test:
       if: "$Verbosity!='Terse'"
       then: [T: "la"]      # phrase('the' square root of 25 equals 5)
-  - T: "log base"      # phrase(the 'log base' is often base 10)
+  - T: "base del logaritmo"      # phrase(the 'log base' is often base 10)
   - x: "*[1]"
   - pause: medium
   - test:
@@ -516,7 +516,7 @@
         else:  # don't bother with special cases as this isn't likely to happen
         - T: "elevato alla"      # phrase(x 'raised to the' second power)
         - x: "*[2]"
-        - T: "potenza"      # phrase(x raised to the second 'power')
+        - T: "potenza"           # phrase(x raised to the second 'power')
   - pause: short
 
 - name: multi-line
@@ -627,7 +627,7 @@
   - T: "per 1 colonna"      # phrase(the 2 'by 1 column' matrix)
   - test:
       if: "$ClearSpeak_Matrix = 'Vector' or $ClearSpeak_Matrix = 'EndVector'"
-      then: [T: "vettoriale"]      # phrase(the 2 by 2 'vector')
+      then: [T: "vettore"]      # phrase(the 2 by 2 'vector')
       else: [T: "matrice"]      # phrase(the 2 by 2 'matrix')
   - pause: long
   - x: "*/*"
@@ -645,7 +645,7 @@
   variables: [IsColumnSilent: true()]
   match: "*[self::m:mtr][count(*) = 1]"
   replace:
-  - T: "the"      # phrase('the' 2 by 2 matrix M)
+  - T: "la"      # phrase('the' 2 by 2 matrix M)
   - x: "count(*)"
   - T: "per 1 colonna"      # phrase(the 2 'by 1 column' matrix)
   - test:
@@ -667,13 +667,13 @@
   - count(*[1]/*)<=3 and # at least two cols
   - IsNode(*/*/*,'simple') # IsNode() returns true if all the nodes are simple
   replace:
-  - T: "la matrice 1 di"      # phrase('the 1 by' 2 matrix)
+  - T: "1 per"      # phrase('the 1 by' 2 matrix)
   - x: count(*/*)
   - T: "righe"      # phrase(the 1 by 4 'row' matrix)
   - test:
       if: "$ClearSpeak_Matrix = 'Vector' or $ClearSpeak_Matrix = 'EndVector'"
-      then: [T: "il 1 per"]      # phrase('the 1 by' 2 row 'vector')
-      else: [T: "la 1 per"]      # phrase('the 1 by' 2 'matrix')
+      then: [T: "il vettore 1 per"]      # phrase('the 1 by' 2 row 'vector')
+      else: [T: "la matrice 1 per"]      # phrase('the 1 by' 2 'matrix')
   - pause: long
   - x: "*/*"
   - test:
@@ -683,7 +683,7 @@
       - test:
           if: $ClearSpeak_Matrix = 'EndMatrix'
           then: [T: "matrice"]      # phrase(the 2 by 2 'matrix')
-          else: [T: "vettoriale"]      # phrase(the 2 by 1 'vector')
+          else: [T: "vettore"]      # phrase(the 2 by 1 'vector')
 
 - name: default-row-matrix
   tag: matrix
@@ -743,7 +743,7 @@
   replace:
   - T: "la"      # phrase('the' 1 by 2 matrix M)
   - x: "count(*)"
-  - T: "di"      # phrase(the 1 'by' 2 matrix)
+  - T: "per"      # phrase(the 1 'by' 2 matrix)
   - x: "count(*[self::m:mtr][1]/*)"
   - test:
       if: "self::m:determinant"
@@ -984,9 +984,9 @@
     - if: ".='s'"
       then: [T: "solido"]      # phrase(Boron is a 'solid' in its natural state)
     - else_if: ".='l'"
-      then: [T: "acqua è un "]      # phrase(water is a 'liquid')
+      then: [T: "liquido"]      # phrase(water is a 'liquid')
     - else_if: ".='g'"
-      then: [T: "idrogeno è un "]      # phrase(hydrogen is a 'gas' )
+      then: [T: "gas"]      # phrase(hydrogen is a 'gas' )
       else: [T: "acquosa"]      # phrase(an 'aqueous' solution is contained in water)
   - pause: short
 
@@ -1024,7 +1024,7 @@
       then_test:
         if: "$Verbosity='Terse'"
         then: [T: "forma"]      # phrase(hydrogen and oxygen 'forms' water )
-        else: [T: "idrogeno e "]      # phrase(hydrogen and oxygen 'reacts to form' water)
+        else: [T: "reagisce a formare"]      # phrase(hydrogen and oxygen 'reacts to form' water)
     - else_if: ".='⇌' or .='\u1f8d2'"
       then: [T: "è in equilibrio con"]      # phrase(a reactant 'is in equilibrium with' a product)
     - else_if: ".='\u1f8d4'"

--- a/Rules/Languages/it/SharedRules/linear-algebra.yaml
+++ b/Rules/Languages/it/SharedRules/linear-algebra.yaml
@@ -67,7 +67,7 @@
       if: "$Verbosity='Verbose'"
       then:
       - T: "la"      # phrase('the' square root of 25 equals 5)
-  - T: "trace"      # phrase('trace' of a matrix)
+  - T: "traccia"      # phrase('trace' of a matrix)
   - test:
       if: "$Verbosity!='Terse'"
       then:
@@ -97,7 +97,7 @@
       if: "$Verbosity='Verbose'"
       then:
       - T: "la"      # phrase('the' square root of 25 equals 5)
-  - T: "l"      # phrase('homomorphism' indicates similarity of form)
+  - T: "omomorfismo"      # phrase('homomorphism' indicates similarity of form)
   - test:
       if: "$Verbosity!='Terse'"
       then:

--- a/Rules/Languages/it/SimpleSpeak_Rules.yaml
+++ b/Rules/Languages/it/SimpleSpeak_Rules.yaml
@@ -20,7 +20,7 @@
   replace:
   - test:
       if: "$Verbosity!='Terse'"
-      then: [T: ""]    # phrase('the' square root of x)
+      then: [T: "la"]    # phrase('the' square root of x)
   - T: "radice quadrata"      # phrase(the 'square root' of x)
   - test:
       if: "$Verbosity!='Terse'"
@@ -38,7 +38,7 @@
   replace:
   - test:
       if: "$Verbosity!='Terse'"
-      then: [T: ""]
+      then: [T: "la"]
   - test:
       if: "*[2][self::m:mn]"
       then_test:
@@ -109,7 +109,7 @@
   replace:
   - test:
       if: "$Impairment = 'Blindness'"
-      then: [T: "Inizio frazione"]      # phrase(the 'fraction' 3 over 4)
+      then: [T: "inizio frazione"]      # phrase(the 'fraction' 3 over 4)
   - pause: short
   - x: "*[1]"
   - test:
@@ -231,7 +231,7 @@
   - test:
       if: "$Impairment = 'Blindness'"
       then:
-      - T: "esponente 4 "      # phrase(start 2 raised to the exponent 4 'end of exponent')
+      - T: "fine esponente"      # phrase(start 2 raised to the exponent 4 'end of exponent')
       - pause: short
       else:
       - pause: medium
@@ -258,13 +258,13 @@
       then:
       - test:
           if: "$Verbosity!='Terse'"
-          then: [T: ""]      # phrase('the' empty set)
+          then: [T: "l'"]      # phrase('the' empty set)
       - T: "insieme vuoto"      # phrase(when a set contains no value it is called an 'empty set' and this is valid)
     - else_if: "count(*[1]/*)=3 and *[1]/*[2][self::m:mo][text()=':' or text()='|' or text()='∣']"
       then:
       - test:
           if: "$Verbosity!='Terse'"
-          then: [T: ""]      # phrase('the' set of all integers)
+          then: [T: "l'"]      # phrase('the' set of all integers)
       - T: "insieme degli interi positivi "      # phrase(the 'set of all' positive integers less than 10)
       - x: "*[1]/*[1]"
       - T: "tale che"      # phrase(x 'such that' x is less than y)
@@ -272,7 +272,7 @@
       else:
       - test:
           if: "$Verbosity!='Terse'"
-          then: [T: ""]      # phrase('the' set of integers)
+          then: [T: "l'"]      # phrase('the' set of integers)
       - T: "insieme"      # phrase(here is a 'set' of numbers)
       - x: "*[1]"
 

--- a/Rules/Languages/it/definitions.yaml
+++ b/Rules/Languages/it/definitions.yaml
@@ -32,14 +32,16 @@
          "diciassette", "diciotto", "diciannove"
     ]
 
+# 'zeresimo' is kind of akward, but it documented in Italian, see for example:
+# https://www.treccani.it/vocabolario/esimo/
 - NumbersOrdinalOnes: [
-         "zero", "primo", "secondo", "terzo", "quarto", "quinto", "sesto", "settimo", "ottavo", "nono",
+         "zeresimo", "primo", "secondo", "terzo", "quarto", "quinto", "sesto", "settimo", "ottavo", "nono",
          "decimo", "undicesimo", "dodicesimo", "tredicesimo", "quattordicesimo", "quindicesimo", "sedicesimo",
          "diciassettesimo", "diciottesimo", "diciannovesimo"
     ]
 
 - NumbersOrdinalPluralOnes: [
-         "zero", "primi", "secondi", "terzi", "quarti", "quinti", "sesti", "settimi", "ottavi", "noni",
+         "zeresimi", "primi", "secondi", "terzi", "quarti", "quinti", "sesti", "settimi", "ottavi", "noni",
          "decimi", "undicesimi", "dodicesimi", "tredicesimi", "quattordicesimi", "quindicesimi", "sedicesimi",
          "diciassettesimi", "diciottesimi", "diciannovesimi"
     ]
@@ -75,13 +77,13 @@
     ]
 
 - NumbersOrdinalHundreds: [
-       "", "un centesimo", "duecentesimo", "trecentesimo", "quattrocentesimo", "cinquecentesimo",
+       "", "centesimo", "duecentesimo", "trecentesimo", "quattrocentesimo", "cinquecentesimo",
          "seicentesimo", "settecentesimo", "ottocentesimo", "novecentesimo"
     ]
 
 - NumbersOrdinalPluralHundreds: [
-       "", "un centesimo", "due centesimi", "tre centesimi", "quattro centesimi", "cinque centesimi",
-         "sei centesimi", "sette centesimi", "otto centesimi", "nove centesimi"
+       "", "centesimo", "duecentesimi", "trecentesimi", "quattrocentesimi", "cinquecentesimi",
+         "seicentesimi", "settecentesimi", "ottocentesimi", "novecentesimi"
     ]
       
 

--- a/Rules/Languages/it/navigate.yaml
+++ b/Rules/Languages/it/navigate.yaml
@@ -84,7 +84,7 @@
   - test:
       if: "count($Child2D/preceding-sibling::*)=0"
       then: [T: "base"]            # phrase(the 'base' of the power)
-      else: [T: "elevato alla"]     # phrase(x with 'superscript' 2)  # FIX: it would be better to use the word used when reading (power, exponent, ...)
+      else: [T: "apice"]     # phrase(x with 'superscript' 2)  # FIX: it would be better to use the word used when reading (power, exponent, ...)
   - pause: "medium"
 
 - name: into-or-out-of
@@ -97,7 +97,7 @@
       then: [T: "base"]             # phrase(the 'base' of the power)
     - else_if: "count($Child2D/preceding-sibling::*)=1"
       then: [T: "pedice"]        # phrase(x with 'subscript' 2)
-      else: [T: "elevato alla"]      # phrase(x with 'superscript' 2)  # FIX: it would be better to use the word used when reading (power, exponent, ...)
+      else: [T: "apice"]      # phrase(x with 'superscript' 2)  # FIX: it would be better to use the word used when reading (power, exponent, ...)
   - pause: "medium"
 
 - name: into-or-out-of
@@ -203,7 +203,7 @@
         - else_if: "$PreviousNavCommand = 'ZoomOut'"
           then: [T: "annulla riduci dettaglio"]                      # phrase('undo zoom out')
         - else_if: "$PreviousNavCommand = 'ZoomInAll'"
-          then: [T: "annulla Aumenta dettaglio al massimo"]        # phrase('undo zooming in all the way')
+          then: [T: "annulla aumenta dettaglio al massimo"]        # phrase('undo zooming in all the way')
         - else_if: "$PreviousNavCommand = 'ZoomOutAll'"
           then: [T: "annulla riduci dettaglio al minimo"]       # phrase('undo zooming out all the way')
         - else_if: "$PreviousNavCommand = 'MovePrevious' or $PreviousNavCommand = 'MovePreviousZoom'"
@@ -494,7 +494,7 @@
   - set_variables: [NavNode: "../@id"]
 
 - name: zoom-out
-  # a row around a single element -- these might duplicate the position/offset, so we jump an extra level here  
+  # a row around a single element -- these might duplicate the position/offset, so we jump an extra level here
   tag: "*"
   match: "$NavCommand = 'ZoomOut'"
   replace:
@@ -1126,11 +1126,11 @@
       then:
       - test:
         - if: "$NavCommand = 'MoveNext'"
-          then: [T: "sposta"]                                  # phrase('move' to next entry in table)     
+          then: [T: "spostati"]                               # phrase('move' to next entry in table)
         - else_if: "$NavCommand = 'ReadNext'"
-          then: [T: "leggi"]                                  # phrase('read' next entry in table)     
-          else: [T: "descrivi"]                              # phrase('describe' next entry in table)     
-      - T: "destra"                                           # phrase(move 'right')                                           # phrase(move 'right')
+          then: [T: "leggi"]                                  # phrase('read' next entry in table)
+          else: [T: "descrivi"]                               # phrase('describe' next entry in table)
+      - T: "destra"                                           # phrase(move 'right')
       - pause: short
   - with:
       variables: [MatchCounter: "$MatchCounter + 1"]
@@ -1169,10 +1169,10 @@
       - T: "impossibile"                                          # phrase('cannot' move right in expression)
       - test:
         - if: "$NavCommand = 'MoveNext'"
-          then: [T: "spostarsi"]                                  # phrase('move' to next entry in table)     
+          then: [T: "spostati"]                                  # phrase('move' to next entry in table)
         - else_if: "$NavCommand = 'ReadNext'"
-          then: [T: "leggere"]                                  # phrase('read' next entry in table)     
-          else: [T: "descrivi"]                              # phrase('describe' next entry in table)     
+          then: [T: "leggere"]                                  # phrase('read' next entry in table)
+          else: [T: "descrivi"]                              # phrase('describe' next entry in table)
       - T: "a destra, fine della matematica"                              # phrase(move 'right, end of math')
       - pause: long
   - set_variables: [SpeakExpression: "'false'"]
@@ -1194,10 +1194,10 @@
       then:
       - test:
         - if: "$NavCommand = 'MoveNext'"
-          then: [T: "sposta"]                                  # phrase('move' to next entry in table)     
+          then: [T: "spostati"]                                  # phrase('move' to next entry in table)
         - else_if: "$NavCommand = 'ReadNext'"
-          then: [T: "leggi"]                                  # phrase('read' next entry in table)     
-          else: [T: "descrivi"]                              # phrase('describe' next entry in table)     
+          then: [T: "leggi"]                                  # phrase('read' next entry in table)
+          else: [T: "descrivi"]                              # phrase('describe' next entry in table)
       - T: "destra"                                           # phrase(move 'right')                                           # phrase(move 'right')
       - pause: short
   - with:
@@ -1283,10 +1283,10 @@
       then:
       - test:
         - if: "$NavCommand = 'MoveNext'"
-          then: [T: "sposta"]                                  # phrase('move' to next entry in table)     
+          then: [T: "spostati"]                                  # phrase('move' to next entry in table)
         - else_if: "$NavCommand = 'ReadNext'"
-          then: [T: "leggi"]                                  # phrase('read' next entry in table)     
-          else: [T: "descrivi"]                              # phrase('describe' next entry in table)     
+          then: [T: "leggi"]                                  # phrase('read' next entry in table)
+          else: [T: "descrivi"]                              # phrase('describe' next entry in table)
       - T: "destra"                                           # phrase(move 'right')                                           # phrase(move 'right')
       - pause: short
   - set_variables: [NavNode: "following-sibling::*[1]/*[2]/@id"]
@@ -1304,10 +1304,10 @@
       then:
       - test:
         - if: "$NavCommand = 'MoveNext'"
-          then: [T: "sposta"]                                  # phrase('move' to next entry in table)     
+          then: [T: "spostati"]                                  # phrase('move' to next entry in table)
         - else_if: "$NavCommand = 'ReadNext'"
-          then: [T: "leggi"]                                  # phrase('read' next entry in table)     
-          else: [T: "descrivi"]                              # phrase('describe' next entry in table)     
+          then: [T: "leggi"]                                  # phrase('read' next entry in table)
+          else: [T: "descrivi"]                              # phrase('describe' next entry in table)
       - T: "destra"                                           # phrase(move 'right')                                           # phrase(move 'right')
       - pause: short
   - test:
@@ -1337,10 +1337,10 @@
       then:
       - test:
         - if: "$NavCommand = 'MoveNext'"
-          then: [T: "sposta"]                                  # phrase('move' to next entry in table)     
+          then: [T: "spostati"]                                  # phrase('move' to next entry in table)
         - else_if: "$NavCommand = 'ReadNext'"
-          then: [T: "leggi"]                                  # phrase('read' next entry in table)     
-          else: [T: "descrivi"]                              # phrase('describe' next entry in table)     
+          then: [T: "leggi"]                                  # phrase('read' next entry in table)
+          else: [T: "descrivi"]                              # phrase('describe' next entry in table)
       - T: "destra"                                           # phrase(move 'right')                                           # phrase(move 'right')
       - pause: short
   - test:
@@ -1365,10 +1365,10 @@
       then:
       - test:
         - if: "$NavCommand = 'MovePrevious'"
-          then: [T: "sposta"]                                  # phrase('move' to next entry in table)     
+          then: [T: "sposta"]                                  # phrase('move' to next entry in table)
         - else_if: "$NavCommand = 'ReadPrevious'"
-          then: [T: "leggi"]                                  # phrase('read' next entry in table)     
-          else: [T: "descrivi"]                              # phrase('describe' next entry in table)     
+          then: [T: "leggi"]                                  # phrase('read' next entry in table)
+          else: [T: "descrivi"]                              # phrase('describe' next entry in table)
       - T: "sinistra"                                            # phrase(move 'left')
       - pause: short
   - with:
@@ -1436,10 +1436,10 @@
       then:
       - test:
         - if: "$NavCommand = 'MovePrevious'"
-          then: [T: "sposta"]                                  # phrase('move' to next entry in table)     
+          then: [T: "spostati"]                                  # phrase('move' to next entry in table)
         - else_if: "$NavCommand = 'ReadPrevious'"
-          then: [T: "leggi"]                                  # phrase('read' next entry in table)     
-          else: [T: "descrivi"]                              # phrase('describe' next entry in table)     
+          then: [T: "leggi"]                                  # phrase('read' next entry in table)
+          else: [T: "descrivi"]                              # phrase('describe' next entry in table)
       - T: "sinistra"                                            # phrase(move 'left')
       - pause: short
   - with:
@@ -1482,10 +1482,10 @@
       then:
       - test:
         - if: "$NavCommand = 'MovePrevious'"
-          then: [T: "sposta"]                                  # phrase('move' to next entry in table)     
+          then: [T: "spostati"]                                  # phrase('move' to next entry in table)
         - else_if: "$NavCommand = 'ReadPrevious'"
-          then: [T: "leggi"]                                  # phrase('read' next entry in table)     
-          else: [T: "descrivi"]                              # phrase('describe' next entry in table)     
+          then: [T: "leggi"]                                  # phrase('read' next entry in table)
+          else: [T: "descrivi"]                              # phrase('describe' next entry in table)
       - T: "sinistra"                                            # phrase(move 'left')
       - pause: short
   - test:
@@ -1571,10 +1571,10 @@
           then:
           - test:
             - if: "$NavCommand = 'MovePrevious'"
-              then: [T: "sposta"]                                  # phrase('move' to next entry in table)     
+              then: [T: "spostati"]                                  # phrase('move' to next entry in table)
             - else_if: "$NavCommand = 'ReadPrevious'"
-              then: [T: "leggi"]                                  # phrase('read' next entry in table)     
-              else: [T: "descrivi"]                              # phrase('describe' next entry in table)     
+              then: [T: "leggi"]                                  # phrase('read' next entry in table)
+              else: [T: "descrivi"]                              # phrase('describe' next entry in table)
           - T: "sinistra"                                            # phrase(move 'left')
           - pause: short
       - with:
@@ -1593,10 +1593,10 @@
       then:
       - test:
         - if: "$NavCommand = 'MovePrevious'"
-          then: [T: "sposta"]                                  # phrase('move' to next entry in table)     
+          then: [T: "spostati"]                                  # phrase('move' to next entry in table)
         - else_if: "$NavCommand = 'ReadPrevious'"
-          then: [T: "leggi"]                                  # phrase('read' next entry in table)     
-          else: [T: "descrivi"]                              # phrase('describe' next entry in table)     
+          then: [T: "leggi"]                                  # phrase('read' next entry in table)
+          else: [T: "descrivi"]                              # phrase('describe' next entry in table)
       - T: "sinistra"                                            # phrase(move 'left')
       - pause: short
   - test:
@@ -1671,7 +1671,7 @@
       - pause: long
       - set_variables: [Overview: "'false'"]
       else:
-      - T: "panoramica dell'"          # phrase('overview of expression after move')
+      - T: "panoramica dell'espressione dopo lo spostamento"          # phrase('overview of expression after move')
       - pause: long
       - set_variables: [Overview: "'true'"]
 
@@ -1685,7 +1685,7 @@
       - test:
         - if: "$NavCommand = 'ReadCurrent'"
           then: [T: "leggi"]                                  # phrase('read' next entry in table) 
-          else: [T: "descrivi"]                              # phrase('describe' next entry in table)     
+          else: [T: "descrivi"]                              # phrase('describe' next entry in table)
       - T: "corrente"                                         # phrase('current' entry in table)
       - pause: long
   - set_variables: [NavNode: "@id"]
@@ -1704,11 +1704,11 @@
       then:
       - test:
         - if: "starts-with($NavCommand, 'Read')"
-          then: [T: "leggi"]                                  # phrase('read' next entry in table)     
+          then: [T: "leggi"]                                  # phrase('read' next entry in table)
         - else_if: "starts-with($NavCommand, 'Describe')"
-          then: [T: "descrivi"]                              # phrase('describe' next entry in table)     
+          then: [T: "descrivi"]                              # phrase('describe' next entry in table)
         - else_if: "starts-with($NavCommand, 'MoveTo')"
-          then: [T: "sposta a"]                              # phrase('move to' the next entry in table) 
+          then: [T: "spostati a"]                              # phrase('move to' the next entry in table)
           else: [T: "imposta"]                                   # phrase('set' the value of the next entry in table) 
       - T: "segnaposto"                                     # phrase('placeholder' for the value)
       - x: "$PlaceMarkerIndex"

--- a/Rules/Languages/it/unicode.yaml
+++ b/Rules/Languages/it/unicode.yaml
@@ -5,7 +5,7 @@
  - "a-z": 
     - test: 
         if: "$TTS='none'"
-        then: [t: "."]                          	
+        then: [T: "."]
         else: [spell: "'.'"]                       
 
  # Capital letters are a little tricky: users can pick their favorite word (something that was requested) and 
@@ -25,55 +25,55 @@
           if: "$SpeechOverrides_CapitalLetters = ''"
           then_test:
             if: "$Impairment = 'Blindness'"
-            then: [t: "maiuscolo"]              	# 	(en: 'cap', google translation)
+            then: [T: "maiuscolo"]                #   (en: 'cap')
           else: [x: "$SpeechOverrides_CapitalLetters"] 
     - pitch:
         value: "$CapitalLetters_Pitch"
         # note: processing of ranges converts '.' into the character, so it needs to be in quotes below
         replace: [spell: "translate('.', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz')"]
 
- - "0-9": [t: "."]    
- - " ": [t: "spazio"]                           	#  0x20	(en: ' ', google: ' ')
+ - "0-9": [T: " "]
+ - " ": [T: " "]                            #  0x20 (en: ' ', google: ' ')
 
- - "!":                                         	#  0x21
+ - "!":                                           #  0x21
     - test:
         if: "ancestor-or-self::*[contains(@data-intent-property, ':structure:')]"
         then_test:
             if: "$Verbosity = 'Terse'"
-            then: [t: "scoppio"]                	#  0x21	(en: 'bang', google translation)
-            else: [t: "punto esclamativo"]      	#  0x21	(en: 'exclamation point')
-        else: [t: "punto esclamativo"]          	#  0x21	(en: 'factorial')
+            then: [T: "punto esclamativo"]                  #  0x21 (en: 'bang')
+            else: [T: "punto esclamativo"]        #  0x21 (en: 'exclamation point')
+        else: [T: "fattoriale"]           #  0x21 (en: 'factorial')
           
- - "\"": [t: "back slash"]                      	#  0x22	(en: 'quotation mark')
- - "#": [t: "cancelletto"]                      	#  0x23	(en: 'number')
- - "$": [t: "dollaro"]                          	#  0x24	(en: 'dollars')
- - "%": [t: "percento"]                         	#  0x25	(en: 'percent')
- - "&": [t: "e commerciale"]                    	#  0x26	(en: 'ampersand')
- - "'": [t: "apostrofo"]                        	#  0x27	(en: 'apostrophe')
- - "(":                                         	#  0x28
+ - "\"": [T: "virgolette"]                        #  0x22 (en: 'quotation mark')
+ - "#": [T: "numero"]                       #  0x23 (en: 'number')
+ - "$": [T: "dollari"]                            #  0x24 (en: 'dollars')
+ - "%": [T: "percento"]                           #  0x25 (en: 'percent')
+ - "&": [T: "e commerciale"]                      #  0x26 (en: 'ampersand')
+ - "'": [T: "apostrofo"]                          #  0x27 (en: 'apostrophe')
+ - "(":                                           #  0x28
     - test:
         if: $SpeechStyle = 'ClearSpeak' or $SpeechStyle = 'SimpleSpeak'
         then_test:
             if: "$Verbosity='Terse'"
-            then: [t: "aprire"]                 	#  0x28	(en: 'open', google translation)
-            else: [t: "parentesi tonda aperta"] 	#  0x28	(en: 'open paren', MathPlayer: 'aperta parentesi tonda', google: 'parentesi aperta')
-        else: [t: "parentesi tonda aperta"]     	#  0x28	(en: 'left paren', MathPlayer: 'aperta parentesi tonda', google: 'parentesi lasciata')
- - ")":                                         	#  0x29
+            then: [T: "aprire"]                   #  0x28 (en: 'open')
+            else: [T: "aperta parentesi"]   #  0x28 (en: 'open paren', MathPlayer: 'aperta parentesi tonda', google: 'parentesi aperta')
+        else: [T: "parentesi aperta"]       #  0x28 (en: 'left paren', MathPlayer: 'aperta parentesi tonda', google: 'parentesi lasciata')
+ - ")":                                           #  0x29
     - test:
         if: $SpeechStyle = 'ClearSpeak' or $SpeechStyle = 'SimpleSpeak'
         then_test:
             if: "$Verbosity='Terse'"
-            then: [t: "vicino"]                 	#  0x29	(en: 'close', google translation)
-            else: [t: "parentesi tonda chiusa"] 	#  0x29	(en: 'close paren', MathPlayer: 'chiusa parentesi tonda', google: 'close parentesi')
-        else: [t: "parentesi tonda chiusa"]     	#  0x29	(en: 'right paren', MathPlayer: 'chiusa parentesi tonda', google: 'parentesi giusta')
+            then: [T: "chiudere"]                   #  0x29 (en: 'close')
+            else: [T: "chiusa parentesi"]   #  0x29 (en: 'close paren', MathPlayer: 'chiusa parentesi tonda', google: 'close parentesi')
+        else: [T: "parentesi chiusa"]       #  0x29 (en: 'right paren', MathPlayer: 'chiusa parentesi tonda', google: 'parentesi giusta')
 
- - "*":                                         	#  0x2a
+ - "*":                                           #  0x2a
     test:
         if: "parent::*[name(.)='msup' or name(.)='msubsup' or name(.)='skip-super']"
-        then: [t: "stella"]                     	#  0x2a	(en: 'star', google translation)
-        else: [t: "asterisco"]                  	#  0x2a	(en: 'times', MathPlayer: 'per', google: 'volte')
- - "+": [t: "più"]                              	#  0x2b	(en: 'plus', MathPlayer: 'piu'')
- - ",":                                         	#  0x2c
+        then: [T: "stella"]                       #  0x2a (en: 'star', google translation)
+        else: [T: "per"]                    #  0x2a (en: 'times', MathPlayer: 'per', google: 'volte')
+ - "+": [T: "più"]                                #  0x2b (en: 'plus', MathPlayer: 'piu'')
+ - ",":                                           #  0x2c
     # the following deals with the interaction of "," with "…" which sometimes wants the ',' to be silent
     # that this test is here and not with "…" is not ideal, but seems simplest
      test:
@@ -84,109 +84,109 @@
             - "( following-sibling::*[1][text()!= '…'] and preceding-sibling::*[1][text()!='…']  ) or "
                # except if expression starts with '…'
             - "../*[1][text()='…'] "
-        then: [t: "virgola"]                    	# 	(en: 'comma', google translation)
+        then: [T: "virgola"]                      #   (en: 'comma')
         # else silent
 
- - "-": [t: "meno"]                             	#  0x2d	(en: 'minus')
- - ".":                                         	#  0x2e
+ - "-": [T: "meno"]                               #  0x2d (en: 'minus')
+ - ".":                                           #  0x2e
     - test:
         if: "parent::*[1][self::m:mn]"
-        then: [t: "punto"]                      	# 	(en: 'point', google translation)
-        else: [t: "punto"]                      	# 	(en: 'dot')
- - "/": [t: "diviso"]                           	#  0x2f	(en: 'divided by')
- - ":": [t: "due punti"]                        	#  0x3a	(en: 'colon')
- - ";": [t: "punto e virgola"]                  	#  0x3b	(en: 'semicolon')
- - "<":                                         	#  0x3c
+        then: [T: "punto"]                        #   (en: 'point')
+        else: [T: "punto"]                        #   (en: 'dot')
+ - "/": [T: "diviso per"]                             #  0x2f (en: 'divided by')
+ - ":": [T: "due punti"]                          #  0x3a (en: 'colon')
+ - ";": [T: "punto e virgola"]                    #  0x3b (en: 'semicolon')
+ - "<":                                           #  0x3c
      - test: 
          if: "$Verbosity!='Terse'"
-         then: [t: "è"]                         	# 	(en: 'is', google translation)
-     - t: "minore di"                           	# 	(en: 'less than')
- - "=":                                         	#  0x3d
+         then: [T: "è"]                           #   (en: 'is')
+     - T: "minore di"                             #   (en: 'less than')
+ - "=":                                           #  0x3d
     - test: 
         if: "$Verbosity!='Terse'"
-        then: [t: "è uguale a"]                 	# 	(en: 'is equal to', google translation)
-        else: [t: "uguale a"]                   	# 	(en: 'equals')
+        then: [T: "è uguale a"]                   #   (en: 'is equal to')
+        else: [T: "uguale a"]                     #   (en: 'equals')
 
- - ">":                                         	#  0x3e
+ - ">":                                           #  0x3e
      - test: 
          if: "$Verbosity!='Terse'"
-         then: [t: "è"]                         	# 	(en: 'is', google translation)
-     - t: "maggiore di"                         	# 	(en: 'greater than')
- - "?": [t: "punto interrogativo"]              	#  0x3f	(en: 'question mark')
- - "@": [t: "simbolo at"]                       	#  0x40	(en: 'at sign')
- - "[":                                         	#  0x5b
+         then: [T: "è"]                           #   (en: 'is')
+     - T: "maggiore di"                           #   (en: 'greater than')
+ - "?": [T: "punto interrogativo"]                #  0x3f (en: 'question mark')
+ - "@": [T: "chiocciola"]                         #  0x40 (en: 'at sign')
+ - "[":                                           #  0x5b
     - test:
         if: $SpeechStyle = 'ClearSpeak' or $SpeechStyle = 'SimpleSpeak'
-        then: [t: "parentesi aperta"]           	# 	(en: 'open bracket', google translation)
-        else: [t: "parentesi quadra aperta"]    	# 	(en: 'left bracket', MathPlayer: 'aperta parentesi quadra', google: 'fascia sinistra')
- - "\\": [t: "parentesi quadra aperta"]         	#  0x5c	(en: 'back slash', MathPlayer: 'aperta parentesi quadra', google: 'back slash')
- - "]":                                         	#  0x5d
+        then: [T: "parentesi aperta"]             #   (en: 'open bracket')
+        else: [T: "aperta parentesi quadra"]      #   (en: 'left bracket', MathPlayer: 'aperta parentesi quadra', google: 'fascia sinistra')
+ - "\\": [T: "back slash"]          #  0x5c (en: 'back slash', MathPlayer: 'aperta parentesi quadra', google: 'back slash')
+ - "]":                                           #  0x5d
     - test:
         if: $SpeechStyle = 'ClearSpeak' or $SpeechStyle = 'SimpleSpeak'
-        then: [t: "ravvicinarsi"]               	# 	(en: 'close bracket', google translation)
-        else: [t: "parentesi quadra chiusa"]    	# 	(en: 'right bracket', MathPlayer: 'chiusa parentesi quadra', google: 'parentesi destra')
- - "^":                                         	#  0x5e
+        then: [T: "parentesi chiusa"]                 #   (en: 'close bracket', google translation)
+        else: [T: "chiusa parentesi quadra"]      #   (en: 'right bracket', MathPlayer: 'chiusa parentesi quadra', google: 'parentesi destra')
+ - "^":                                           #  0x5e
     - test:
         if: "parent::m:modified-variable or parent::m:mover"
-        then: [t: "cappello"]                   	# 	(en: 'hat', google translation)
-        else: [t: "accento circonflesso"]       	# 	(en: 'caret', MathPlayer: 'cappuccio', google: 'assegnato')
- - "_": [t: "barra sotto"]                      	#  0x5f	(en: 'under bar', MathPlayer: 'under bar', google: 'sotto la barra')
- - "`": [t: "accento grave"]                    	#  0x60	(en: 'grave')
- - "{":                                         	#  0x7b
+        then: [T: "cappellino"]                     #   (en: 'hat')
+        else: [T: "accento circonflesso"]         #   (en: 'caret', MathPlayer: 'cappuccio', google: 'assegnato')
+ - "_": [t: "trattino basso"]                       #  0x5f (en: 'under bar', MathPlayer: 'under bar', google: 'sotto la barra')
+ - "`": [t: "accento grave"]                      #  0x60 (en: 'grave')
+ - "{":                                           #  0x7b
     - test:
         if: $SpeechStyle = 'ClearSpeak' or $SpeechStyle = 'SimpleSpeak'
-        then: [t: "braccia aperta"]             	# 	(en: 'open brace', google translation)
-        else: [t: "parentesi graffa aperta"]    	# 	(en: 'left brace', MathPlayer: 'aperta parentesi graffa', google: 'braccia sinistra')
- - "|":                                         	#  0x7c
+        then: [T: "aperta graffa"]              #   (en: 'open brace')
+        else: [T: "aperta parentesi graffa"]      #   (en: 'left brace', MathPlayer: 'aperta parentesi graffa', google: 'braccia sinistra')
+ - "|":                                           #  0x7c
     # note: for ClearSpeak and SimpleSpeak, "|" inside of sets is handled at the mrow level, same for 'sets'
      - test:
         - if: "$SpeechStyle != 'ClearSpeak' or not(preceding-sibling::*) or not(following-sibling::*)"
-          then: [t: "linea verticale"]          	# 	(en: 'vertical line', google translation)
+          then: [T: "linea verticale"]            #   (en: 'vertical line', google translation)
         - else_if: "$ClearSpeak_VerticalLine = 'SuchThat'"
-          then: [t: "tale che"]                 	# 	(en: 'such that', google translation)
+          then: [T: "tale che"]                   #   (en: 'such that', google translation)
         - else_if: "$ClearSpeak_VerticalLine = 'Given'"  
-          then: [t: "dato"]                     	# 	(en: 'given', google translation)
-        - else: [t: "barra verticale"]          	# 	(en: 'divides')
+          then: [T: "dato"]                       #   (en: 'given', google translation)
+        - else: [T: "barra verticale"]            #   (en: 'divides')
 
- - "}":                                         	#  0x7d
+ - "}":                                           #  0x7d
     - test:
         if: $SpeechStyle = 'ClearSpeak' or $SpeechStyle = 'SimpleSpeak'
-        then: [t: "close brace"]                	# 	(google translation)
-        else: [t: "parentesi graffa chiusa"]    	# 	(en: 'right brace', MathPlayer: 'chiusa parentesi graffa', google: 'braccia destra')
+        then: [T: "chiusa graffa"]                  #   (en: 'close brace')
+        else: [T: "chiusa parentesi graffa"]      #   (en: 'right brace', MathPlayer: 'chiusa parentesi graffa', google: 'braccia destra')
 
- - "~": [t: "tilde"]                            	#  0x7e
- - " ":                                         	#  0xa0
+ - "~": [T: "tilde"]                              #  0x7e
+ - " ":                                           #  0xa0
     - test:
         if: "@data-empty-in-2D and ../../../../*[name(.)!='equations']"
-        then: [t: "vuoto"]                      	#  want to say something for fraction (etc) with empty child	(en: 'empty', google translation)
-        else: [t: ""]                            
+        then: [T: "vuoto"]                        #  want to say something for fraction (etc) with empty child  (en: 'empty')
+        else: [T: ""]
 
- - "¬": [t: "simbolo not"]                      	#  0xac	(en: 'not', MathPlayer: 'not', google: 'non')
- - "°": [t: "gradi"]                            	#  0xb0	(en: 'degrees', MathPlayer: 'grado')
- - "±": [t: "più o meno"]                       	#  0xb1	(en: 'plus or minus', MathPlayer: 'piu' o meno')
- - "´": [t: "accento acuto"]                    	#  0xb4	(en: 'acute')
- - "·":                                         	#  0xB7
+ - "¬": [T: "non"]                        #  0xac (en: 'not', MathPlayer: 'not', google: 'non')
+ - "°": [T: "gradi"]                              #  0xb0 (en: 'degrees', MathPlayer: 'grado')
+ - "±": [T: "più o meno"]                         #  0xb1 (en: 'plus or minus', MathPlayer: 'piu' o meno')
+ - "´": [T: "accento acuto"]                      #  0xb4 (en: 'acute')
+ - "·":                                           #  0xB7
     - test:
         if: "$SpeechStyle != 'ClearSpeak' or $ClearSpeak_MultSymbolDot = 'Auto'"
-        then: [t: "volte"]                      	# 	(en: 'times', google translation)
-        else: [t: "puntino nel mezzo"]          	# 	(en: 'dot')
- - "×":                                         	#  0xd7
+        then: [T: "volte"]                        #   (en: 'times')
+        else: [T: "puntino"]            #   (en: 'dot')
+ - "×":                                           #  0xd7
     - test:
         if: "$SpeechStyle != 'ClearSpeak' or $ClearSpeak_MultSymbolX = 'Auto'"
-        then: [t: "volte"]                      	# 	(en: 'times', google translation)
+        then: [T: "volte"]                        #   (en: 'times')
         else_test:
             if: $ClearSpeak_MultSymbolX = 'By'
-            then: [t: "di"]                     	# 	(en: 'by', google translation)
-            else: [t: "per"]                    	# 	(en: 'cross', MathPlayer: 'moltiplicato', google: 'attraverso')
- - "÷": [t: "diviso"]                           	#  0xf7	(en: 'divided by')
- - "̀": [t: "ornamento accento grave"]          	#  0x300	(en: 'grave accent embellishment', google: 'grave accento abbellimento')
- - "́": [t: "segno di accento acuto"]           	#  0x301	(en: 'acute accent embellishment', google: 'abbellimento di accento acuto')
- - "̂": [t: "ornamento cappello"]               	#  0x302	(en: 'circumflex accent embellishment', google: 'abbellimento di accento circonflesso')
- - "̃": [t: "ornamento tilde"]                  	#  0x303	(en: 'tilde embellishment', google: 'abbellimento di tilde')
- - "̄": [t: "combining con segno di vocale lunga"]	#  0x304	(en: 'macron embellishment', google: 'abbellimento di macron')
- - "̅": [t: "overbar embellishment"]            	#  0x305	(google: 'overbar abbellimento')
- - "̆": [t: "combining breve"]                  	#  0x306	(en: 'breve', google: 'breve')
- - "̇": [t: "ornamento punto sopra"]            	#  0x307	(en: 'dot above embellishment', google: 'punto sopra abbellimento')
+            then: [T: "per"]                      #   (en: 'by')
+            else: [T: "moltiplicato"]                     #   (en: 'cross', MathPlayer: 'moltiplicato', google: 'attraverso')
+ - "÷": [T: "diviso"]                             #  0xf7 (en: 'divided by')
+ - "̀": [T: "decorazione con accento grave"]            #  0x300  (en: 'grave accent embellishment', google: 'grave accento abbellimento')
+ - "́": [T: "decorazione con accento acuto"]            #  0x301  (en: 'acute accent embellishment', google: 'abbellimento di accento acuto')
+ - "̂": [T: "decorazione con  accento circonflesso "]                 #  0x302  (en: 'circumflex accent embellishment', google: 'abbellimento di accento circonflesso')
+ - "̃": [T: "decorazione con tilde"]                    #  0x303  (en: 'tilde embellishment', google: 'abbellimento di tilde')
+ - "̄": [T: "decorazione con barra sopra"]  #  0x304  (en: 'macron embellishment', google: 'abbellimento di macron')
+ - "̅": [T: "decorazione con barra sopra"]              #  0x305  (google: 'overbar abbellimento')
+ - "̆": [T: "breve"]                    #  0x306  (en: 'breve', google: 'breve')
+ - "̇": [T: "decorazione con punto sopra"]              #  0x307  (en: 'dot above embellishment', google: 'punto sopra abbellimento')
 
    # Note: ClearSpeak has pref TriangleSymbol for "Δ", but that is wrong
  - "Α-Ω": 
@@ -202,298 +202,298 @@
           if: "$SpeechOverrides_CapitalLetters = ''"
           then_test:
             if: "$Impairment = 'Blindness'"
-            then: [t: "maiuscolo"]              	# 	(en: 'cap', google translation)
+            then: [T: "maiuscolo"]                #   (en: 'cap', google translation)
           else: [x: "$SpeechOverrides_CapitalLetters"] 
     - pitch:
         value: "$CapitalLetters_Pitch"
         # note: processing of ranges converts '.' into the character, so it needs to be in quotes below
         replace: [spell: "translate('.', 'ΑΒΓΔΕΖΗΘΙΚΛΜΝΞΟΠΡ΢ΣΤΥΦΧΨΩ', 'αβγδεζηθικλμνξοπρςστυφχψω')"]
 
- - "α": [t: "alfa"]                             	#  0x3b1	(en: 'alpha')
- - "β": [t: "beta"]                             	#  0x3b2
- - "γ": [t: "gamma"]                            	#  0x3b3
- - "δ": [t: "delta"]                            	#  0x3b4
- - "ε": [t: "epsilon"]                          	#  0x3b5
- - "ζ": [t: "zeta"]                             	#  0x3b6
- - "η": [t: "eta"]                              	#  0x3b7
- - "θ": [t: "theta"]                            	#  0x3b8
- - "ι": [t: "iota"]                             	#  0x3b9
- - "κ": [t: "kappa"]                            	#  0x3ba
- - "λ": [t: "lamda"]                            	#  0x3bb	(en: 'lambda', google: 'lambda')
- - "μ": [t: "mu"]                               	#  0x3bc
- - "ν": [t: "nu"]                               	#  0x3bd
- - "ξ": [t: "xi"]                               	#  0x3be	(en: 'zai', google: 'zai')
- - "ο": [t: "omicron"]                          	#  0x3bf
- - "π": [t: "pi greco"]                         	#  0x3c0	(en: 'pi', google: 'pi')
- - "ρ": [t: "rho"]                              	#  0x3c1
- - "ς": [t: "final sigma"]                      	#  0x3c2	(google: 'sigma finale')
- - "σ": [t: "sigma"]                            	#  0x3c3
- - "τ": [t: "tau"]                              	#  0x3c4
- - "υ": [t: "upsilon"]                          	#  0x3c5
- - "φ": [t: "phi"]                              	#  0x3c6
- - "χ": [t: "chi"]                              	#  0x3c7
- - "ψ": [t: "psi"]                              	#  0x3c8
- - "ω": [t: "omega"]                            	#  0x3c9
- - "ϕ": [t: "straight phi"]                     	#  0x3d5	(en: 'phi', google: 'phi')
- - "ϖ": [t: "variant pi"]                       	#  0x3d6	(en: 'pi', google: 'pi')
- - "ϵ": [t: "epsilon"]                          	#  0x3f5
- - "϶": [t: "epsilon dritto invertito"]         	#  0x3f6	(en: 'reversed epsilon', MathPlayer: 'reversed epsilon', google: 'epsilon invertito')
+ - "α": [T: "alfa"]                               #  0x3b1  (en: 'alpha')
+ - "β": [T: "beta"]                               #  0x3b2
+ - "γ": [T: "gamma"]                              #  0x3b3
+ - "δ": [T: "delta"]                              #  0x3b4
+ - "ε": [T: "epsilon"]                            #  0x3b5
+ - "ζ": [T: "zeta"]                               #  0x3b6
+ - "η": [T: "eta"]                                #  0x3b7
+ - "θ": [T: "theta"]                              #  0x3b8
+ - "ι": [T: "iota"]                               #  0x3b9
+ - "κ": [T: "kappa"]                              #  0x3ba
+ - "λ": [T: "lamda"]                              #  0x3bb  (en: 'lambda', google: 'lambda')
+ - "μ": [T: "mu"]                                 #  0x3bc
+ - "ν": [T: "nu"]                                 #  0x3bd
+ - "ξ": [T: "xi"]                                 #  0x3be  (en: 'zai', google: 'zai')
+ - "ο": [T: "omicron"]                            #  0x3bf
+ - "π": [T: "pi greco"]                           #  0x3c0  (en: 'pi', google: 'pi')
+ - "ρ": [T: "rho"]                                #  0x3c1
+ - "ς": [T: "sigma finale"]                       #  0x3c2  (google: 'sigma finale')
+ - "σ": [T: "sigma"]                              #  0x3c3
+ - "τ": [T: "tau"]                                #  0x3c4
+ - "υ": [T: "upsilon"]                            #  0x3c5
+ - "φ": [T: "phi"]                                #  0x3c6
+ - "χ": [T: "chi"]                                #  0x3c7
+ - "ψ": [T: "psi"]                                #  0x3c8
+ - "ω": [T: "omega"]                              #  0x3c9
+ - "ϕ": [T: "phi"]                                #  0x3d5  (en: 'phi', google: 'phi')
+ - "ϖ": [T: "phi"]                                #  0x3d6  (en: 'pi', google: 'pi')
+ - "ϵ": [T: "epsilon"]                            #  0x3f5
+ - "϶": [T: "epsilon rovesciata"]           #  0x3f6  (en: 'reversed epsilon', MathPlayer: 'reversed epsilon', google: 'epsilon invertito')
 
- - "–": [t: "en dash"]                          	#  0x2013	(SRE: 'lineetta enne')
- - "—": [t: "em dash"]                          	#  0x2014	(SRE: 'lineetta emme')
- - "―": [t: "barra orizzontale"]                	#  0x2015	(en: 'horizontal bar', SRE: 'lineetta di citazione')
- - "‖": [t: "doppia barra verticale"]           	#  0x2016	(en: 'double vertical line')
- - "…":                                         	#  0x2026
+ - "–": [T: "trattino medio"]                     #  0x2013 (SRE: 'lineetta enne')
+ - "—": [T: "trattino lungo”"]                    #  0x2014 (SRE: 'lineetta emme')
+ - "―": [T: "barretta orizzontale"]                 #  0x2015 (en: 'horizontal bar', SRE: 'lineetta di citazione')
+ - "‖": [T: "doppia barretta verticale"]            #  0x2016 (en: 'double vertical line')
+ - "…":                                           #  0x2026
     test:
         if:
             - "$SpeechStyle != 'ClearSpeak' or $ClearSpeak_Ellipses = 'Auto' or"
                # must be ClearSpeak and $ClearSpeak_Ellipses = 'AndSoOn'
                # speak '…' as 'and so on...' unless expr starts with '…'
             - "../*[1][text()='…']"
-        then: [t: "punto punto punto"]          	# 	(en: 'dot dot dot', google translation)
-        else_test:                              	#  must have $ClearSpeak_Ellipses = 'AndSoOn'
+        then: [T: "puntini di sospensione"]           #   (en: 'dot dot dot', google translation)
+        else_test:                                #  must have $ClearSpeak_Ellipses = 'AndSoOn'
             if: "count(following-sibling::*) = 0"
-            then: [t: "e così via"]             	# 	(en: 'and so on', google translation)
-            else: [t: "punti di sospensione"]   	# 	(en: 'and so on up to')
+            then: [T: "e così via"]               #   (en: 'and so on', google translation)
+            else: [T: "e così via fino a"]        #   (en: 'and so on up to')
 
- - "⁡":                                         	#  0x2061
+ - "⁡":                                           #  0x2061
     - test:
         if: "$Verbosity!='Terse' and not(preceding-sibling::*[1][IsInDefinition(., 'GeometryShapes')]) and
              not(@data-changed='added' and ancestor-or-self::*[contains(@data-intent-property, ':structure:')])"
-        then: [t: "di"]                         	# 	(en: 'of', google translation)
- - "⁢": [t: ""]                                 	#  0x2062
- - "⁣": [t: ""]                                 	#  0x2063
- - "⁤": [t: "più"]                              	#  0x2064	(en: 'and', google: 'e')
- - "′": [t: "primo"]                            	#  0x2032	(en: 'prime')
- - "″": [t: "doppio primo"]                     	#  0x2033	(en: 'double prime')
- - "‴": [t: "triplo primo"]                     	#  0x2034	(en: 'triple prime')
+        then: [T: "di"]                           #   (en: 'of', google translation)
+ - "⁢": [T: ""]                                   #  0x2062
+ - "⁣": [T: ""]                                   #  0x2063
+ - "⁤": [T: "e"]                                #  0x2064 (en: 'and', google: 'e')
+ - "′": [T: "primo"]                              #  0x2032 (en: 'prime')
+ - "″": [T: "doppio primo"]                       #  0x2033 (en: 'double prime')
+ - "‴": [T: "triplo primo"]                       #  0x2034 (en: 'triple prime')
 
- - "ℂℕℚℝℤ":                                     	#  here we rely on this running through the table again to speak "cap xxx"
-    - t: "triplo primo"                         	# 	(en: 'double-struck')
+ - "ℂℕℚℝℤ":                                       #  here we rely on this running through the table again to speak "cap xxx"
+    - T: "doppio tratto"              #   (en: 'double-struck')
     - spell: "translate('.', 'ℂℕℚℝℤ', 'CNQRZ')"
 
- - "℃": [t: "gradi celsius"]                    	#  0x2103	(en: 'degrees celsius', google translation)
- - "℉": [t: "gradi fahrenheit"]                 	#  0x2109	(en: 'degrees fahrenheit', google translation)
- - "ℋℛℓ":                                       	#  0x210b
-    - t: "sceneggiatura"                        	# 	(en: 'script', google translation)
+ - "℃": [T: "gradi celsius"]                      #  0x2103 (en: 'degrees celsius', google translation)
+ - "℉": [T: "gradi fahrenheit"]                   #  0x2109 (en: 'degrees fahrenheit', google translation)
+ - "ℋℛℓ":                                         #  0x210b
+    - t: "aratteri calligrafici"                  #   (en: 'script', google translation)
     - spell: "translate('.', 'ℋℛℓ', 'HRl')"
- - "ℎ": [t: "costante di planck"]               	#  0x210e	(en: 'planck constant')
- - "ℜ":                                         	#  0x211c
-    - t: "fraktur r maiuscola"                  	# 	(en: 'fraktur', google: 'fraktur')
+ - "ℎ": [T: "costante di planck"]                 #  0x210e (en: 'planck constant')
+ - "ℜ":                                           #  0x211c
+    - T: "R gotica"                               #   (en: 'fraktur', google: 'fraktur')
     - spell: "'R'"
 
- - "Ω": [t: "simbolo dell'ohm"]                 	#  0x2126	(en: 'ohms')
- - "K": [t: "segno Kelvin"]                     	#  0x212a	(en: 'kelvin', google: 'kelvin')
- - "Å": [t: "angstrom"]                         	#  0x212b	(en: 'angstroms')
- - "ⅆⅇⅈⅉ":                                      	#  0x2146-9
-    - t: "angstrom"                             	# 	(en: 'double-struck italic')
+ - "Ω": [T: "ohm"]                                #  0x2126 (en: 'ohms')
+ - "K": [T: "kelvin"]                             #  0x212a (en: 'kelvin', google: 'kelvin')
+ - "Å": [T: "angstrom"]                           #  0x212b (en: 'angstroms')
+ - "ⅆⅇⅈⅉ":                                        #  0x2146-9
+    - T: "doppio tratto corsivo"                              #   (en: 'double-struck italic')
     - spell: "translate('.', 'ⅆⅇⅈⅉ', 'deij')"
 
- - "←": [t: "freccia verso sinistra"]           	#  0x2190	(en: 'leftwards arrow')
- - "↑": [t: "freccia verso l'alto"]             	#  0x2191	(en: 'upwards arrow')
- - "→":                                         	#  0x2192
+ - "←": [T: "freccia verso sinistra"]             #  0x2190 (en: 'leftwards arrow')
+ - "↑": [T: "freccia verso l'alto"]               #  0x2191 (en: 'upwards arrow')
+ - "→":                                           #  0x2192
      - test:
         if: "ancestor::*[2][self::m:limit]"
-        then: [t: "approcci"]                   	# 	(en: 'approaches', google translation)
-        else: [t: "freccia verso destra"]       	# 	(en: 'right arrow')
+        then: [T: "approccia"]                    #   (en: 'approaches', google translation)
+        else: [T: "freccia verso destra"]         #   (en: 'right arrow')
 
- - "↓": [t: "freccia verso il basso"]           	#  0x2193	(en: 'downwards arrow')
- - "⇒": [t: "freccia doppia verso destra"]      	#  0x21d2	(en: 'rightwards double arrow')
- - "∀": [t: "per ogni"]                         	#  0x2200	(en: 'for all')
- - "∂":                                         	#  0x2202
+ - "↓": [T: "freccia verso il basso"]             #  0x2193 (en: 'downwards arrow')
+ - "⇒": [T: "freccia doppia verso destra"]        #  0x21d2 (en: 'rightwards double arrow')
+ - "∀": [T: "per ogni"]                           #  0x2200 (en: 'for all')
+ - "∂":                                           #  0x2202
      - test: 
          if: "$Verbosity='Terse'"
-         then: [t: "parziale"]                  	# 	(en: 'partial', google translation)
-         else: [t: "parziale"]                  	# 	(en: 'partial derivative', google: 'derivata parziale')
- - "∃": [t: "esiste"]                           	#  0x2203	(en: 'there exists')
- - "∄": [t: "non esiste"]                       	#  0x2204	(en: 'there does not exist')
- - "∅": [t: "insieme vuoto"]                    	#  0x2205	(en: 'empty set')
- - "∆":                                         	#  0x2206
+         then: [T: "parziale"]                    #   (en: 'partial')
+         else: [T: "derivata parziale"]           #   (en: 'partial derivative', google: 'derivata parziale')
+ - "∃": [T: "esiste"]                             #  0x2203 (en: 'there exists')
+ - "∄": [T: "non esiste"]                         #  0x2204 (en: 'there does not exist')
+ - "∅": [T: "insieme vuoto"]                      #  0x2205 (en: 'empty set')
+ - "∆":                                           #  0x2206
      - test: 
          if: "$Verbosity!='Terse'"
-         then: [t: "il"]                        	# 	(en: 'the', google translation)
-     - t: "incremento"                          	# 	(en: 'laplacian of')
- - "∇":                                         	#  0x2207
+         then: [T: "il"]                          #   (en: 'the')
+     - T: "laplaciano di"                         #   (en: 'laplacian of')
+ - "∇":                                           #  0x2207
      - test: 
          if: "$Verbosity!='Terse'"
-         then: [t: "il"]                        	# 	(en: 'the', google translation)
-     - t: "gradiente (nabla)"                   	# 	(en: 'gradient of', google: 'gradiente di')
- - "∈":                                         	#  0x2208
+         then: [T: "il"]                          #   (en: 'the')
+     - T: "gradiente di"                          #   (en: 'gradient of', google: 'gradiente di')
+ - "∈":                                           #  0x2208
      - test:
         if: "$SpeechStyle != 'ClearSpeak'"
-        then: [t: "un elemento di"]             	# 	(en: 'an element of', google translation)
+        then: [T: "un elemento di"]               #   (en: 'an element of')
         # Several options for speaking elements in ClearSpeak -- they split between being inside a set or not and then the option
         else_test:
-            if: "../../self::m:set or ../../../self::m:set"	#  inside a set
+            if: "../../self::m:set or ../../../self::m:set" #  inside a set
             then_test:
               - if: $ClearSpeak_SetMemberSymbol = 'Auto' or $ClearSpeak_SetMemberSymbol = 'In'
-                then: [t: "in"]                 	# 	(google translation)
+                then: [T: "in"]                   #   (en: 'in')
               - else_if: $ClearSpeak_SetMemberSymbol = 'Member'
-                then: [t: "membro di"]          	# 	(en: 'member of', google translation)
+                then: [T: "membro di"]            #   (en: 'member of')
               - else_if: $ClearSpeak_SetMemberSymbol = 'Element'
-                then: [t: "elemento di"]        	# 	(en: 'element of', google translation)
-              - else: [t: "appartenente a"]     	#  $ClearSpeak_SetMemberSymbol = 'Belongs'	(en: 'belonging to')
+                then: [T: "elemento di"]          #   (en: 'element of')
+              - else: [T: "appartenente a"]       #  $ClearSpeak_SetMemberSymbol = 'Belongs'  (en: 'belonging to')
             else_test:
               - if: $ClearSpeak_SetMemberSymbol = 'Auto' or $ClearSpeak_SetMemberSymbol = 'Member'
-                then: [t: "è un membro di"]     	# 	(en: 'is a member of', google translation)
+                then: [T: "è un membro di"]       #   (en: 'is a member of')
               - else_if: $ClearSpeak_SetMemberSymbol = 'Element'
-                then: [t: "è un elemento di"]   	# 	(en: 'is an element of', google translation)
+                then: [T: "è un elemento di"]     #   (en: 'is an element of')
               - else_if: $ClearSpeak_SetMemberSymbol = 'In'
-                then: [t: "è in"]               	# 	(en: 'is in', google translation)
-              - else: [t: "appartenente a"]     	#  $ClearSpeak_SetMemberSymbol = 'Belongs'	(en: 'belongs to')
- - "∉":                                         	#  0x2209
+                then: [T: "è in"]                 #   (en: 'is in')
+              - else: [T: "appartenente a"]       #  $ClearSpeak_SetMemberSymbol = 'Belongs'  (en: 'belongs to')
+ - "∉":                                           #  0x2209
     # rule is identical to 0x2208
      - test:
         if: "$SpeechStyle != 'ClearSpeak'"
-        then: [t: "non è un elemento di"]       	# 	(en: 'is not an element of', google translation)
+        then: [T: "non è un elemento di"]         #   (en: 'is not an element of')
         # Several options for speaking elements in ClearSpeak -- they split between being inside a set or not and then the option
         else_test:
-            if: "../../self::m:set or ../../../self::m:set"	#  inside a set
+            if: "../../self::m:set or ../../../self::m:set" #  inside a set
             then_test:
               - if: $ClearSpeak_SetMemberSymbol = 'Auto' or $ClearSpeak_SetMemberSymbol = 'In'
-                then: [t: "non in"]             	# 	(en: 'not in', google translation)
+                then: [T: "non in"]               #   (en: 'not in')
               - else_if: $ClearSpeak_SetMemberSymbol = 'Member'
-                then: [t: "non membro di"]      	# 	(en: 'not member of', google translation)
+                then: [T: "non membro di"]        #   (en: 'not member of')
               - else_if: $ClearSpeak_SetMemberSymbol = 'Element'
-                then: [t: "non elemento di"]    	# 	(en: 'not element of', google translation)
-              - else: [t: "non appartenente a"] 	#  $ClearSpeak_SetMemberSymbol = 'Belongs'	(en: 'not belonging to')
+                then: [T: "non elemento di"]      #   (en: 'not element of')
+              - else: [T: "non appartenente a"]   #  $ClearSpeak_SetMemberSymbol = 'Belongs'  (en: 'not belonging to')
             else_test:
               - if: $ClearSpeak_SetMemberSymbol = 'Auto' or $ClearSpeak_SetMemberSymbol = 'Member'
-                then: [t: "non è un membro di"] 	# 	(en: 'is not a member of', google translation)
+                then: [T: "non è un membro di"]   #   (en: 'is not a member of')
               - else_if: $ClearSpeak_SetMemberSymbol = 'Element'
-                then: [t: "non è un elemento di"]	# 	(en: 'is not an element of', google translation)
+                then: [T: "non è un elemento di"] #   (en: 'is not an element of')
               - else_if: $ClearSpeak_SetMemberSymbol = 'In'
-                then: [t: "non è in"]           	# 	(en: 'is not in', google translation)
-              - else: [t: "non appartenente a"] 	#  $ClearSpeak_SetMemberSymbol = 'Belongs'	(en: 'does not belong to')
- - "∊":                                         	#  0x220a
+                then: [T: "non è in"]             #   (en: 'is not in')
+              - else: [T: "non appartiene a"]     #  $ClearSpeak_SetMemberSymbol = 'Belongs'  (en: 'does not belong to')
+ - "∊":                                           #  0x220a
      - test:
         if: "$SpeechStyle != 'ClearSpeak'"
-        then: [t: "è un elemento di"]           	# 	(en: 'is an element of', google translation)
+        then: [T: "è un elemento di"]             #   (en: 'is an element of')
         # Several options for speaking elements in ClearSpeak -- they split between being inside a set or not and then the option
         else_test:
-            if: "../../self::m:set or ../../../self::m:set"	#  inside a set
+            if: "../../self::m:set or ../../../self::m:set" #  inside a set
             then_test:
               - if: $ClearSpeak_SetMemberSymbol = 'Auto' or $ClearSpeak_SetMemberSymbol = 'In'
-                then: [t: "in"]                 	# 	(google translation)
+                then: [T: "in"]                   #   (en: 'in')
               - else_if: $ClearSpeak_SetMemberSymbol = 'Member'
-                then: [t: "membro di"]          	# 	(en: 'member of', google translation)
+                then: [T: "membro di"]            #   (en: 'member of')
               - else_if: $ClearSpeak_SetMemberSymbol = 'Element'
-                then: [t: "elemento di"]        	# 	(en: 'element of', google translation)
-              - else: [t: "appartenente a"]     	#  $ClearSpeak_SetMemberSymbol = 'Belongs'	(en: 'belonging to')
+                then: [T: "elemento di"]          #   (en: 'element of')
+              - else: [T: "appartenente a"]       #  $ClearSpeak_SetMemberSymbol = 'Belongs'  (en: 'belonging to')
             else_test:
               - if: $ClearSpeak_SetMemberSymbol = 'Auto' or $ClearSpeak_SetMemberSymbol = 'Member'
-                then: [t: "è un membro di"]     	# 	(en: 'is a member of', google translation)
+                then: [T: "è un membro di"]       #   (en: 'is a member of')
               - else_if: $ClearSpeak_SetMemberSymbol = 'Element'
-                then: [t: "è un elemento di"]   	# 	(en: 'is an element of', google translation)
+                then: [T: "è un elemento di"]     #   (en: 'is an element of')
               - else_if: $ClearSpeak_SetMemberSymbol = 'In'
-                then: [t: "è in"]               	# 	(en: 'is in', google translation)
-              - else: [t: "appartenente a"]     	#  $ClearSpeak_SetMemberSymbol = 'Belongs'	(en: 'belongs to')
- - "∏": [t: "prodotto"]                         	#  0x220f	(en: 'product', SRE: 'produttoria')
- - "∐": [t: "coprodotto"]                       	#  0x2210	(en: 'co-product')
- - "∑": [t: "somma"]                            	#  0x2211	(en: 'sum', SRE: 'sommatoria')
- - "−": [t: "meno"]                             	#  0x2212	(en: 'minus')
- - "∓": [t: "meno più"]                         	#  0x2213	(en: 'minus or plus', MathPlayer: 'meno piu'', google: 'meno o più')
- - "∗": [t: "asterisco"]                        	#  0x2217	(en: 'times', MathPlayer: 'operatore asterisco', google: 'volte')
- - "∘": [t: "composizione"]                     	#  0x2218	(en: 'composed with')
- - "√":                                         	#  0x221a
+                then: [T: "è in"]                 #   (en: 'is in')
+              - else: [T: "appartiene a"]         #  $ClearSpeak_SetMemberSymbol = 'Belongs'  (en: 'belongs to')
+ - "∏": [T: "produttoria"]                        #  0x220f (en: 'product', SRE: 'produttoria')
+ - "∐": [T: "coproduttoria"]                      #  0x2210 (en: 'co-product')
+ - "∑": [T: "sommatoria"]                         #  0x2211 (en: 'sum', SRE: 'sommatoria')
+ - "−": [T: "meno"]                               #  0x2212 (en: 'minus')
+ - "∓": [T: "meno o più"]                         #  0x2213 (en: 'minus or plus', MathPlayer: 'meno piu'', google: 'meno o più')
+ - "∗": [T: "volte"]                              #  0x2217 (en: 'times', MathPlayer: 'operatore asterisco', google: 'volte')
+ - "∘": [T: "composto con"]                       #  0x2218 (en: 'composed with')
+ - "√":                                           #  0x221a
      - test: 
          if: "$Verbosity!='Terse'"
-         then: [t: "il"]                        	# 	(en: 'the', google translation)
-     - t: "radice quadrata"                     	# 	(en: 'square root of', MathPlayer: 'radicale', google: 'radice quadrata di')
- - "∝":                                         	#  0x221d
+         then: [T: "il"]                          #   (en: 'the')
+     - T: "radice quadrata di"                    #   (en: 'square root of', MathPlayer: 'radicale', google: 'radice quadrata di')
+ - "∝":                                           #  0x221d
      - test: 
          if: "$Verbosity!='Terse'"
-         then: [t: "è"]                         	# 	(en: 'is', google translation)
-     - t: "proporzionale a"                     	# 	(en: 'proportional to')
- - "∞": [t: "infinito"]                         	#  0x221e	(en: 'infinity')
- - "∟": [t: "angolo retto"]                     	#  0x221f	(en: 'right angle', MathPlayer: 'angolo destro')
- - "∠": [t: "angolo"]                           	#  0x2220	(en: 'angle')
- - "∡": [t: "angolo misurato"]                  	#  0x2221	(en: 'measured angle')
- - "∣": [t: "divide"]                           	#  0x2223	(en: 'divides')
- - "∤": [t: "non divide"]                       	#  0x2224	(en: 'does not divide')
- - "∥":                                         	#  0x2225
+         then: [T: "è"]                           #   (en: 'is', google translation)
+     - T: "proporzionale a"                       #   (en: 'proportional to')
+ - "∞": [T: "infinito"]                           #  0x221e (en: 'infinity')
+ - "∟": [T: "angolo retto"]                       #  0x221f (en: 'right angle', MathPlayer: 'angolo destro')
+ - "∠": [T: "angolo"]                             #  0x2220 (en: 'angle')
+ - "∡": [T: "ampiezza dell'angolo"]               #  0x2221 (en: 'measured angle')
+ - "∣": [T: "divide"]                             #  0x2223 (en: 'divides')
+ - "∤": [T: "non divide"]                         #  0x2224 (en: 'does not divide')
+ - "∥":                                           #  0x2225
      - test: 
          if: "$Verbosity!='Terse'"
-         then: [t: "è"]                         	# 	(en: 'is', google translation)
-     - t: "parallelo a"                         	# 	(en: 'parallel to')
- - "∦":                                         	#  0x2226
+         then: [T: "è"]                           #   (en: 'is')
+     - T: "parallelo a"                           #   (en: 'parallel to')
+ - "∦":                                           #  0x2226
      - test: 
          if: "$Verbosity!='Terse'"
-         then: [t: "è"]                         	# 	(en: 'is', google translation)
-     - t: "non parallelo a"                     	# 	(en: 'not parallel to')
- - "∧": [t: "e"]                                	#  0x2227	(en: 'and')
- - "∨": [t: "o"]                                	#  0x2228	(en: 'or')
- - "∩": [t: "intersezione"]                     	#  0x2229	(en: 'intersection')
- - "∪": [t: "unione"]                           	#  0x222a	(en: 'union')
- - "∫": [t: "integrale"]                        	#  0x222b	(en: 'integral')
- - "∬": [t: "integrale doppio"]                 	#  0x222c	(en: 'double integral')
- - "∭": [t: "integrale triplo"]                 	#  0x222d	(en: 'triple integral')
- - "∮": [t: "integrale di contorno"]            	#  0x222e	(en: 'contour integral')
- - "∶":                                         	#  0x2236
+         then: [T: "è"]                           #   (en: 'is')
+     - T: "non parallelo a"                       #   (en: 'not parallel to')
+ - "∧": [T: "e"]                                  #  0x2227 (en: 'and')
+ - "∨": [T: "o"]                                  #  0x2228 (en: 'or')
+ - "∩": [T: "intersezione"]                       #  0x2229 (en: 'intersection')
+ - "∪": [T: "unione"]                             #  0x222a (en: 'union')
+ - "∫": [T: "integrale"]                          #  0x222b (en: 'integral')
+ - "∬": [T: "integrale doppio"]                   #  0x222c (en: 'double integral')
+ - "∭": [T: "integrale triplo"]                   #  0x222d (en: 'triple integral')
+ - "∮": [T: "integrale di contorno"]              #  0x222e (en: 'contour integral')
+ - "∶":                                           #  0x2236
      - test: 
          if: "$Verbosity!='Terse'"
-         then: [t: "è"]                         	# 	(en: 'is', google translation)
-     - t: "rapporto"                            	# 	(en: 'to')
- - "∷": [t: "proporzione"]                      	#  0x2237	(en: 'as')
- - "∼": [t: "tilde"]                            	#  0x223c	(en: 'varies with', MathPlayer: 'operatore tilde', google: 'varia con')
- - "∽": [t: "tilde invertita"]                  	#  0x223d	(en: 'reversed tilde', MathPlayer: 'reversed tilde', google: 'tilde invertito')
- - "∾":                                         	#  0x223e
+         then: [T: "è"]                           #   (en: 'is')
+     - T: "in rapporto"                           #   (en: 'to')
+ - "∷": [T: "come"]                               #  0x2237 (en: 'as')
+ - "∼": [T: "varia con"]                          #  0x223c (en: 'varies with', MathPlayer: 'operatore tilde', google: 'varia con')
+ - "∽": [T: "tilde invertita"]                    #  0x223d (en: 'reversed tilde', MathPlayer: 'reversed tilde', google: 'tilde invertito')
+ - "∾":                                           #  0x223e
      - test: 
          if: "$Verbosity!='Terse'"
-         then: [t: "è"]                         	# 	(en: 'is', google translation)
-     - t: "s invertita"                         	# 	(en: 'most positive', MathPlayer: 'inverted lazy s', google: 'più positivo')
- - "∿": [t: "onda seno"]                        	#  0x223f	(en: 'sine wave')
- - "≠":                                         	#  0x2260
+         then: [T: "è"]                           #   (en: 'is')
+     - T: "il più positivo"                       #   (en: 'most positive', MathPlayer: 'inverted lazy s', google: 'più positivo')
+ - "∿": [T: "onda seno"]                          #  0x223f (en: 'sine wave')
+ - "≠":                                           #  0x2260
      - test: 
          if: "$Verbosity!='Terse'"
-         then: [t: "è"]                         	# 	(en: 'is', google translation)
-     - t: "diverso da"                          	# 	(en: 'not equal to')
- - "≡":                                         	#  0x2261
+         then: [T: "è"]                           #   (en: 'is')
+     - T: "diverso da"                            #   (en: 'not equal to')
+ - "≡":                                           #  0x2261
      - test: 
          if: "$Verbosity!='Terse'"
-         then: [t: "è"]                         	# 	(en: 'is', google translation)
-     - t: "identico a"                          	# 	(en: 'identical to')
- - "≤":                                         	#  0x2264
+         then: [T: "è"]                           #   (en: 'is')
+     - T: "identico a"                            #   (en: 'identical to')
+ - "≤":                                           #  0x2264
      - test: 
          if: "$Verbosity!='Terse'"
-         then: [t: "è"]                         	# 	(en: 'is', google translation)
-     - t:  "less than or equal to"
- - "≥":                                         	#  0x2265
+         then: [T: "è"]                           #   (en: 'is')
+     - T:  "minora o uguale a"
+ - "≥":                                           #  0x2265
      - test: 
          if: "$Verbosity!='Terse'"
-         then: [t: "è"]                         	# 	(en: 'is', google translation)
-     - t: "maggiore o uguale a"                 	# 	(en: 'greater than or equal to')
- - "≦": [t: "minore di sopra uguale a"]         	#  0x2266	(en: 'less than over equal to')
- - "≧": [t: "maggiore di sopra uguale a"]       	#  0x2267	(en: 'greater than over equal to')
- - "≺": [t: "precede"]                          	#  0x227a	(en: 'precedes')
- - "≻": [t: "segue"]                            	#  0x227b	(en: 'succeeds')
- - "⊂":                                         	#  0x2282
+         then: [T: "è"]                           #   (en: 'is')
+     - T: "maggiore o uguale a"                   #   (en: 'greater than or equal to')
+ - "≦": [T: "minore o uguale a"]                  #  0x2266 (en: 'less than over equal to')
+ - "≧": [T: "maggiore o uguale a"]                #  0x2267 (en: 'greater than over equal to')
+ - "≺": [T: "precede"]                            #  0x227a (en: 'precedes')
+ - "≻": [T: "segue"]                              #  0x227b (en: 'succeeds')
+ - "⊂":                                           #  0x2282
      - test: 
          if: "$Verbosity!='Terse'"
-         then: [t: "è un"]                      	# 	(en: 'is a', google translation)
-     - t: "sottoinsieme di"                     	# 	(en: 'subset of')
- - "⊃":                                         	#  0x2283
+         then: [T: "è un"]                        #   (en: 'is a')
+     - T: "sottoinsieme di"                       #   (en: 'subset of')
+ - "⊃":                                           #  0x2283
      - test: 
          if: "$Verbosity!='Terse'"
-         then: [t: "è un"]                      	# 	(en: 'is a', google translation)
-     - t: "superinsieme di"                     	# 	(en: 'superset of')
- - "⊄":                                         	#  0x2284
+         then: [T: "è un"]                        #   (en: 'is a')
+     - T: "soprainsieme di"                       #   (en: 'superset of')
+ - "⊄":                                           #  0x2284
      - test: 
          if: "$Verbosity!='Terse'"
-         then: [t: "è"]                         	# 	(en: 'is', google translation)
-     - t: "non un sottoinsieme di"              	# 	(en: 'not a subset of')
- - "⊅":                                         	#  0x2285
+         then: [T: "è"]                           #   (en: 'is')
+     - T: "non un sottoinsieme di"                #   (en: 'not a subset of')
+ - "⊅":                                           #  0x2285
      - test: 
          if: "$Verbosity!='Terse'"
-         then: [t: "è"]                         	# 	(en: 'is', google translation)
-     - t: "non un super insieme di"             	# 	(en: 'not a superset of')
- - "⊆":                                         	#  0x2286
+         then: [T: "è"]                           #   (en: 'is')
+     - T: "non un soprainsieme di"                #   (en: 'not a superset of')
+ - "⊆":                                           #  0x2286
      - test: 
          if: "$Verbosity!='Terse'"
-         then: [t: "è un"]                      	# 	(en: 'is a', google translation)
-     - t: "sottoinsieme di o uguale a"          	# 	(en: 'subset of or equal to')
- - "⊇":                                         	#  0x2287
+         then: [t: "è un"]                        #   (en: 'is a', google translation)
+     - t: "sottoinsieme proprio o improprio di"   #   (en: 'subset of or equal to')
+ - "⊇":                                           #  0x2287
      - test: 
          if: "$Verbosity!='Terse'"
-         then: [t: "è un"]                      	# 	(en: 'is a', google translation)
-     - t: "superinsieme di o uguale a"          	# 	(en: 'superset of or equal to')
+         then: [t: "è un"]                        #   (en: 'is a', google translation)
+     - t: "soprainsieme proprio p improprio di"   #   (en: 'superset of or equal to')


### PR DESCRIPTION
I am working on the Italian translation. The only file that still needs to be translated (completely) is `unicode-full.yaml`. This PR does the following:

  - Translate `ClearSpeak_Rules.yaml`, `unicode.yaml`
  - Revise `navigate.yaml`, `definitions.yaml`, `SimpleSpeak_Rules.yaml`
  - Revise SharedRules for Italian

I have read the ["Translator and Rule Developer Guide"](https://nsoiffer.github.io/MathCAT/helpers.html) and I am going to implement some tests in Rust. I would also like to try out the translations, but I am not an NVDA user, how can I try them out in another way? FYI, I am working on an Ubuntu Linux machine.

Also, I was wondering if the current files that I have translated are up to date. For example, I have compared the file in [`it/SharedRules/calculus.yaml`](https://github.com/CristianCantoro/MathCAT/blob/it/Rules/Languages/it/SharedRules/calculus.yaml) with the latest version of [`en/SharedRules/calculus.yaml`](https://github.com/NSoiffer/MathCAT/blob/main/Rules/Languages/en/SharedRules/calculus.yaml) and they are different.