### PR TITLE
language comparison tool 

### DIFF
--- a/PythonScripts/audit-translations.py
+++ b/PythonScripts/audit-translations.py
@@ -222,52 +222,6 @@ class UI:
 
         print(f"{c.CYAN}{s.BOX_BL}{s.BOX_H * (width - 2)}{s.BOX_BR}{c.RESET}")
 
-    def print_warnings(result: ComparisonResult, file_name: str) -> int:
-        """Print warnings to console. Returns count of issues found."""
-    c = UI.Colors
-    s = UI.Symbols
-    issues = 0
-
-    has_issues = result.missing_rules or result.untranslated_text or result.extra_rules
-
-    if has_issues:
-        UI.print_file_header(file_name, result.english_rule_count, result.translated_rule_count)
-
-    if result.missing_rules:
-        UI.print_issue_category(
-            s.CROSS, c.RED,
-            "Missing Rules",
-            len(result.missing_rules),
-            "in English but not in translation"
-        )
-        for rule in result.missing_rules:
-            UI.print_rule_item(rule, context=" in English")
-            issues += 1
-
-    if result.untranslated_text:
-        UI.print_issue_category(
-            s.WARNING, c.YELLOW,
-            "Untranslated Text",
-            len(result.untranslated_text),
-            "lowercase t/ot/ct keys"
-        )
-        for rule, texts in result.untranslated_text:
-            UI.print_rule_item(rule)
-            UI.print_text_samples(texts)
-            issues += 1
-
-    if result.extra_rules:
-        UI.print_issue_category(
-            s.INFO, c.BLUE,
-            "Extra Rules",
-            len(result.extra_rules),
-            "may be intentional"
-        )
-        for rule in result.extra_rules:
-            UI.print_rule_item(rule)
-
-    return issues
-
 
 
 # =============================================================================
@@ -529,6 +483,51 @@ def compare_files(english_path: str, translated_path: str) -> ComparisonResult:
         translated_rule_count=len(translated_rules)
     )
 
+def print_warnings(result: ComparisonResult, file_name: str) -> int:
+    """Print warnings to console. Returns count of issues found."""
+    c = UI.Colors
+    s = UI.Symbols
+    issues = 0
+
+    has_issues = result.missing_rules or result.untranslated_text or result.extra_rules
+
+    if has_issues:
+        UI.print_file_header(file_name, result.english_rule_count, result.translated_rule_count)
+
+    if result.missing_rules:
+        UI.print_issue_category(
+            s.CROSS, c.RED,
+            "Missing Rules",
+            len(result.missing_rules),
+            "in English but not in translation"
+        )
+        for rule in result.missing_rules:
+            UI.print_rule_item(rule, context=" in English")
+            issues += 1
+
+    if result.untranslated_text:
+        UI.print_issue_category(
+            s.WARNING, c.YELLOW,
+            "Untranslated Text",
+            len(result.untranslated_text),
+            "lowercase t/ot/ct keys"
+        )
+        for rule, texts in result.untranslated_text:
+            UI.print_rule_item(rule)
+            UI.print_text_samples(texts)
+            issues += 1
+
+    if result.extra_rules:
+        UI.print_issue_category(
+            s.INFO, c.BLUE,
+            "Extra Rules",
+            len(result.extra_rules),
+            "may be intentional"
+        )
+        for rule in result.extra_rules:
+            UI.print_rule_item(rule)
+
+    return issues
 
 def get_yaml_files(lang_dir: Path) -> List[str]:
     """Get all YAML files to audit for a language"""


### PR DESCRIPTION
This is the first prototype of the language comparison tool we discussed.

I tried out using a package for `YAML`, but as ideally we want to remember specific line numbers, I decided to just work with the raw text instead in the end. Additionally, this leads to the script having 0 package dependencies.

I maybe went a bit overboard with the UI, but I wanted to learn about this topic anyway, so I took my chance here ;)

I'm not sure if the logic exactly corresponds to what you are looking for, so I think you should just try it out yourself and give me feedback.

Usage guide and examples are contained in the docstring of the script.

Below are two screenshots from the output of running it against the German translations, to see what it looks like so far:

_start of output:_
<img width="844" height="819" alt="image" src="https://github.com/user-attachments/assets/22f59621-2945-4904-8328-a276a8b472c7" />

_end of output:_
<img width="842" height="864" alt="image" src="https://github.com/user-attachments/assets/56a3faf0-20c1-4362-8022-645892a0e3ae" />
