### PR TITLE
only show full details when using `--verbose` flag

### DIFF
--- a/PythonScripts/audit_translations/README.md
+++ b/PythonScripts/audit_translations/README.md
@@ -67,6 +67,7 @@ uv run python -m audit_translations --list
 * `--format`: Output format (`rich`, `jsonl`). `--output` is honored only for `jsonl`; rich output always prints to the console.
 * `--rules-dir`: Override the Rules/Languages directory path.
 * `--only`: Filter issue types (comma-separated): `missing`, `untranslated`, `extra`, `diffs`, `all`.
+* `--verbose`: Show detailed output including English/translated snippets for rule differences (only affects rich format; default shows summary only).
 * **Summary Stats:** Provides a statistical summary after every run.
 
 **Examples:**
@@ -89,4 +90,7 @@ uv run python -m audit_translations es --format jsonl --output es-issues.jsonl
 
 # Audit a regional variant (merges Rules/Languages/de and Rules/Languages/de/CH)
 uv run python -m audit_translations de-CH
+
+# Show detailed output with English/translated snippets for rule differences
+uv run python -m audit_translations es --verbose
 ```

--- a/PythonScripts/audit_translations/auditor.py
+++ b/PythonScripts/audit_translations/auditor.py
@@ -161,16 +161,17 @@ def print_rule_item(rule: RuleInfo, context: str = ""):
     console.print(f"      [dim]•[/] {rule_label(rule)} [dim](line {rule.line_number}{context})[/]")
 
 
-def print_diff_item(diff: RuleDifference):
+def print_diff_item(diff: RuleDifference, verbose: bool = False):
     """Print a single rule difference"""
     rule = diff.english_rule
     console.print(
         f"      [dim]•[/] {rule_label(rule)} "
         f"[dim](line {rule.line_number} en, {diff.translated_rule.line_number} tr)[/]"
     )
-    console.print(f"          [dim]{diff.description}:[/]")
-    console.print(f"          [green]en:[/] {escape(diff.english_snippet)}")
-    console.print(f"          [red]tr:[/] {escape(diff.translated_snippet)}")
+    console.print(f"          [dim]{diff.description}[/]")
+    if verbose:
+        console.print(f"          [green]en:[/] {escape(diff.english_snippet)}")
+        console.print(f"          [red]tr:[/] {escape(diff.translated_snippet)}")
 
 
 def issue_base(rule: RuleInfo, file_name: str, language: str) -> dict:
@@ -259,7 +260,7 @@ class IssueWriter:
         self.stream.write(json.dumps(issue, ensure_ascii=False) + "\n")
 
 
-def print_warnings(result: ComparisonResult, file_name: str) -> int:
+def print_warnings(result: ComparisonResult, file_name: str, verbose: bool = False) -> int:
     """Print warnings to console. Returns count of issues found."""
     issues = 0
 
@@ -296,7 +297,7 @@ def print_warnings(result: ComparisonResult, file_name: str) -> int:
             f"[[magenta]{total_diffs}[/]] [dim](structural differences between en and translation)[/]"
         )
         for diff in result.rule_differences:
-            print_diff_item(diff)
+            print_diff_item(diff, verbose)
             issues += 1
 
     if result.extra_rules:
@@ -315,6 +316,7 @@ def audit_language(
     output_path: Optional[str] = None,
     rules_dir: Optional[str] = None,
     issue_filter: Optional[set[str]] = None,
+    verbose: bool = False,
 ) -> int:
     """Audit translations for a specific language. Returns total issue count."""
     rules_dir_path = get_rules_dir(rules_dir)
@@ -382,7 +384,7 @@ def audit_language(
         has_issues = result.missing_rules or result.untranslated_text or result.extra_rules or result.rule_differences
         if output_format == "rich":
             if has_issues:
-                issues = print_warnings(result, file_name)
+                issues = print_warnings(result, file_name, verbose)
                 if issues > 0:
                     files_with_issues += 1
                 total_issues += issues

--- a/PythonScripts/audit_translations/cli.py
+++ b/PythonScripts/audit_translations/cli.py
@@ -39,6 +39,11 @@ Examples:
         "--only",
         help="Comma-separated issue types: missing, untranslated, extra, diffs, all",
     )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Show detailed output including rule snippets (only affects rich format)",
+    )
 
     args = parser.parse_args()
 
@@ -70,6 +75,7 @@ Examples:
             args.output,
             args.rules_dir,
             issue_filter,
+            args.verbose,
         )
 
 


### PR DESCRIPTION
now that I'm writing this, maybe we should call it -`-detailed`. I think "verbose" is more of a software term and might confuse people. what do you think?

default, without `--verbose`:
<img width="604" height="172" alt="image" src="https://github.com/user-attachments/assets/a2f80094-1ad7-4ac6-9fdc-bdc23e6e7cf3" />


with `--verbose` (was the default until now):
<img width="1758" height="296" alt="image" src="https://github.com/user-attachments/assets/66d334fe-c892-4792-938f-c281da35d752" />
