### PR TITLE
Add tests for Roman numeral regex validation

### DIFF
--- a/src/canonicalize.rs
+++ b/src/canonicalize.rs
@@ -6530,12 +6530,12 @@ mod canonicalize_tests {
 	fn test_roman_numeral_regex() {
 		assert!(UPPER_ROMAN_NUMERAL.is_match("XII"));
 		assert!(UPPER_ROMAN_NUMERAL.is_match("V  "));
-		assert!(!UPPER_ROMAN_NUMERAL.is_match("  XII"));
+		assert!(!UPPER_ROMAN_NUMERAL.is_match("  II"));
 		assert!(!UPPER_ROMAN_NUMERAL.is_match(" MCMXCIX "));
 
 		assert!(LOWER_ROMAN_NUMERAL.is_match("xii"));
 		assert!(LOWER_ROMAN_NUMERAL.is_match("v  "));
-		assert!(!LOWER_ROMAN_NUMERAL.is_match("  xii"));
+		assert!(!LOWER_ROMAN_NUMERAL.is_match("  ii"));
 		assert!(!LOWER_ROMAN_NUMERAL.is_match(" mcmxcix "));
 	}
 


### PR DESCRIPTION
while working with `LazyLock`, I saw that `UPPER_ROMAN_NUMERAL` and `LOWER_ROMAN_NUMERAL` have two matching operators `^` at the start, making them  not match leading whitespace. Is that the correct behaviour?
The comment in the code sounds like they aren't really needed generally though.

in the added test cases, the ones with leading whitespace are failing (`cargo test test_roman_numeral_regex`)