### PR TITLE
Update Italian translation

### DIFF
--- a/Rules/Languages/it/ClearSpeak_Rules.yaml
+++ b/Rules/Languages/it/ClearSpeak_Rules.yaml
@@ -498,7 +498,7 @@
       then:
       - test:
           if: "$Verbosity!='Terse'"
-          then: [t: "l'"]      # phrase('the' set of all integers)
+          then: [T: "l'"]      # phrase('the' set of all integers)
       - T: "insieme di"      # phrase(this is a 'set of' numbers)
       - test:
           if: $ClearSpeak_Sets != 'woAll'

--- a/Rules/Languages/it/SharedRules/default.yaml
+++ b/Rules/Languages/it/SharedRules/default.yaml
@@ -23,7 +23,7 @@
   tag: mrow
   match: "not(*)"
   replace:
-  - t: "" # say nothing -- placeholder
+  - T: "" # say nothing -- placeholder
 
 - name: default
   tag: mrow
@@ -62,7 +62,7 @@
   tag: ms
   match: "."
   replace:
-  - t: "la stringa"      # phrase('the string' is long)
+  - T: "la stringa"      # phrase('the string' is long)
   - pause: short
   - x: "text()"
 
@@ -82,7 +82,7 @@
   - "not(ancestor::*[name() != 'mrow'][1]/self::m:fraction)" # FIX: can't test for mrow -- what should be used???
   replace:
   - x: "*[1]"
-  - t: "la frazione x "               # phrase("the fraction x 'over' y")
+  - T: "fratto"               # phrase("the fraction x 'over' y")
   - x: "*[2]"
   - pause: short
 
@@ -90,13 +90,13 @@
   tag: mfrac
   match: "."
   replace:
-  - t: "start"              # phrase("'start'  fraction x over y end of fraction")
+  - T: "inizio"              # phrase("'start'  fraction x over y end of fraction")
   - pause: short
   - x: "*[1]"
   - test:
       if: "not(IsNode(*[1],'leaf'))"
       then: [pause: short]
-  - t: "la frazione x "               # phrase("the fraction x 'over' y")
+  - T: "fratto"               # phrase("the fraction x 'over' y")
   - test:
       if: "not(IsNode(*[2],'leaf'))"
       then: [pause: short]
@@ -104,7 +104,7 @@
   - pause: short
   - test:
       if: "$Impairment = 'Blindness'"
-      then: [t: "inizio della frazione x su y "]          # phrase("start of fraction x over y 'end over'")
+      then: [T: "fine fratto"]          # phrase("start of fraction x over y 'end over'")
   - pause: medium
 
 
@@ -115,16 +115,16 @@
   replace:
   - test:
       if: "$Verbosity!='Terse'"
-      then: [t: "la"]    # phrase("'the' root of x")
-  - t: "simbolo di radice"
+      then: [T: "la"]    # phrase("'the' root of x")
+  - T: "radice"
   - test:
       if: "$Verbosity!='Terse'"
-      then: [t: "la radice"]    # phrase("the root 'of' x")
+      then: [T: "di"]    # phrase("the root 'of' x")
   - x: "*[1]"
   - pause: short
   - test:
       if: "not(IsNode(*[1],'leaf')) or $Impairment = 'Blindness'"
-      then: [t: "root of x "] # phrase("root of x 'end root symbol'")
+      then: [T: "fine simbolo di radice"] # phrase("root of x 'end root symbol'")
 
 # not sure what really should be said for these since we should not assume they are square roots
 - name: structure-default
@@ -156,7 +156,7 @@
   - x: "*[1]"
   - test:
       if: "$Verbosity!='Terse' or not(*[2][self::m:mn])" # just say "x 1" for terse vs "x sub 1"
-      then: [t: "sub"]      # phrase(x 'sub' 2)
+      then: [T: "pedice"]      # phrase(x 'sub' 2)
   - x: "*[2]"
 
 - name: default
@@ -164,11 +164,11 @@
   match: "count(*)=2"
   replace:
   - x: "*[1]"
-  - t: "sub"               # phrase(x 'sub' 2)
+  - T: "pedice"               # phrase(x 'sub' 2)
   - x: "*[2]"
   - test:
       if: "$Impairment = 'Blindness'"
-      then: [t: "fine del sub"]           # phrase(x sub 2 'end of sub')
+      then: [T: "fine pedice"]           # phrase(x sub 2 'end of sub')
   - pause: short
 
 
@@ -177,7 +177,7 @@
   match: "."
   replace:
   - x: "*[1]"
-  - t: "sub"              # phrase(x 'sub' 2)
+  - T: "pedice"              # phrase(x 'sub' 2)
   - x: "*[2]"
 
 - name: structure
@@ -188,7 +188,7 @@
   - test:
       if: "name(.)='msubsup'"
       then:
-      - t: "sub"          # phrase(x 'sub' 2)
+      - T: "pedice"          # phrase(x 'sub' 2)
       - x: "*[2]"
   - test:
       if: "*[last()][translate(., '′″‴⁗†‡°*', '')='']"
@@ -196,15 +196,15 @@
       else_test:
           if: "ancestor-or-self::*[contains(@data-intent-property, ':structure:')]"  # FIX: is this test necessary?
           then:
-          - t: "super"      # phrase(x 'super' 2)
+          - T: "apice"      # phrase(x 'super' 2)
           - x: "*[last()]"
           - test:
               if: "not(IsNode(*[last()], 'simple')) or $Impairment = 'Blindness'"
-              then: [t: "end of super"]      # phrase(x super 2 'end of super')
+              then: [T: "fine apice"]      # phrase(x super 2 'end of super')
           else:
-          - t: "cresciuto al"            # phrase(5 'raised to the' second power equals 25)
+          - T: "elevato alla"            # phrase(5 'raised to the' second power equals 25)
           - x: "*[last()]"
-          - t: "potere"                    # phrase(5 raised to the second 'power' equals 25)
+          - T: "potenza"                    # phrase(5 raised to the second 'power' equals 25)
 
 - name: default
   tag: munder
@@ -212,11 +212,11 @@
   replace:
   - test:
       if: "not(IsNode(*[1], 'leaf'))"
-      then: [t: "modificata"]      # phrase(phrase(x 'modified' with y above it)
+      then: [T: "modificata"]      # phrase(phrase(x 'modified' with y above it)
   - x: "*[1]"
-  - t: "con"      # phrase(x 'with' z below it)
+  - T: "con"      # phrase(x 'with' z below it)
   - x: "*[2]"
-  - t: "sotto"      # phrase(x with z 'below' it)
+  - T: "al di sotto"      # phrase(x with z 'below' it)
 
 - name: diacriticals
   tag: mover
@@ -231,11 +231,11 @@
   replace:
   - test:
       if: "not(IsNode(*[1], 'leaf'))"
-      then: [t: "modificata"]      # phrase(phrase(x 'modified' with y above it)
+      then: [T: "modificata"]      # phrase(phrase(x 'modified' with y above it)
   - x: "*[1]"
-  - t: "con"         # phrase(x modified 'with' y above it)
+  - T: "con"         # phrase(x modified 'with' y above it)
   - x: "*[2]"
-  - t: "con"        # phrase(x modified 'with' y above it)
+  - T: "con"        # phrase(x modified 'with' y above it)
 
 - name: default
   tag: munderover
@@ -243,13 +243,13 @@
   replace:
   - test:
       if: "not(IsNode(*[1], 'leaf'))"
-      then: [t: "equazione è stata "]      # phrase(the equation has been 'modified')
+      then: [T: "modificata"]      # phrase(the equation has been 'modified')
   - x: "*[1]"
-  - t: "con"         # phrase(x modified 'with' y above it)
+  - T: "con"         # phrase(x modified 'with' y above it)
   - x: "*[2]"
-  - t: "sotto e"    # phrase(x modified with y 'below and' y above it)
+  - T: "sotto e"    # phrase(x modified with y 'below and' y above it)
   - x: "*[3]"
-  - t: "sopra"        # phrase(x modified with y 'above' it)
+  - T: "sopra"        # phrase(x modified with y 'above' it)
 
 - name: default
   #   Here we support up to 2 prescripts and up to 4 postscripts -- that should cover all reasonable cases
@@ -276,9 +276,9 @@
           - test: # only bother announcing if there is more than one prescript
               if: "count($Prescripts) > 2"
               then:
-              - t: "con"      # phrase(substitute x 'with' y)
+              - T: "con"      # phrase(substitute x 'with' y)
               - x: "count($Prescripts) div 2"
-              - t: "prescrizioni"      # phrase(in this equation certain 'prescripts' apply)
+              - T: "indici a sinistra"      # phrase(in this equation certain 'prescripts' apply)
               - pause: short
           - test:
               if: "not($Prescripts[1][self::m:none])"
@@ -287,7 +287,7 @@
               - x: "$Prescripts[1]"
           - test:
               if: "not($Prescripts[1][self::m:none] or $Prescripts[2][self::m:none])"
-              then: [t: "e"]      # phrase(10 is greater than 8 'and' less than 15)
+              then: [T: "e"]      # phrase(10 is greater than 8 'and' less than 15)
           - test:
               if: "not($Prescripts[2][self::m:none])"
               then:
@@ -304,7 +304,7 @@
                   - x: "$Prescripts[3]"
               - test:
                   if: "not($Prescripts[3][self::m:none] or $Prescripts[4][self::m:none])"
-                  then: [t: "e"]      # phrase(10 is grater than 8 'and' less than 15)
+                  then: [T: "e"]      # phrase(10 is grater than 8 'and' less than 15)
               - test:
                   if: "not($Prescripts[4][self::m:none])"
                   then:
@@ -313,9 +313,9 @@
               - test:
                   if: "count($Prescripts) > 4" # give up and just dump them out so at least the content is there
                   then:
-                  - t: "e prescrizioni alternate"      # phrase(in this case there are values 'and alternating prescripts')
+                  - T: "e indici a sinistra alternati"      # phrase(in this case there are values 'and alternating prescripts')
                   - x: "$Prescripts[position() > 4]"
-                  - t: "prescrizioni di fine"      # phrase(This is where 'end prescripts' occurs)
+                  - T: "fine indici a sinistra"      # phrase(This is where 'end prescripts' occurs)
   - test:
       if: "$Postscripts"
       then:
@@ -329,10 +329,10 @@
               then:
               - test:
                   if: "$Prescripts"
-                  then: [t: "e"]      # phrase(10 is greater than 8 'and' less than 15)
-              - t: "con"      # phrase(substitute x 'with' y)
+                  then: [T: "e"]      # phrase(10 is greater than 8 'and' less than 15)
+              - T: "con"      # phrase(substitute x 'with' y)
               - x: "count($Postscripts) div 2"
-              - t: "post -script"      # phrase(this material includes several 'postscripts')
+              - T: "indici a destra"      # phrase(this material includes several 'postscripts')
               - pause: short
           - test:
               if: "not($Postscripts[1][self::m:none])"
@@ -341,7 +341,7 @@
               - x: "$Postscripts[1]"
           - test:
               if: "not($Postscripts[1][self::m:none] or $Postscripts[2][self::m:none])"
-              then: [t: "e"]      # phrase(10 is greater than 8 'and' less than 15)
+              then: [T: "e"]      # phrase(10 is greater than 8 'and' less than 15)
           - test:
               if: "not($Postscripts[2][self::m:none])"
               then:
@@ -357,7 +357,7 @@
                   - x: "$Postscripts[3]"
               - test:
                   if: "not($Postscripts[3][self::m:none] or $Postscripts[4][self::m:none])"
-                  then: [t: "e"]      # phrase(10 is greater than 8 'and' less than 15)
+                  then: [T: "e"]      # phrase(10 is greater than 8 'and' less than 15)
               - test:
                   if: "not($Postscripts[4][self::m:none])"
                   then:
@@ -373,7 +373,7 @@
                       - x: "$Postscripts[5]"
                   - test:
                       if: "not($Postscripts[5][self::m:none] or $Postscripts[6][self::m:none])"
-                      then: [t: "e"]      # phrase(10 is greater than 8 'and' less than 15)
+                      then: [T: "e"]      # phrase(10 is greater than 8 'and' less than 15)
                   - test:
                       if: "not($Postscripts[6][self::m:none])"
                       then:
@@ -389,7 +389,7 @@
                           - x: "$Postscripts[7]"
                       - test:
                           if: "not($Postscripts[7][self::m:none] or $Postscripts[8][self::m:none])"
-                          then: [t: "e"]      # phrase(10 is less than 15 'and' greater than 5)
+                          then: [T: "e"]      # phrase(10 is less than 15 'and' greater than 5)
                       - test:
                           if: "not($Postscripts[8][self::m:none])"
                           then:
@@ -398,16 +398,16 @@
                       - test:
                           if: "count($Postscripts) > 8" # give up and just dump them out so at least the content is there
                           then:
-                          - t: "e script alternati"      # phrase(this situation involves complexities 'and alternating scripts')
+                          - T: "e indici alternati"      # phrase(this situation involves complexities 'and alternating scripts')
                           - x: "$Postscripts[position() > 8]"
-                          - t: "script di fine"      # phrase(At this point 'end scripts' occurs)
+                          - T: "fine indici"      # phrase(At this point 'end scripts' occurs)
 
 - name: default
   tag: mtable
   variables: [IsColumnSilent: false()]
   match: "."
   replace:
-  - t: "tavolo con"      # phrase(the 'table with' 3 rows)
+  - T: "tabella con"      # phrase(the 'table with' 3 rows)
   - x: count(*)
   - test:
       if: count(*)=1
@@ -417,8 +417,8 @@
   - x: "count(*[1]/*)"
   - test:
       if: "count(*[1]/*)=1"
-      then: [t: "colonna"]      # phrase(the table with 3 rows and 1 'column')
-      else: [t: "colonne"]      # phrase(the table with 3 rows and 4 'columns')
+      then: [T: "colonna"]      # phrase(the table with 3 rows and 1 'column')
+      else: [T: "colonne"]      # phrase(the table with 3 rows and 4 'columns')
   - pause: long
   - x: "*"
 
@@ -428,12 +428,12 @@
   tag: [mtr, mlabeledtr]
   match: "."
   replace:
-  - t: "riga"      # phrase(the first 'row' of a matrix)
+  - T: "riga"      # phrase(the first 'row' of a matrix)
   - x: "count(preceding-sibling::*)+1"
   - test:
       if: .[self::m:mlabeledtr]
       then:
-      - t: "con etichetta"      # phrase(the line 'with label' first equation)
+      - T: "con etichetta"      # phrase(the line 'with label' first equation)
       - x: "*[1]/*"
       - pause: short
   - pause: medium
@@ -452,7 +452,7 @@
       #   if: not($IsColumnSilent) and ($ClearSpeak_Matrix = 'SpeakColNum' or count(preceding-sibling::*) != 0)
       if: "not($IsColumnSilent)"
       then:
-      - t: "colonna"      # phrase(the first 'column' of the matrix)
+      - T: "colonna"      # phrase(the first 'column' of the matrix)
       - x: "count(preceding-sibling::*)+1"
       - pause: medium
   - x: "*"
@@ -471,7 +471,7 @@
   tag: menclose
   match: "@notation='box' and *[self::m:mtext and text()=' ']"
   replace:
-  - t: "casella vuota"      # phrase(the 'empty box' contains no values)
+  - T: "casella vuota"      # phrase(the 'empty box' contains no values)
 
 - name: default
   # The ordering below is the order in which words come out when there is more than one value
@@ -481,29 +481,29 @@
   replace:
   - test:
       if: ".[contains(concat(' ', normalize-space(@notation), ' '), ' box ')]"
-      then: [t: "scatola", pause: short]      # phrase(the 'box' around the expression)
+      then: [T: "riquadro", pause: short]      # phrase(the 'box' around the expression)
   - test:
       if: ".[contains(@notation,'roundedbox')]"
-      then: [T: "rettangolo arrotondato", pause: short]      # phrase(the 'round box' around the expression)
+      then: [T: "riquadro arrotondato", pause: short]      # phrase(the 'round box' around the expression)
   - test:
       if: ".[contains(@notation,'circle')]"
-      then: [t: "cerchio", pause: short]      # phrase(the 'circle' around the expression)
+      then: [T: "circolo", pause: short]      # phrase(the 'circle' around the expression)
   - test:
       if: ".[ contains(concat(' ', normalize-space(@notation), ' '), ' left ') or contains(concat(' ', normalize-space(@notation), ' '), ' right ') or contains(@notation,'top') or contains(@notation,'bottom') ]"
       then:
-      - t: "riga"      # phrase(draw a straight 'line' on the page)
+      - T: "linea"      # phrase(draw a straight 'line' on the page)
       - test:
           if: ".[contains(concat(' ', normalize-space(@notation), ' '), ' left ')]"
-          then: [t: "sinistra", pause: short]      # phrase(line on 'left' of the expression)
+          then: [T: "a sinistra", pause: short]      # phrase(line on 'left' of the expression)
       - test:
           if: ".[contains(concat(' ', normalize-space(@notation), ' '), ' right ')]"
-          then: [t: "giusto", pause: short]      # phrase(line on 'right' of the expression)
+          then: [T: "a destra", pause: short]      # phrase(line on 'right' of the expression)
       - test:
           if: ".[contains(@notation,'top')]"
-          then: [t: "top", pause: short]      # phrase(line on 'top' of the expression)
+          then: [T: "sopra", pause: short]      # phrase(line on 'top' of the expression)
       - test:
           if: ".[contains(@notation,'bottom')]"
-          then: [t: "fondo", pause: short]      # phrase(line on the 'bottom' of the expression)
+          then: [T: "sotto", pause: short]      # phrase(line on the 'bottom' of the expression)
   - test:
       if: ".[ contains(@notation,'updiagonalstrike') or contains(@notation,'downdiagonalstrike') or contains(@notation,'verticalstrike') or contains(@notation,'horizontalstrike') ]"
       then:
@@ -516,14 +516,14 @@
               then: [T: "diagonale verso l'alto", pause: short]      # phrase(the line runs 'up diagonal')
           - test:
               if: ".[contains(@notation,'downdiagonalstrike')]"
-              then: [t: "giù diagonale", pause: short]      # phrase(the line runs 'down diagonal')
+              then: [T: "diagonale verso il basso", pause: short]      # phrase(the line runs 'down diagonal')
       - test:
           if: ".[contains(@notation,'verticalstrike')]"
-          then: [t: "verticale", pause: short]      # phrase(the line is  'vertical')
+          then: [T: "verticale", pause: short]      # phrase(the line is  'vertical')
       - test:
           if: ".[contains(@notation,'horizontalstrike')]"
-          then: [t: "orizzontale", pause: short]      # phrase(the line is 'horizontal')
-      - t: "crompi"      # phrase(please 'cross out' the incorrect answer)
+          then: [T: "orizzontale", pause: short]      # phrase(the line is 'horizontal')
+      - T: "barrare"      # phrase(please 'cross out' the incorrect answer)
       - pause: short
   - test:
       if: ".[contains(@notation,'uparrow')]"
@@ -539,22 +539,22 @@
       then: [T: "freccia verso destra", pause: short]      # phrase(the 'right arrow' indicates moving forward)
   - test:
       if: ".[contains(@notation,'northeastarrow')]"
-      then: [t: "freccia nord -est", pause: short]      # phrase(direction is indicated by the 'northeast arrow')
+      then: [T: "freccia verso nord-est", pause: short]      # phrase(direction is indicated by the 'northeast arrow')
   - test:
       if: ".[contains(concat(' ', normalize-space(@notation), ' '), ' southeastarrow ')]"
-      then: [t: "freccia sud -est", pause: short]      # phrase(direction is shown by the 'southeast arrow')
+      then: [T: "freccia verso sud-est", pause: short]      # phrase(direction is shown by the 'southeast arrow')
   - test:
       if: ".[contains(concat(' ', normalize-space(@notation), ' '), ' southwestarrow ')]"
       then: [T: "freccia verso sud-ovest", pause: short]      # phrase(direction is shown by the 'southwest arrow')
   - test:
       if: ".[contains(@notation,'northwestarrow')]"
-      then: [t: "freccia del nord -ovest", pause: short]      # phrase(direction is shown by the 'northwest arrow')
+      then: [T: "freccia verso nord-ovest", pause: short]      # phrase(direction is shown by the 'northwest arrow')
   - test:
       if: ".[contains(@notation,'updownarrow')]"
       then: [T: "freccia verticale a doppia estremità", pause: short]      # phrase(upward movement is indicated by the 'double ended vertical arrow')
   - test:
       if: ".[contains(@notation,'leftrightarrow')]"
-      then: [t: "freccia orizzontale a doppia estremità", pause: short]      # phrase(progress is indicated by the 'double ended horizontal arrow')
+      then: [T: "freccia orizzontale a doppia estremità", pause: short]      # phrase(progress is indicated by the 'double ended horizontal arrow')
   - test:
       if: ".[contains(@notation,'northeastsouthwestarrow')]"
       then: [T: "freccia diagonale verso l'alto a doppia estremità", pause: short]      # phrase(trend is indicated by the 'double ended up diagonal arrow')
@@ -563,27 +563,27 @@
       then: [T: "freccia diagonale verso il basso a doppia estremità", pause: short]      # phrase(trend is indicated by the 'double ended down diagonal arrow')
   - test:
       if: ".[contains(@notation,'actuarial')]"
-      then: [t: "simbolo attuariale", pause: short]      # phrase(the 'actuarial symbol' represents a specific quantity)
+      then: [T: "simbolo attuariale", pause: short]      # phrase(the 'actuarial symbol' represents a specific quantity)
   - test:
       if: ".[contains(@notation,'madrub')]"
-      then: [t: "simbolo fattoriale arabo", pause: short]      # phrase(the 'arabic factorial symbol' represents a factorial operation)
+      then: [T: "simbolo fattoriale arabo", pause: short]      # phrase(the 'arabic factorial symbol' represents a factorial operation)
   - test:
       if: ".[contains(@notation,'phasorangle')]"
       then: [T: "angolo di fase", pause: short]      # phrase(the 'phasor angle' is used to measure electrical current)
   - test:
       if: ".[contains(@notation,'longdiv') or not(@notation) or normalize-space(@notation) ='']" # default
-      then: [t: "simbolo della divisione lunga", pause: short]      # phrase(the 'long division symbol' indicates  a long division calculation)
+      then: [T: "simbolo della divisione lunga", pause: short]      # phrase(the 'long division symbol' indicates  a long division calculation)
   - test:
       if: ".[contains(@notation,'radical')]"
-      then: [t: "radice quadrata", pause: short]      # phrase(5 is the 'square root' of 25)
-  - t: "racchiudono"      # phrase(parentheses are 'enclosing' part of the equation)
+      then: [T: "radice quadrata", pause: short]      # phrase(5 is the 'square root' of 25)
+  - T: "racchiudono"      # phrase(parentheses are 'enclosing' part of the equation)
   - test:
       if: "*[self::m:mtext and text()=' ']"
       then: [T: "spazio"]     # otherwise there is complete silence      # phrase(there is a 'space' between the words)
       else: [x: "*"]
   - test:
       if: "$Impairment = 'Blindness' and ( $SpeechStyle != 'SimpleSpeak' or not(IsNode(*[1], 'leaf')) )"
-      then: [t: "recinto finale"]      # phrase(reached the 'end enclosure' point)
+      then: [T: "fine parentesi"]      # phrase(reached the 'end enclosure' point)
   - pause: short
 
 - name: semantics
@@ -603,7 +603,7 @@
   match: .
   replace:
   - x: "*[1]"
-  - t: "applicata a"      # phrase(the function sine 'applied to' x plus y)
+  - T: "applicata a"      # phrase(the function sine 'applied to' x plus y)
   - x: "*[2]"
 
 
@@ -652,7 +652,7 @@
   match: count(*)>0
   replace:
   - x: "translate(name(.), '-_', '  ')"
-  - t: "di"      # phrase(sine 'of' 5)
+  - T: "di"      # phrase(sine 'of' 5)
   - pause: short
   - insert:
       nodes: "*"

--- a/Rules/Languages/it/SharedRules/general.yaml
+++ b/Rules/Languages/it/SharedRules/general.yaml
@@ -8,12 +8,12 @@
   - test:
       if: "$Verbosity!='Terse'"
       then:
-      - t: "la"      # phrase('the' square root of 25 equals 5)
+      - T: "la"      # phrase('the' square root of 25 equals 5)
   - bookmark: "*[2]/@id"
   - test:
     - if: "*[2][text()='+']"
-      then: [t: "positivi"]      # phrase(set of all 'positive' integers less than 10)
-      else: [t: "negativi"]      # phrase(set of all 'negative' integers less than minus 10)
+      then: [T: "positivi"]      # phrase(set of all 'positive' integers less than 10)
+      else: [T: "negativi"]      # phrase(set of all 'negative' integers less than minus 10)
   - bookmark: "*[1]/@id"
   - test:
     - if: "*[1][text()='ℂ']"
@@ -37,15 +37,15 @@
   - bookmark: "*[1]/@id"
   - test:
     - if: "*[1][text()='ℂ']"
-      then: [t: "c"]      # phrase(the letter 'C' used to represent complex number)
+      then: [T: "c"]      # phrase(the letter 'C' used to represent complex number)
     - else_if: "*[1][text()='ℕ']"
-      then: [t: "n"]      # phrase(the letter 'N' may represent natural numbers)
+      then: [T: "n"]      # phrase(the letter 'N' may represent natural numbers)
     - else_if: "*[1][text()='ℚ']"
-      then: [t: "q"]      # phrase(the letter 'Q' may represent rational numbers)
+      then: [T: "q"]      # phrase(the letter 'Q' may represent rational numbers)
     - else_if: "*[1][text()='ℝ']"
-      then: [t: "r"]      # phrase(the letter 'R' may represent real numbers)
+      then: [T: "r"]      # phrase(the letter 'R' may represent real numbers)
     - else_if: "*[1][text()='ℤ']"
-      then: [t: "z"]      # phrase(the letter 'Z' may represent integers)
+      then: [T: "z"]      # phrase(the letter 'Z' may represent integers)
       else: [x: "*[1][text()]"] # shouldn't happen
   - bookmark: "*[2]/@id"
   - x: "*[2]"
@@ -57,15 +57,15 @@
   - bookmark: "@id"
   - test:
     - if: "text()='ℂ'"
-      then: [t: "i numeri complessi"]      # phrase('the complex numbers' include 2 parts)
+      then: [T: "i numeri complessi"]      # phrase('the complex numbers' include 2 parts)
     - else_if: "text()='ℕ'"
-      then: [t: "i numeri naturali"]      # phrase('the natural numbers' begin at 1)
+      then: [T: "i numeri naturali"]      # phrase('the natural numbers' begin at 1)
     - else_if: "text()='ℚ'"
-      then: [t: "i numeri razionali"]      # phrase('the rational numbers' are the fraction of 2 integers)
+      then: [T: "i numeri razionali"]      # phrase('the rational numbers' are the fraction of 2 integers)
     - else_if: "text()='ℝ'"
-      then: [t: "i numeri reali"]      # phrase('the real numbers' can be both positive and negative)
+      then: [T: "i numeri reali"]      # phrase('the real numbers' can be both positive and negative)
     - else_if: "text()='ℤ'"
-      then: [t: "i numeri interi"]      # phrase('the integers' are natural numbers above 0)
+      then: [T: "gli interi"]      # phrase('the integers' are natural numbers above 0)
       else: [x: "text()"] # shouldn't happen
 
 - name: real-part
@@ -73,14 +73,14 @@
   match: "."
   replace:
   - bookmark: "@id"
-  - t: "la parte reale"      # phrase('the real part' of a complex number does not include the imaginary part)
+  - T: "la parte reale"      # phrase('the real part' of a complex number does not include the imaginary part)
 
 - name: imaginary-part
   tag: imaginary-part
   match: "."
   replace:
   - bookmark: "@id"
-  - t: "la parte immaginaria"      # phrase('the imaginary part' is part of a complex number)
+  - T: "la parte immaginaria"      # phrase('the imaginary part' is part of a complex number)
 
 # rules on scripted vertical bars ('evaluated at')
 - name: evaluated-at-2
@@ -89,7 +89,7 @@
   replace:
   - x: "*[1]"
   - pause: auto
-  - t: "valutato a"      # phrase(results were 'evaluated at' a given point)
+  - T: "valutato in"      # phrase(results were 'evaluated at' a given point)
   - pause: auto
   - x: "*[2]"
 
@@ -99,10 +99,10 @@
   replace:
   - x: "*[1]"
   - pause: auto
-  - t: "valutato a"      # phrase(results were 'evaluated at' this point)
+  - T: "valutato in"      # phrase(results were 'evaluated at' this point)
   - pause: auto
   - x: "*[3]"
-  - t: "meno la stessa espressione valutata a"      # phrase(this result is 'minus the same expression evaluated at' an earlier point)
+  - T: "l'opposto della stessa espressione valutata in"      # phrase(this result is 'minus the same expression evaluated at' an earlier point)
   - x: "*[2]"
 
 - name: binomial
@@ -110,7 +110,7 @@
   match: "count(*)=2 and not(@data-intent-property)"
   replace:
   - x: "*[1]"
-  - t: "scegliere"      # phrase(you can 'choose' a number at random)
+  - T: "scegliere"      # phrase(you can 'choose' a number at random)
   - x: "*[2]"
 
 - name: permutation
@@ -118,7 +118,7 @@
   match: "count(*)=2 and not(@data-intent-property)"
   replace:
   - x: "*[2]"
-  - t: "permutazioni di"      # phrase(the solution  involves several 'permutations of' values)
+  - T: "permutazioni dei"      # phrase(the solution  involves several 'permutations of' values)
   - x: "*[1]"
 
 - name: intervals
@@ -128,18 +128,18 @@
   - test:
       if: "$Verbosity!='Terse'"
       then:
-      - t: "la"      # phrase('the' square root of 25 equals 5)
+      - T: "la"      # phrase('the' square root of 25 equals 5)
   - x: "translate(name(.),'-', ' ')"
   - test:
       if: "$Verbosity!='Terse'"
       then:
-      - t: "da"      # phrase(subtracting 5 'from' 10 gives 5)
+      - T: "da"      # phrase(subtracting 5 'from' 10 gives 5)
       - x: "*[1]"
-      - t: "a"      # phrase(adding 6 'to' 6 equals  12)
+      - T: "a"      # phrase(adding 6 'to' 6 equals  12)
       - x: "*[2]"
       else:
       - x: "*[1]"
-      - t: "virgola"      # phrase(use a 'comma' to divide large numbers or as a decimal point)
+      - T: "virgola"      # phrase(use a 'comma' to divide large numbers or as a decimal point)
       - x: "*[2]"
 
 - name: default-point
@@ -152,7 +152,7 @@
       - T: "la"      # phrase('the' square root of 25 equals 5)
   - T: "punto"       # phrase(a decimal 'point' indicates the fraction component of a number)
   - x: "*[1]"
-  - t: "virgola"      # phrase(use a 'comma' to divide large numbers or as a decimal point)
+  - T: "virgola"      # phrase(use a 'comma' to divide large numbers or as a decimal point)
   - x: "*[2]"
 
 - name: absolute-value
@@ -174,7 +174,7 @@
   match: "count(*)=1 and not(@data-intent-property)"
   replace:
   - bookmark: "./@id"
-  - t: "negativi"      # phrase('negative' numbers are those less than 0)
+  - T: "negativi"      # phrase('negative' numbers are those less than 0)
   - x: "*[1]"
 
 - name: positive
@@ -182,7 +182,7 @@
   match: "count(*)=1 and not(@data-intent-property)"
   replace:
   - bookmark: "./@id"
-  - t: "positivo"      # phrase(multiplying two negatives results in a 'positive' number)
+  - T: "positivo"      # phrase(multiplying two negatives results in a 'positive' number)
   - x: "*[1]"
 
 - name: subscript
@@ -190,15 +190,15 @@
   match: "count(*)=2 and not(@data-intent-property)"
   replace:
   - x: "*[1]"
-  - t: "pedice"      # phrase(the subscripted variable a 'sub' i)
+  - T: "pedice"      # phrase(the subscripted variable a 'sub' i)
   - x: "*[2]"
   - test:
       if: "not(IsNode(*[2],'leaf')) and $Impairment = 'Blindness'"
       then:
       - test:
           if: "$Verbosity='Verbose'"
-          then: [t: "fine pedice"]      # phrase(this is the 'end subscript' position)
-          else: [t: "fine pedice"]      # phrase(this is the 'end sub' position)
+          then: [T: "fine pedice"]      # phrase(this is the 'end subscript' position)
+          else: [T: "fine pedice"]      # phrase(this is the 'end sub' position)
   - pause: short
 
 - name: bigop-both
@@ -207,15 +207,15 @@
   replace:
   - test:
       if: "$Verbosity!='Terse'"
-      then: [t: "la"]      # phrase('the' square root of 25 equals 5)
+      then: [T: "la"]      # phrase('the' square root of 25 equals 5)
   - x: "*[1]"
-  - t: "da"      # phrase(subtracting 5 'from' 10 gives 5)
+  - T: "da"      # phrase(subtracting 5 'from' 10 gives 5)
   - x: "*[2]"
-  - t: "a"      # phrase(adding 6 'to' 6 equals  12)
+  - T: "a"      # phrase(adding 6 'to' 6 equals  12)
   - x: "*[3]"
   - test:
       if: "following-sibling::*"
-      then: [t: "di"]      # phrase(the square root 'of' 25 equals 5)
+      then: [T: "di"]      # phrase(the square root 'of' 25 equals 5)
 
 - name: bigop-under
   tag: large-op
@@ -223,13 +223,13 @@
   replace:
   - test:
       if: "$Verbosity!='Terse'"
-      then: [t: "la"]      # phrase('the' square root of 25 equals 5)
+      then: [T: "la"]      # phrase('the' square root of 25 equals 5)
   - x: "*[1]"
-  - t: "over"      # phrase(2 'over' 3 equals two thirds)
+  - T: "fratto"      # phrase(2 'over' 3 equals two thirds)
   - x: "*[2]"
   - test:
       if: "following-sibling::*"
-      then: [t: "di"]      # phrase(the square root 'of' 25 equals 5)
+      then: [T: "di"]      # phrase(the square root 'of' 25 equals 5)
 
 - name: largeop
   tag: mrow
@@ -237,9 +237,9 @@
   replace:
   - test:
       if: "$Verbosity!='Terse'"
-      then: [t: "la"]      # phrase('the' square root of 25 equals 5)
+      then: [T: "la"]      # phrase('the' square root of 25 equals 5)
   - x: "*[1]"
-  - t: "di"      # phrase(the square root 'of' 25 equals 5)
+  - T: "di"      # phrase(the square root 'of' 25 equals 5)
   - x: "*[2]"
 
 - name: limit
@@ -248,22 +248,22 @@
   replace:
   - test:
       if: "$Verbosity!='Terse'"
-      then: [t: "il"]           # phrase('the' limit as x approaches 1)
+      then: [T: "il"]           # phrase('the' limit as x approaches 1)
   - test:
     - if: "*[1][.='lim']"
-      then: [t: "limite"]
+      then: [T: "lim"]
     - else_if: "*[1][.='limsup']"
       then_test:
           if: "$Verbosity='Terse'"
-          then: [t: "lim sup"]
-          else: [t: "limitare il superiore"]
+          then: [T: "lim sup"]
+          else: [T: "limite superiore"]
     - else_if: "*[1][.='liminf']"
       then_test:
           if: "$Verbosity='Terse'"
           then: [T: "lim inf"]
           else: [T: "limite inferiore"]
     - else: [x: "*[1]"]
-  - t: "come"                      # phrase(the limit 'as' x approaches 1)
+  - T: "quando"                      # phrase(the limit 'as' x approaches 1)
   - x: "*[2]"
   - pause: short
 
@@ -271,7 +271,7 @@
   tag: modified-variable
   match: "count(*)=2 and *[2][text()='→']"
   replace:
-  - t: "vettore"      # phrase(the 'vector' reflects size and direction)
+  - T: "vettore"      # phrase(the 'vector' reflects size and direction)
   - x: "*[1]"
 
 - name: default
@@ -293,8 +293,8 @@
       if: "name(.)='say-super'"
       then_test:
         if: "$Verbosity='Terse'"
-        then: [t: "super"]      # phrase(this is a 'super' set of numbers)
-        else: [t: "apriple"]      # phrase(a 'superscript' number indicates raised to a power)
+        then: [T: "sopra"]      # phrase(this is a 'super' set of numbers)
+        else: [T: "apice"]      # phrase(a 'superscript' number indicates raised to a power)
   - x: "*[2]"
   - pause: short
 
@@ -306,8 +306,8 @@
   - x: "*[1]"
   - test:
       if: "$Verbosity='Verbose'"
-      then: [t: "pedice"]      # phrase(a 'subscript' may be used to indicate an index)
-      else: [t: "sub"]      # phrase(the result is 'sub' optimal)
+      then: [T: "pedice"]      # phrase(a 'subscript' may be used to indicate an index)
+      else: [T: "sub"]      # phrase(the result is 'sub' optimal)
   - x: "*[2]"
   - test:
       if: "not(IsNode(*[2],'leaf') and $Impairment = 'Blindness')"
@@ -334,7 +334,7 @@
   match: "text()='sin'"
   replace:
   - bookmark: "@id"
-  - t: "seno"      # phrase(the 'sine' of the angle)
+  - T: "seno"      # phrase(the 'sine' of the angle)
 - name: cos
   tag: mi
   match: "text()='cos'"
@@ -342,8 +342,8 @@
   - bookmark: "@id"
   - test:
       if: "$Verbosity='Terse'"
-      then: [t: "cos"]      # phrase('cos' is the abbreviation for cosine)
-      else: [t: "coseno"]      # phrase(find the 'cosine' in a right-angle triangle)
+      then: [T: "cos"]      # phrase('cos' is the abbreviation for cosine)
+      else: [T: "coseno"]      # phrase(find the 'cosine' in a right-angle triangle)
 - name: tan
   tag: mi
   match: "text()='tan' or text()='tg'"
@@ -360,8 +360,8 @@
   - bookmark: "@id"
   - test:
       if: "$Verbosity='Terse'"
-      then: [t: "cercare"]      # phrase(to 'seek' a solution)
-      else: [t: "secant"]      # phrase(a 'secant' intersects a curve at two or more points)
+      then: [T: "cercare"]      # phrase(to 'seek' a solution)
+      else: [T: "secant"]      # phrase(a 'secant' intersects a curve at two or more points)
 - name: csc
   tag: mi
   match: "text()='csc'"
@@ -369,8 +369,8 @@
   - bookmark: "@id"
   - test:
       if: "$Verbosity='Terse'"
-      then: [t: "cosecant"]      # phrase(we will 'cosecant' a solution)
-      else: [t: "cosecant"]      # phrase(the 'cosecant' is the reciprocal of the secant)
+      then: [T: "cosecante"]      # phrase(we will 'cosecant' a solution)
+      else: [T: "cosecante"]      # phrase(the 'cosecant' is the reciprocal of the secant)
 - name: cot
   tag: mi
   match: "text()='cot'"
@@ -378,8 +378,8 @@
   - bookmark: "@id"
   - test:
       if: "$Verbosity='Terse'"
-      then: [t: "cotangent"]      # phrase(find the 'cotangent' in a right-angle triangle)
-      else: [t: "cotangent"]      # phrase(the 'cotangent' is the reciprocal of the tangent)
+      then: [T: "cotangente"]      # phrase(find the 'cotangent' in a right-angle triangle)
+      else: [T: "cotangente"]      # phrase(the 'cotangent' is the reciprocal of the tangent)
 
 - name: sinh
   tag: mi
@@ -388,8 +388,8 @@
   - bookmark: "@id"
   - test:
       if: "$Verbosity='Terse'"
-      then: [t: "sinch"]      # phrase(the word 'sinch' is an abbreviation for hyperbolic sine)
-      else: [t: "seno iperbolico"]      # phrase(the 'hyperbolic sine' is used in mathematics)
+      then: [T: "sinH"]      # phrase(the word 'sinch' is an abbreviation for hyperbolic sine)
+      else: [T: "seno iperbolico"]      # phrase(the 'hyperbolic sine' is used in mathematics)
 - name: cosh
   tag: mi
   match: "text()='cosh'"
@@ -397,8 +397,8 @@
   - bookmark: "@id"
   - test:
       if: "$Verbosity='Terse'"
-      then: [t: "cosh"]      # phrase('cosh' is an abbreviation of hyperbolic cosine)
-      else: [t: "coseno iperbolico"]      # phrase(the 'hyperbolic cosine' is a mathematical function)
+      then: [T: "cosH"]      # phrase('cosh' is an abbreviation of hyperbolic cosine)
+      else: [T: "coseno iperbolico"]      # phrase(the 'hyperbolic cosine' is a mathematical function)
 - name: tanh
   tag: mi
   match: "text()='tanh'"
@@ -406,8 +406,8 @@
   - bookmark: "@id"
   - test:
       if: "$Verbosity='Terse'"
-      then: [t: "tanch"]      # phrase('tanch' is shorthand for hyperbolic tangent)
-      else: [t: "tangente iperbolica"]      # phrase('hyperbolic tangent' is a mathematical function)
+      then: [T: "tanH"]      # phrase('tanch' is shorthand for hyperbolic tangent)
+      else: [T: "tangente iperbolica"]      # phrase('hyperbolic tangent' is a mathematical function)
 - name: sech
   tag: mi
   match: "text()='sech'"
@@ -415,8 +415,8 @@
   - bookmark: "@id"
   - test:
       if: "$Verbosity='Terse'"
-      then: [t: "sheck"]      # phrase('sheck' is shorthand for hyperbolic secant)
-      else: [t: "iperbolic secant"]      # phrase('hyperbolic secant' is a mathematical function)
+      then: [T: "secH"]      # phrase('sheck' is shorthand for hyperbolic secant)
+      else: [T: "secante iperbolica"]      # phrase('hyperbolic secant' is a mathematical function)
 - name: csch
   tag: mi
   match: "text()='csch'"
@@ -424,8 +424,8 @@
   - bookmark: "@id"
   - test:
       if: "$Verbosity='Terse'"
-      then: [t: "cosheck"]      # phrase('cosheck' is shorthand for hyperbolic cosecant)
-      else: [t: "iperbolico cosecant"]      # phrase('hyperbolic cosecant' is a mathematical function)
+      then: [T: "cosecH"]      # phrase('cosheck' is shorthand for hyperbolic cosecant)
+      else: [T: "cosecante iperbolica"]      # phrase('hyperbolic cosecant' is a mathematical function)
 - name: coth
   tag: mi
   match: "text()='coth'"
@@ -451,8 +451,8 @@
   - bookmark: "@id"
   - test:
       if: "$Verbosity='Terse'"
-      then: [t: "cov"]      # phrase('Cov' is shorthand for the covariance function)
-      else: [t: "covarianza"]      # phrase('covariance' function)
+      then: [T: "cov"]      # phrase('Cov' is shorthand for the covariance function)
+      else: [T: "covarianza"]      # phrase('covariance' function)
 
 - # handle both log and ln
   name: log
@@ -468,17 +468,17 @@
       if: "$log_is_simple"
       then_test:
       - if: "*[1][text()='log']"
-        then: [t: "log"]      # phrase(the 'log' function is used in mathematics)
+        then: [T: "log"]      # phrase(the 'log' function is used in mathematics)
       - else_if: "$Verbosity='Terse'"
         then: [spell: "'ln'"]
         else: [T: "logaritmo naturale"]      # phrase(the 'natural log' function is used in mathematics)
       else:
       - test:
           if: "$Verbosity!='Terse' and not(log_is_simple)"
-          then: [t: "la"]      # phrase('the' square root of 25 equals 5)
+          then: [T: "la"]      # phrase('the' square root of 25 equals 5)
       - test:
         - if: "*[1][text()='log']"
-          then: [t: "log"]      # phrase(the 'log' function is used in mathematics)
+          then: [T: "log"]      # phrase(the 'log' function is used in mathematics)
         - else_if: "$Verbosity='Terse'"
           then: [spell: "'ln'"]
           else: [T: "logaritmo naturale"]      # phrase(the 'natural log' function is used in mathematics)
@@ -510,11 +510,11 @@
   - pause: medium
   - test:
       - if: "*[2][text()=2]"
-        then: [t: "quadrato"]     
+        then: [T: "quadrato"]
       - else_if: "*[2][text()=3]"
-        then: [t: "a cubetti"]
+        then: [T: "a cubetti"]
         else:  # don't bother with special cases as this isn't likely to happen
-        - t: "cresciuto al"      # phrase(x 'raised to the' second power)
+        - T: "elevato alla"      # phrase(x 'raised to the' second power)
         - x: "*[2]"
         - T: "potenza"           # phrase(x raised to the second 'power')
   - pause: short
@@ -550,7 +550,7 @@
       if: "parent::m:equations and *[1][count(*)=1 and *[1][@data-added='missing-content']] and
            count(*/*[1][count(*)=1 and *[1][@data-added!='missing-content']]) != 0"
       then:
-      - t: "riga successiva"
+      - T: "riga successiva"
       else_test:
         if: "$LineCount != 1"
         then:
@@ -565,7 +565,7 @@
   - test:
       if: .[self::m:mlabeledtr]
       then:
-      - t: "con etichetta"      # phrase(the diagram is complete 'with label')
+      - T: "con etichetta"      # phrase(the diagram is complete 'with label')
       - x: "*[1]/*"
   - pause: medium
   - test:
@@ -603,13 +603,13 @@
   match: "count(*)=1 and *[self::m:mtr][count(*) = 1]"
   replace:
   - ot: "the"      # phrase('the' 1 by 1 matrix M)
-  - t: "1 per 1"      # phrase(the '1 by 1' matrix)
+  - T: "1 per 1"      # phrase(the '1 by 1' matrix)
   - test:
       if: "self::m:determinant" # just need to check the first bracket since we know it must be (, [, or |
-      then: [t: "determinante"]      # phrase(the 2 by 2 'determinant'))
-      else: [t: "matrice"]      # phrase(the 2 by 2 'matrix')
+      then: [T: "determinante"]      # phrase(the 2 by 2 'determinant'))
+      else: [T: "matrice"]      # phrase(the 2 by 2 'matrix')
       
-  - t: "con voce"      # phrase(the 2 by 2 matrix 'with entry' x)
+  - T: "con elemento"      # phrase(the 2 by 2 matrix 'with entry' x)
   - x: "*[1]/*"
 
 # simpler reading methods for smaller matrices if the entries are simple
@@ -622,9 +622,9 @@
   - count(*)<=3 and # at least two rows
   - IsNode(*/*/*,'simple') # IsNode() returns true if all the nodes are simple
   replace:
-  - t: "the"      # phrase('the' 2 by 2 matrix M)
+  - T: "la"      # phrase('the' 2 by 2 matrix M)
   - x: count(*)
-  - t: "per 1 colonna"      # phrase(the 2 'by 1 column' matrix)
+  - T: "per 1 colonna"      # phrase(the 2 'by 1 column' matrix)
   - test:
       if: "$ClearSpeak_Matrix = 'Vector' or $ClearSpeak_Matrix = 'EndVector'"
       then: [T: "vettore"]      # phrase(the 2 by 2 'vector')
@@ -634,11 +634,11 @@
   - test:
       if: "$ClearSpeak_Matrix = 'EndMatrix' or $ClearSpeak_Matrix = 'EndVector'"
       then:
-      - t: "end"      # phrase('end' of matrix)
+      - T: "fine"      # phrase('end' of matrix)
       - test:
           if: $ClearSpeak_Matrix = 'EndVector'
-          then: [t: "vettore"]      # phrase(the 2 column 'vector')
-          else: [t: "matrice"]      # phrase(the 2 by 2 'matrix')
+          then: [T: "vettore"]      # phrase(the 2 column 'vector')
+          else: [T: "matrice"]      # phrase(the 2 by 2 'matrix')
 
 - name: default-column-matrix
   tag: matrix
@@ -647,16 +647,16 @@
   replace:
   - T: "la"      # phrase('the' 2 by 2 matrix M)
   - x: "count(*)"
-  - t: "per 1 colonna"      # phrase(the 2 'by 1 column' matrix)
+  - T: "per 1 colonna"      # phrase(the 2 'by 1 column' matrix)
   - test:
       if: "$ClearSpeak_Matrix = 'Vector' or $ClearSpeak_Matrix = 'EndVector'"
-      then: [t: "vettore"]      # phrase(the 2 column 'vector')
-      else: [t: "matrice"]      # phrase(the 2 by 2 'matrix')
+      then: [T: "vettore"]      # phrase(the 2 column 'vector')
+      else: [T: "matrice"]      # phrase(the 2 by 2 'matrix')
   - pause: long
   - x: "*" # select the rows (mtr)
   - test:
       if: "$ClearSpeak_Matrix = 'EndMatrix' or $ClearSpeak_Matrix = 'EndVector'"
-      then: [t: "fine della matrice"]      # phrase(the 'end of matrix' has been reached)
+      then: [T: "fine della matrice"]      # phrase(the 'end of matrix' has been reached)
 
 - name: 1x2-or-3-matrix
   tag: matrix
@@ -669,7 +669,7 @@
   replace:
   - T: "1 per"      # phrase('the 1 by' 2 matrix)
   - x: count(*/*)
-  - t: "riga"      # phrase(the 1 by 4 'row' matrix)
+  - T: "riga"      # phrase(the 1 by 4 'row' matrix)
   - test:
       if: "$ClearSpeak_Matrix = 'Vector' or $ClearSpeak_Matrix = 'EndVector'"
       then: [T: "il vettore 1 per"]      # phrase('the 1 by' 2 row 'vector')
@@ -679,7 +679,7 @@
   - test:
       if: "$ClearSpeak_Matrix = 'EndMatrix' or $ClearSpeak_Matrix = 'EndVector'"
       then:
-      - t: "fine"      # phrase(the 'end' of matrix has been reached)
+      - T: "fine"      # phrase(the 'end' of matrix has been reached)
       - test:
           if: $ClearSpeak_Matrix = 'EndMatrix'
           then: [T: "matrice"]      # phrase(the 2 by 2 'matrix')
@@ -690,24 +690,24 @@
   variables: [IsColumnSilent: "$SpeechStyle = 'ClearSpeak' and $ClearSpeak_Matrix = 'SilentColNum'"]
   match: "count(*)=1" # one row
   replace:
-  - t: "la matrice 1 di"      # phrase('the 1 by' 2 matrix)
+  - T: "la matrice 1 per"      # phrase('the 1 by' 2 matrix)
   - x: "count(*/*)"
-  - t: "riga"      # phrase(the 1 by 2 'row' matrix)
+  - T: "riga"      # phrase(the 1 by 2 'row' matrix)
   - test:
       if: "$ClearSpeak_Matrix = 'Vector' or $ClearSpeak_Matrix = 'EndVector'"
-      then: [t: "vettoriale"]      # phrase(the 2 by 1 'vector')
-      else: [t: "matrice"]      # phrase(the 2 by 2 'matrix')
+      then: [T: "vettore"]      # phrase(the 2 by 1 'vector')
+      else: [T: "matrice"]      # phrase(the 2 by 2 'matrix')
   - pause: long
   - pause: medium
   - x: "*/*" # select the cols (mtd)
   - test:
       if: "$ClearSpeak_Matrix = 'EndMatrix' or $ClearSpeak_Matrix = 'EndVector'"
       then:
-      - t: "fine"      # phrase(the 'end' of matrix has been reached)
+      - T: "fine"      # phrase(the 'end' of matrix has been reached)
       - test:
           if: $ClearSpeak_Matrix = 'EndMatrix'
-          then: [t: "matrice"]      # phrase(the 2 by 2 'matrix')
-          else: [t: "vettoriale"]      # phrase(the 2 by 1 'vector')
+          then: [T: "matrice"]      # phrase(the 2 by 2 'matrix')
+          else: [T: "vettore"]      # phrase(the 2 by 1 'vector')
 
 - name: simple-small-matrix
   tag: [matrix, determinant]
@@ -717,48 +717,48 @@
   - IsNode(*/*/*,'simple') # IsNode() returns true if all the nodes are simple
   variables: [IsColumnSilent: "$SpeechStyle = 'SimpleSpeak' or ($SpeechStyle = 'ClearSpeak' and $ClearSpeak_Matrix != 'SpeakColNum')"]
   replace:
-  - t: "the"      # phrase('the' 1 by 2 matrix M)
+  - T: "la"      # phrase('the' 1 by 2 matrix M)
   - x: count(*)
-  - t: "di"      # phrase(the 1 'by' 2 matrix)
+  - T: "per"      # phrase(the 1 'by' 2 matrix)
   - x: count(*[self::m:mtr][1]/*)
   - test:
       if: "self::m:determinant"
-      then: [t: "determinante"]      # phrase(the 2 by 2 'determinant')
-      else: [t: "matrice"]      # phrase(the 2 by 2 'matrix')
+      then: [T: "determinante"]      # phrase(the 2 by 2 'determinant')
+      else: [T: "matrice"]      # phrase(the 2 by 2 'matrix')
   - pause: long
   - x: "*"
   - test:
       if: "$ClearSpeak_Matrix = 'EndMatrix' or $ClearSpeak_Matrix = 'EndVector'"
       then:
-      - t: "fine"      # phrase(the 'end' of matrix has been reached)
+      - T: "fine"      # phrase(the 'end' of matrix has been reached)
       - test:
           if: "self::m:determinant"
-          then: [t: "determinante"]      # phrase(the 2 by 2 'determinant')
-          else: [t: "matrice"]      # phrase(the 2 by 2 'matrix')
+          then: [T: "determinante"]      # phrase(the 2 by 2 'determinant')
+          else: [T: "matrice"]      # phrase(the 2 by 2 'matrix')
 
 - name: default-matrix
   tag: [matrix, determinant]
   variables: [IsColumnSilent: "$SpeechStyle = 'ClearSpeak' and $ClearSpeak_Matrix = 'SilentColNum'"]
   match: "not(@data-intent-property)"
   replace:
-  - t: "the"      # phrase('the' 1 by 2 matrix M)
+  - T: "la"      # phrase('the' 1 by 2 matrix M)
   - x: "count(*)"
   - T: "per"      # phrase(the 1 'by' 2 matrix)
   - x: "count(*[self::m:mtr][1]/*)"
   - test:
       if: "self::m:determinant"
-      then: [t: "determinante"]      # phrase(the 2 by 2 'determinant')
-      else: [t: "matrice"]      # phrase(the 2 by 2 'matrix')
+      then: [T: "determinante"]      # phrase(the 2 by 2 'determinant')
+      else: [T: "matrice"]      # phrase(the 2 by 2 'matrix')
   - pause: long
   - x: "*"
   - test:
       if: "$ClearSpeak_Matrix = 'EndMatrix' or $ClearSpeak_Matrix = 'EndVector'"
       then:
-      - t: "fine"      # phrase(the 'end' of matrix has been reached)
+      - T: "fine"      # phrase(the 'end' of matrix has been reached)
       - test:
           if: "self::m:determinant"
-          then: [t: "determinante"]      # phrase(the 2 by 2 'determinant')
-          else: [t: "matrice"]      # phrase(the 2 by 2 'matrix's)
+          then: [T: "determinante"]      # phrase(the 2 by 2 'determinant')
+          else: [T: "matrice"]      # phrase(the 2 by 2 'matrix's)
 
 - name: chemistry-msub
 
@@ -768,10 +768,10 @@
   - x: "*[2]"
   - test:
       if: "$Verbosity='Verbose'"
-      then: [t: "sobbrottente"]      # phrase(H 'subscript' 2)
+      then: [T: "pedice"]      # phrase(H 'subscript' 2)
       else_test:
         if: "$Verbosity='Medium'"
-        then: [t: "sub"]      # phrase(H 'sub' 2)
+        then: [T: "pedice"]      # phrase(H 'sub' 2)
   - x: "*[3]"
 
 - name: chemistry-msup
@@ -781,10 +781,10 @@
   - x: "*[2]"
   - test:
       if: "$Verbosity='Verbose'"
-      then: [t: "superscript"]      # phrase(H 'superscript' 2)
+      then: [T: "apice"]      # phrase(H 'superscript' 2)
       else_test:
         if: "$Verbosity='Medium'"
-        then: [t: "super"]      # phrase(H 'super' 2)
+        then: [T: "apice"]      # phrase(H 'super' 2)
   - x: "*[3]"
   - test:
       if: "following-sibling::*[1][text()='+' or text()='-']" # a little lazy -- assumes chemistry superscripts end with + or -
@@ -812,10 +812,10 @@
           then:
           - test:
               if: "$Verbosity='Verbose'"
-              then: [t: "superscript"]      # phrase(H 'superscript' 2)
+              then: [T: "apice"]      # phrase(H 'superscript' 2)
               else_test:
                 if: "$Verbosity='Medium'"
-                then: [t: "super"]      # phrase(H 'super' 2)
+                then: [T: "apice"]      # phrase(H 'super' 2)
           - x: "$Prescripts[2]"
           - pause: "short"
       - test:
@@ -823,10 +823,10 @@
           then:
           - test:
               if: "$Verbosity='Verbose'"
-              then: [t: "pedice"]      # phrase(a 'subscript' may be used to indicate an index)
+              then: [T: "pedice"]      # phrase(a 'subscript' may be used to indicate an index)
               else_test:
                 if: "$Verbosity='Medium'"
-                then: [t: "sub"]      # phrase(here is a 'sub' total)
+                then: [T: "sub"]      # phrase(here is a 'sub' total)
           - x: "$Prescripts[1]"
           - pause: "short"
       - test:
@@ -837,10 +837,10 @@
               then:
               - test:
                   if: "$Verbosity='Verbose'"
-                  then: [t: "superscript"]      # phrase(H 'superscript' 2)
+                  then: [T: "apice"]      # phrase(H 'superscript' 2)
                   else_test:
                     if: "$Verbosity='Medium'"
-                    then: [t: "super"]      # phrase(H 'super' 2)
+                    then: [T: "apice"]      # phrase(H 'super' 2)
               - x: "$Prescripts[4]"
               - pause: "short"
           - test:
@@ -848,10 +848,10 @@
               then:
               - test:
                   if: "$Verbosity='Verbose'"
-                  then: [t: "sobbrottente"]      # phrase(H 'subscript' 2)
+                  then: [T: "pedice"]      # phrase(H 'subscript' 2)
                   else_test:
                     if: "$Verbosity='Medium'"
-                    then: [t: "sub"]      # phrase(H 'sub' 2)
+                    then: [T: "pedice"]      # phrase(H 'sub' 2)
               - x: "$Prescripts[3]"
               - pause: "short"
   - x: "*[1]" # base
@@ -863,10 +863,10 @@
           then:
           - test:
               if: "$Verbosity='Verbose'"
-              then: [t: "pedice"]      # phrase(phrase(H 'subscript' 2)
+              then: [T: "pedice"]      # phrase(phrase(H 'subscript' 2)
               else_test:
                 if: "$Verbosity='Medium'"
-                then: [t: "sub"]      # phrase(phrase(H 'sub' 2)
+                then: [T: "pedice"]      # phrase(phrase(H 'sub' 2)
           - x: "$Postscripts[1]"
           - pause: "short"
       - test:
@@ -874,10 +874,10 @@
           then:
           - test:
               if: "$Verbosity='Verbose'"
-              then: [t: "superscript"]      # phrase(H 'superscript' 2)
+              then: [T: "apice"]      # phrase(H 'superscript' 2)
               else_test:
                 if: "$Verbosity='Medium'"
-                then: [t: "super"]          # phrase(H 'super' 2)
+                then: [T: "apice"]          # phrase(H 'super' 2)
           - x: "$Postscripts[2]"
           - pause: "short"
       - test:
@@ -888,10 +888,10 @@
               then:
               - test:
                   if: "$Verbosity='Verbose'"
-                  then: [t: "sobbrottente"]      # phrase(H 'subscript' 2)
+                  then: [T: "pedice"]      # phrase(H 'subscript' 2)
                   else_test:
                     if: "$Verbosity='Medium'"
-                    then: [t: "sub"]          # phrase(H 'sub' 2)
+                    then: [T: "pedice"]          # phrase(H 'sub' 2)
               - x: "$Postscripts[3]"
               - pause: "short"
           - test:
@@ -899,10 +899,10 @@
               then:
               - test:
                   if: "$Verbosity='Verbose'"
-                  then: [t: "superscript"]      # phrase(H 'superscript' 2)
+                  then: [T: "apice"]      # phrase(H 'superscript' 2)
                   else_test:
                     if: "$Verbosity='Medium'"
-                    then: [t: "super"]          # phrase(H 'super' 2)
+                    then: [T: "apice"]          # phrase(H 'super' 2)
               - x: "$Postscripts[4]"
               - pause: "short"
           - test:
@@ -913,10 +913,10 @@
                   then:
                   - test:
                       if: "$Verbosity='Verbose'"
-                      then: [t: "sobbrottente"]    # phrase(H 'subscript' 2)
+                      then: [T: "pedice"]    # phrase(H 'subscript' 2)
                       else_test:
                         if: "$Verbosity='Medium'"
-                        then: [t: "sub"]        # phrase(H 'sub' 2)
+                        then: [T: "pedice"]        # phrase(H 'sub' 2)
                   - x: "$Postscripts[5]"
                   - pause: "short"
               - test:
@@ -924,10 +924,10 @@
                   then:
                   - test:
                       if: "$Verbosity='Verbose'"
-                      then: [t: "superscript"]  # phrase(H 'superscript' 2)
+                      then: [T: "apice"]  # phrase(H 'superscript' 2)
                       else_test:
                         if: "$Verbosity='Medium'"
-                        then: [t: "super"]      # phrase(H 'super' 2)
+                        then: [T: "apice"]      # phrase(H 'super' 2)
                   - x: "$Postscripts[6]"
                   - pause: "short"
               - test:
@@ -938,10 +938,10 @@
                       then:
                       - test:
                           if: "$Verbosity='Verbose'"
-                          then: [t: "sobbrottente"]      # phrase(H 'subscript' 2)
+                          then: [T: "apice"]      # phrase(H 'subscript' 2)
                           else_test:
                             if: "$Verbosity='Medium'"
-                            then: [t: "sub"]      # phrase(H 'sub' 2)
+                            then: [T: "apice"]      # phrase(H 'sub' 2)
                       - x: "$Postscripts[7]"
                       - pause: "short"
                   - test:
@@ -949,10 +949,10 @@
                       then:
                       - test:
                           if: "$Verbosity='Verbose'"
-                          then: [t: "superscript"]      # phrase(H 'superscript' 2)
+                          then: [T: "apice"]      # phrase(H 'superscript' 2)
                           else_test:
                             if: "$Verbosity='Medium'"
-                            then: [t: "super"]      # phrase(H 'super' 2)
+                            then: [T: "apice"]      # phrase(H 'super' 2)
                       - x: "$Postscripts[8]"
                       - pause: "short"
       - test:
@@ -982,7 +982,7 @@
   - bookmark: "*[1]/@id"
   - test:
     - if: ".='s'"
-      then: [t: "solido"]      # phrase(Boron is a 'solid' in its natural state)
+      then: [T: "solido"]      # phrase(Boron is a 'solid' in its natural state)
     - else_if: ".='l'"
       then: [T: "liquido"]      # phrase(water is a 'liquid')
     - else_if: ".='g'"
@@ -998,13 +998,13 @@
   - bookmark: "@id"
   - test:
     - if: "text()='-' or text() = ':'"
-      then: [t: "legame singolo"]      # phrase(a 'single bond' is formed when two atoms share one pair of electrons)
+      then: [T: "legame singolo"]      # phrase(a 'single bond' is formed when two atoms share one pair of electrons)
     - else_if: "text()='=' or text() = '∷'"
-      then: [t: "doppio legame"]      # phrase(a 'double bond' may occur when two atoms share two pairs of electrons)
+      then: [T: "doppio legame"]      # phrase(a 'double bond' may occur when two atoms share two pairs of electrons)
     - else_if: "text()='≡'"
-      then: [t: "triplo legame"]      # phrase(a 'triple bond' occurs when two atoms share three pairs of electrons)
+      then: [T: "triplo legame"]      # phrase(a 'triple bond' occurs when two atoms share three pairs of electrons)
     - else_if: "text()='≣'"
-      then: [t: "legame quadruplo"]      # phrase(a 'quadruple bond' occurs when two atoms share four pairs of electrons)
+      then: [T: "legame quadruplo"]      # phrase(a 'quadruple bond' occurs when two atoms share four pairs of electrons)
       else: [x: "text()"]
 
 - name: chemical-formula-operator
@@ -1026,11 +1026,11 @@
         then: [T: "forma"]      # phrase(hydrogen and oxygen 'forms' water )
         else: [T: "reagisce a formare"]      # phrase(hydrogen and oxygen 'reacts to form' water)
     - else_if: ".='⇌' or .='\u1f8d2'"
-      then: [t: "è in equilibrio con"]      # phrase(a reactant 'is in equilibrium with' a product)
+      then: [T: "è in equilibrio con"]      # phrase(a reactant 'is in equilibrium with' a product)
     - else_if: ".='\u1f8d4'"
-      then: [t: "è in equilibrio distorto a sinistra con"]      # phrase(the reactant 'is in equilibrium biased to the left with' the product)
+      then: [T: "è in equilibrio spostato a sinistra rispetto a"]      # phrase(the reactant 'is in equilibrium biased to the left with' the product)
     - else_if: ".='\u1f8d3'"
-      then: [t: "è in equilibrio distorto a destra con"]      # phrase(the reactant 'is in equilibrium biased to the right with' the product)
+      then: [T: "è in equilibrio spostato a destra rispetto a"]      # phrase(the reactant 'is in equilibrium biased to the right with' the product)
       else: [x: "*"]
 
 - name: chemical-equation-operator

--- a/Rules/Languages/it/SharedRules/geometry.yaml
+++ b/Rules/Languages/it/SharedRules/geometry.yaml
@@ -7,12 +7,12 @@
   - test:
       if: "$Verbosity='Verbose'"
       then:
-      - t: "il segmento di linea da"      # phrase('the line segment from' A to B)
+      - T: "il segmento di linea da"      # phrase('the line segment from' A to B)
       - x: "*[1]"
-      - t: "a"                         # phrase(the line segment from A 'to' B)
+      - T: "a"                         # phrase(the line segment from A 'to' B)
       - x: "*[2]"
       else:
-      - t: "segmento di linea"               # phrase(the 'line segment' A  B)
+      - T: "segmento di linea"               # phrase(the 'line segment' A  B)
       - x: "*[1]"
       - x: "*[2]"
 
@@ -23,12 +23,12 @@
   - test:
       if: "$Verbosity='Verbose'"
       then:
-      - t: "il raggio da"             # phrase('the ray from' A to B)
+      - T: "il raggio da"             # phrase('the ray from' A to B)
       - x: "*[1]"
-      - t: "a"                       # phrase(the ray from A 'to' B)
+      - T: "a"                       # phrase(the ray from A 'to' B)
       - x: "*[2]"
       else:
-      - t: "ray"                      # phrase(the 'ray'A  B)
+      - T: "ray"                      # phrase(the 'ray' A  B)
       - x: "*[1]"
       - x: "*[2]"
 
@@ -38,8 +38,8 @@
   replace:
   - test:
       if: "$Verbosity='Verbose'"
-      then: [t: "l"]            # phrase('the' arc A B C)
-  - t: "arco"                        # phrase(the 'arc' A B C)
+      then: [T: "l'"]            # phrase('the' arc A B C)
+  - T: "arco"                        # phrase(the 'arc' A B C)
   - x: "*[1]"
   - x: "*[2]"
 
@@ -50,9 +50,9 @@
   - test:
       if: "$Verbosity='Verbose'"
       then:
-      - t: "la misura dell"      # phrase('the measure of the angle' ABC)
+      - T: "la misura dell'"      # phrase('the measure of the angle' ABC)
       else:
-      - t: "misura dell"      # phrase('measure of angle' ABC)
+      - T: "misura dell'"      # phrase('measure of angle' ABC)
   - x: "*[1]"
   - x: "*[2]"
   - x: "*[3]"

--- a/Rules/Languages/it/SharedRules/linear-algebra.yaml
+++ b/Rules/Languages/it/SharedRules/linear-algebra.yaml
@@ -7,16 +7,16 @@
   - test:
       if: "$Verbosity='Verbose'"
       then:
-      - t: "la"      # phrase('the' square root of 25 equals 5)
-  - t: "determinante"      # phrase(the 'determinant' of a matrix)
+      - T: "la"      # phrase('the' square root of 25 equals 5)
+  - T: "determinante"      # phrase(the 'determinant' of a matrix)
   - test:
       if: "$Verbosity!='Terse'"
       then:
-      - t: "di"      # phrase(systems 'of' linear equations)
+      - T: "di"      # phrase(systems 'of' linear equations)
   - x: "*[1]"
   - test:
       if: "not(IsNode(*[1], 'simple')) and $Impairment = 'Blindness'"
-      then: [t: "end determinante"]      # phrase('end determinant' of a matrix)
+      then: [T: "fine determinante"]      # phrase('end determinant' of a matrix)
 
 - name: norm
   tag: norm
@@ -25,16 +25,16 @@
   - test:
       if: "$Verbosity='Verbose'"
       then:
-      - t: "la"      # phrase('the' square root of 25 equals 5)
-  - t: "norma"      # phrase(the 'norm' can be a measure of distance)
+      - T: "la"      # phrase('the' square root of 25 equals 5)
+  - T: "norma"      # phrase(the 'norm' can be a measure of distance)
   - test:
       if: "$Verbosity!='Terse'"
       then:
-      - t: "di"      # phrase(this is the mean 'of' the data)
+      - T: "di"      # phrase(this is the mean 'of' the data)
   - x: "*[1]"
   - test:
       if: "not(IsNode(*[1], 'simple')) and $Impairment = 'Blindness'"
-      then: [t: "end norm"]      # phrase('end norm' that is a measure of distance)
+      then: [T: "fine norma"]      # phrase('end norm' that is a measure of distance)
 
 
 - name: subscripted-norm
@@ -44,13 +44,13 @@
   - test:
       if: "$Verbosity='Verbose'"
       then:
-      - t: "la"      # phrase('the' square root of 25 equals 5)
+      - T: "la"      # phrase('the' square root of 25 equals 5)
   - x: "*[2]"
-  - t: "norma"      # phrase(the 'norm' can be a measure of distance)
+  - T: "norma"      # phrase(the 'norm' can be a measure of distance)
   - test:
       if: "$Verbosity!='Terse'"
       then:
-      - t: "di"      # phrase(systems 'of' linear equations)
+      - T: "di"      # phrase(systems 'of' linear equations)
   - x: "*[1]"
 
 - name: transpose
@@ -58,7 +58,7 @@
   match: "count(*)=1 and not(@data-intent-property)"
   replace:
   - x: "*[1]"
-  - t: "trasponi"      # phrase(this will 'transpose' the values)
+  - T: "trasporrà"      # phrase(this will 'transpose' the values)
 - name: trace
   tag: trace
   match: "not(@data-intent-property)"
@@ -71,7 +71,7 @@
   - test:
       if: "$Verbosity!='Terse'"
       then:
-      - t: "di"      # phrase(systems 'of' linear equations)
+      - T: "di"      # phrase(systems 'of' linear equations)
   - x: "*[1]"
 
 - name: dimension
@@ -81,12 +81,12 @@
   - test:
       if: "$Verbosity='Verbose'"
       then:
-      - t: "la"      # phrase('the' square root of 25 equals 5)
-  - t: "dimensione"      # phrase(the 'dimension' of the matrix)
+      - T: "la"      # phrase('the' square root of 25 equals 5)
+  - T: "dimensione"      # phrase(the 'dimension' of the matrix)
   - test:
       if: "$Verbosity!='Terse'"
       then:
-      - t: "di"      # phrase(systems 'of' linear equations)
+      - T: "di"      # phrase(systems 'of' linear equations)
   - x: "*[1]"
 
 - name: homomorphism
@@ -101,7 +101,7 @@
   - test:
       if: "$Verbosity!='Terse'"
       then:
-      - t: "di"      # phrase(systems 'of' linear equations)
+      - T: "di"      # phrase(systems 'of' linear equations)
   - x: "*[1]"
 
 - name: kernel
@@ -111,11 +111,11 @@
   - test:
       if: "$Verbosity='Verbose'"
       then:
-      - t: "la"      # phrase('the' square root of 25 equals 5)
-  - t: "kernel"      # phrase(this is the 'kernel' of the function)
+      - T: "la"      # phrase('the' square root of 25 equals 5)
+  - T: "kernel"      # phrase(this is the 'kernel' of the function)
   - test:
       if: "$Verbosity!='Terse'"
       then:
-      - t: "di"      # phrase(systems 'of' linear equations)
+      - T: "di"      # phrase(systems 'of' linear equations)
   - x: "*[1]"
 

--- a/Rules/Languages/it/SimpleSpeak_Rules.yaml
+++ b/Rules/Languages/it/SimpleSpeak_Rules.yaml
@@ -11,7 +11,7 @@
   tag: mn
   match: "starts-with(text(), '-')"
   replace:
-  - t: "meno"        # phrase(x 'minus' y)
+  - T: "meno"        # phrase(x 'minus' y)
   - x: "translate(text(), '-_', '')"
 
 - name: default
@@ -24,13 +24,13 @@
   - T: "radice quadrata"      # phrase(the 'square root' of x)
   - test:
       if: "$Verbosity!='Terse'"
-      then: [t: "di"]   # phrase(the square root 'of' x)
+      then: [T: "di"]   # phrase(the square root 'of' x)
       else: [pause: short]
   - x: "*[1]"
   - test:
       if: "IsNode(*[1], 'leaf') or $Impairment != 'Blindness'"
       then: [pause: short]
-      else: [t: "fine radice", pause: short]  # phrase(start the square root of x 'end of root')
+      else: [T: "fine radice", pause: short]  # phrase(start the square root of x 'end of root')
 
 - name: default
   tag: root
@@ -43,11 +43,11 @@
       if: "*[2][self::m:mn]"
       then_test:
       - if: "*[2][text()='2']"
-        then: [t: "radice quadrata"]        # phrase(the 'square root' of x)
+        then: [T: "radice quadrata"]        # phrase(the 'square root' of x)
       - else_if: "*[2][text()='3']"
-        then: [t: "radice del cubo"]        # phrase(the 'cube root' of x)
+        then: [T: "radice cubica"]        # phrase(the 'cube root' of x)
       - else_if: "*[2][not(contains(., '.'))]"
-        then: [x: "ToOrdinal(*[2])", t: "radice"]        # phrase(the square 'root' of x)
+        then: [x: "ToOrdinal(*[2])", T: "radice"]        # phrase(the square 'root' of x)
       else:
       - test:
           if: "*[2][self::m:mi][string-length(.)=1]"
@@ -55,15 +55,15 @@
           - x: "*[2]"
           - pronounce: [{text: "-th"}, {ipa: "θ"}, {sapi5: "th"}, {eloquence: "T"}]
           else: [x: "*[2]"]
-      - t: "radice"        # phrase(the square 'root' of)
+      - T: "radice"        # phrase(the square 'root' of)
   - test:
       if: "$Verbosity!='Terse'"
-      then: [t: "di"]        # phrase(the square root 'of' x)
+      then: [T: "di"]        # phrase(the square root 'of' x)
   - x: "*[1]"
   - test:
       if: "IsNode(*[1], 'leaf') or $Impairment != 'Blindness'"
       then: [pause: short]
-      else: [t: "fine radice", pause: short]      # phrase(start the fifth root of x 'end of root')
+      else: [T: "fine radice", pause: short]      # phrase(start the fifth root of x 'end of root')
 
 # Fraction rules
 # Mixed numbers mostly "just work" because the invisible char reads as "and" and other parts read properly on their own
@@ -99,7 +99,7 @@
   - "not(ancestor::*[name() != 'mrow'][1]/self::m:fraction)" # FIX: can't test for mrow -- what should be used???
   replace:
   - x: "*[1]"
-  - t: "oltre"      # phrase(the fraction 3 'over' 4)
+  - T: "fratto"      # phrase(the fraction 3 'over' 4)
   - x: "*[2]"
   - pause: short
 
@@ -109,13 +109,13 @@
   replace:
   - test:
       if: "$Impairment = 'Blindness'"
-      then: [T: "inizio frazione"]      # phrase(the 'fraction' 3 over 4)
+      then: [T: "frazione"]      # phrase(the 'fraction' 3 over 4)
   - pause: short
   - x: "*[1]"
   - test:
       if: "not(IsNode(*[1],'leaf'))"
       then: [pause: short]
-  - t: "oltre"      # phrase(the fraction 3 'over' 4)
+  - T: "fratto"      # phrase(the fraction 3 'over' 4)
   - test:
       if: "not(IsNode(*[2],'leaf'))"
       then: [pause: short]
@@ -123,7 +123,7 @@
   - pause: short
   - test:
       if: "$Impairment = 'Blindness'"
-      then: [t: "fine della frazione"]      # phrase(start 7 over 8 'end of fraction')
+      then: [T: "fine frazione"]      # phrase(start 7 over 8 'end of fraction')
   - pause: medium
 
 # rules for functions raised to a power
@@ -133,7 +133,7 @@
   tag: inverse-function
   match: "."
   replace:
-  - t: "inverso"      # phrase(the 'inverse' of f)
+  - T: "inverso"      # phrase(the 'inverse' of f)
   - x: "*[1]"
 
 - name: function-squared-or-cubed
@@ -146,8 +146,8 @@
   - bookmark: "*[2]/@id"
   - test:
       if: "*[2][text()=2]"
-      then: [t: "al quadrato"]      # phrase(5 'squared' equals 25)
-      else: [t: "al cubed"]      # phrase(5 'cubed' equals 125)
+      then: [T: "al quadrato"]      # phrase(5 'squared' equals 25)
+      else: [T: "al cubo"]      # phrase(5 'cubed' equals 125)
 - name: function-power
   tag: power
   match:
@@ -155,13 +155,13 @@
   replace:
   - test:
       if: "$Verbosity!='Terse'"
-      then: [t: "il"]      # # phrase('the' fourth power of 10)
+      then: [T: "la"]      # # phrase('the' fourth power of 10)
   - bookmark: "*[2]/@id"
   - test:
       if: "*[2][self::m:mn][not(contains(., '.'))]"
       then: [x: "ToOrdinal(*[2])"]
       else: [x: "*[2]"]
-  - t: "potere di"      # phrase(the fourth 'power of' 2)
+  - T: "potenza di"      # phrase(the fourth 'power of' 2)
   - pause: short
   - x: "*[1]"
 
@@ -174,15 +174,15 @@
   - bookmark: "*[2]/@id"
   - test:
       if: "*[2][text()=2]"
-      then: [t: "quadrato"]      # phrase(5 'squared' equals 25)
-      else: [t: "cubed"]      # phrase(5 'cubed' equals 125)
+      then: [T: "al quadrato"]      # phrase(5 'squared' equals 25)
+      else: [T: "al cubo"]      # phrase(5 'cubed' equals 125)
 
 - name: simple-integer
   tag: power
   match: "*[2][self::m:mn][not(contains(., '.'))]"
   replace:
   - x: "*[1]"
-  - t: "al"      # phrase(15 raised 'to the' second power equals 225)
+  - T: "alla"      # phrase(15 raised 'to the' second power equals 225)
   - test:
       if: "*[2][.>0]"
       then: {x: "ToOrdinal(*[2])"}
@@ -194,14 +194,14 @@
   - "     *[1][self::m:mn][not(contains(., '.'))]]"
   replace:
   - x: "*[1]"
-  - t: "al"      # phrase(15 raised 'to the' second power equals 225)
+  - T: "alla"      # phrase(15 raised 'to the' second power equals 225)
   - x: "*[2]"
 - name: simple-var
   tag: power
   match: "*[2][self::m:mi][string-length(.)=1]"
   replace:
   - x: "*[1]"
-  - t: "al"      # phrase(15 raised 'to the' second power equals 225)
+  - T: "alla"      # phrase(15 raised 'to the' second power equals 225)
   - x: "*[2]"
   - pronounce: [{text: "-th"}, {ipa: "θ"}, {sapi5: "th"}, {eloquence: "T"}]
 
@@ -210,7 +210,7 @@
   match: "IsNode(*[2], 'leaf')"
   replace:
   - x: "*[1]"
-  - t: "alla"      # phrase(15 raised 'to the' second power equals 225)
+  - T: "alla"      # phrase(15 raised 'to the' second power equals 225)
   - x: "*[2]"
 
 - name: nested
@@ -225,7 +225,7 @@
   - "    ]"
   replace:
   - x: "*[1]"
-  - t: "cresciuto al"      # phrase(15 'raised to the' second power equals 225)
+  - T: "elevato alla"      # phrase(15 'raised to the' second power equals 225)
   - x: "*[2]"
   - pause: short
   - test:
@@ -241,9 +241,9 @@
   match: "."
   replace:
   - x: "*[1]"
-  - t: "apice"      # phrase(15 'raised to the' second power equals 225)
+  - T: "elevato alla"      # phrase(15 'raised to the' second power equals 225)
   - x: "*[2]"
-  - t: "fine apice"      # phrase(15 raised to the second 'power' equals 225)
+  - T: "potenza"      # phrase(15 raised to the second 'power' equals 225)
   - pause: short
 
 #
@@ -265,9 +265,9 @@
       - test:
           if: "$Verbosity!='Terse'"
           then: [T: "l'"]      # phrase('the' set of all integers)
-      - T: "insieme degli interi positivi "      # phrase(the 'set of all' positive integers less than 10)
+      - T: "insieme di tutti gli"      # phrase(the 'set of all' positive integers less than 10)
       - x: "*[1]/*[1]"
-      - t: "tale che"      # phrase(x 'such that' x is less than y)
+      - T: "tale che"      # phrase(x 'such that' x is less than y)
       - x: "*[1]/*[3]"
       else:
       - test:
@@ -296,7 +296,7 @@
   - "    IsBracketed(., '(', ')') or IsBracketed(., '[', ']') or IsBracketed(., '|', '|')]" # followed by parens
   - " )"
   replace:
-  - t: "volte"      # phrase(7 'times' 5 equals 35)
+  - T: "volte"      # phrase(7 'times' 5 equals 35)
 
 - name: no-say-parens
   tag: mrow

--- a/Rules/Languages/it/definitions.yaml
+++ b/Rules/Languages/it/definitions.yaml
@@ -82,7 +82,7 @@
     ]
 
 - NumbersOrdinalPluralHundreds: [
-       "", "centesimo", "duecentesimi", "trecentesimi", "quattrocentesimi", "cinquecentesimi",
+       "", "centesimi", "duecentesimi", "trecentesimi", "quattrocentesimi", "cinquecentesimi",
          "seicentesimi", "settecentesimi", "ottocentesimi", "novecentesimi"
     ]
       

--- a/Rules/Languages/it/unicode.yaml
+++ b/Rules/Languages/it/unicode.yaml
@@ -130,8 +130,8 @@
         if: "parent::m:modified-variable or parent::m:mover"
         then: [T: "cappellino"]                     #   (en: 'hat')
         else: [T: "accento circonflesso"]         #   (en: 'caret', MathPlayer: 'cappuccio', google: 'assegnato')
- - "_": [t: "trattino basso"]                       #  0x5f (en: 'under bar', MathPlayer: 'under bar', google: 'sotto la barra')
- - "`": [t: "accento grave"]                      #  0x60 (en: 'grave')
+ - "_": [T: "trattino basso"]                       #  0x5f (en: 'under bar', MathPlayer: 'under bar', google: 'sotto la barra')
+ - "`": [T: "accento grave"]                      #  0x60 (en: 'grave')
  - "{":                                           #  0x7b
     - test:
         if: $SpeechStyle = 'ClearSpeak' or $SpeechStyle = 'SimpleSpeak'
@@ -275,7 +275,7 @@
  - "℃": [T: "gradi celsius"]                      #  0x2103 (en: 'degrees celsius', google translation)
  - "℉": [T: "gradi fahrenheit"]                   #  0x2109 (en: 'degrees fahrenheit', google translation)
  - "ℋℛℓ":                                         #  0x210b
-    - t: "aratteri calligrafici"                  #   (en: 'script', google translation)
+    - T: "caratteri calligrafici"                  #   (en: 'script', google translation)
     - spell: "translate('.', 'ℋℛℓ', 'HRl')"
  - "ℎ": [T: "costante di planck"]                 #  0x210e (en: 'planck constant')
  - "ℜ":                                           #  0x211c
@@ -490,10 +490,10 @@
  - "⊆":                                           #  0x2286
      - test: 
          if: "$Verbosity!='Terse'"
-         then: [t: "è un"]                        #   (en: 'is a', google translation)
-     - t: "sottoinsieme proprio o improprio di"   #   (en: 'subset of or equal to')
+         then: [T: "è un"]                        #   (en: 'is a')
+     - T: "sottoinsieme proprio o improprio di"   #   (en: 'subset of or equal to')
  - "⊇":                                           #  0x2287
      - test: 
          if: "$Verbosity!='Terse'"
-         then: [t: "è un"]                        #   (en: 'is a', google translation)
-     - t: "soprainsieme proprio p improprio di"   #   (en: 'superset of or equal to')
+         then: [T: "è un"]                        #   (en: 'is a', google translation)
+     - T: "soprainsieme proprio o improprio di"   #   (en: 'superset of or equal to')


### PR DESCRIPTION
This PR updates the translation files to the latest version:
* `Rules/Languages/it/ClearSpeak_Rules.yaml`
* `Rules/Languages/it/definitions.yaml`
* `Rules/Languages/it/SharedRules/default.yaml`
* `Rules/Languages/it/SharedRules/general.yaml`
* `Rules/Languages/it/SharedRules/geometry.yaml`
* `Rules/Languages/it/SharedRules/linear-algebra.yaml`
* `Rules/Languages/it/SimpleSpeak_Rules.yaml`
* `Rules/Languages/it/unicode.yaml`

The only file that still needs to be translated is `unicode-full.yaml`, with 2846 strings that need to be translated:
```
$ grep -c -E '\s+(- |\[?)t:' unicode-full.yaml
2846
```