### PR TITLE
panic when calling an unimplemented function

### DIFF
--- a/src/navigate.rs
+++ b/src/navigate.rs
@@ -943,7 +943,7 @@ fn navigation_command_string(command: NavigationCommand, param: NavigationParam)
             }
         },
         NavigationCommand::ReadTo => {
-            unimplemented!("ReadTo navigation command")
+            todo!("ReadTo navigation command")
         },
         NavigationCommand::Locate => {
             if param ==NavigationParam::Previous {


### PR DESCRIPTION
only a very small change.

I was stepping through the fix comments and saw that here it would be safer to actually [throw an exception](https://doc.rust-lang.org/std/macro.unimplemented.html)