### PR TITLE
Update match pattern and translation rules for "curl" in calculus.yaml

### DIFF
--- a/Rules/Languages/de/SharedRules/calculus.yaml
+++ b/Rules/Languages/de/SharedRules/calculus.yaml
@@ -16,9 +16,12 @@
 
 - name: curl
   tag: curl
-  match: "."
+  match: "count(*) = 1"
   replace:
-  - t: "rotation von"      # phrase(the 'curl of' a field)
+  - T: "Rotation"      # phrase(die 'Rotation' eines Feldes)
+  - test:
+      if: "$Verbosity!='Terse'"
+      then: [T: "von"]
   - test:
       if: "not(IsNode(*[1], 'leaf'))"
       then: [pause: short]


### PR DESCRIPTION
This is my first minor PR to get started with the rules for German.

My thoughts:

- Why does `en/SharedRules/calculus.yaml` have the condition `match: "count(*) = 1"`, while the one for German so far uses `"."` ? I think it makes sense to only match when there is exactly one child, in both languages.
- _Rotation_ is a noun, therefore should be written in uppercase (this is pretty strict, basically the only time you don't do this if you are casually texting or something like that, but never in a formal publication)
- The English case supports `"$Verbosity!='Terse'"`, while the German one does not. Generally, this should be supported as much as possible, right?
- The `# phrase` should always be an example for the language in use, so is this just a copy-paste error?