### PR TITLE
get test coverage

### DIFF
--- a/docs/developers.md
+++ b/docs/developers.md
@@ -1,0 +1,124 @@
+# Developer Guide
+
+This guide provides technical information for developers working on the MathCAT codebase.
+
+## Prerequisites
+
+To develop MathCAT, you need to have Rust installed. If you haven't already:
+
+1. [Download and install Rust](https://www.rust-lang.org/tools/install)
+2. Clone the MathCAT repository
+3. Open the project directory in your IDE
+
+## Working with Cargo
+
+Cargo is Rust's build system and package manager. Here are the essential commands you'll use:
+
+### Building the Project
+
+```bash
+# Build the project in debug mode
+cargo build
+
+# Build the project in release mode (optimized)
+cargo build --release
+```
+
+### Running the Project
+
+```bash
+# Run the main executable
+cargo run
+
+# Run with specific arguments
+cargo run -- <args>
+```
+
+### Managing Dependencies
+
+Dependencies are defined in `Cargo.toml`. Cargo automatically downloads and manages them.
+
+```bash
+# Update dependencies to their latest compatible versions
+cargo update
+```
+
+## Testing
+
+Testing is crucial for maintaining code quality and ensuring that changes don't break existing functionality.
+
+### Running Tests
+
+```bash
+# Run all tests
+cargo test
+
+# Run a specific test
+cargo test test_name
+```
+
+### Writing Tests
+
+Tests in MathCAT verify that MathML expressions produce the expected speech output. Example:
+
+```rust
+#[test]
+fn test_simple_fraction() {
+    let expr = "<math>
+                    <mfrac>
+                        <mn>1</mn>
+                        <mn>2</mn>
+                    </mfrac>
+                </math>";
+    test("en", "SimpleSpeak", expr, "1 half");
+}
+```
+
+### Test Coverage
+
+Test coverage helps identify which parts of the code are exercised by tests and which parts need more testing.
+
+<details>
+<summary>Using grcov on macOS</summary>
+
+This approach uses `llvm-cov` and `grcov` to generate test coverage reports. Other operating systems should also work with [grcov](https://github.com/mozilla/grcov), but may require some adjustments regarding LLVM paths and configuration.
+
+**One-time setup:**
+
+```bash
+# Install required components
+rustup component add llvm-tools-preview
+cargo install grcov
+```
+
+**Generate coverage report:**
+
+```bash
+# Set environment variable for profiling data
+export LLVM_PROFILE_FILE="target/coverage/%p-%m.profraw"
+
+# Run tests with coverage instrumentation
+RUSTFLAGS="-Cinstrument-coverage" cargo test
+
+# Example: Run a single test
+# RUSTFLAGS="-Cinstrument-coverage" cargo test Languages::zh::tw::units::without_prefix_powers_of_2
+
+# Generate HTML report
+grcov . \
+  --source-dir . \
+  --binary-path ./target/debug/deps \
+  -t html \
+  --branch \
+  --ignore-not-existing \
+  --ignore "target/*" \
+  -o target/coverage/html
+
+# Open the report in your browser
+open target/coverage/html/index.html
+```
+
+</details>
+
+**Alternative: IDE Integration**
+
+Many Rust IDEs provide built-in test coverage support, like RustRover or VSCode.

--- a/docs/helpers.md
+++ b/docs/helpers.md
@@ -252,38 +252,7 @@ Whether you are developing code or writing rules, writing and running the tests 
 
 The `tests` directory is similar to the `Rules` directory. If you are a translator, see the section above that describes what you should do.
 
-Rust provides testing support with the command `cargo test`.
-
-### Test Coverage
-
-This section explains test coverage with `llvm-cov` and `grcov` on _MacOS_.
-Another option is using built-in coverage-support of your IDE, for example _RustRover_ by _JetBrains_.
-
-Using other operating systems should also work with [grcov](https://github.com/mozilla/grcov),
-but may require some tweaks regarding LLVM, paths, etc.
-
-```bash
-# One-time setup
-rustup component add llvm-tools-preview
-cargo install grcov
-
-export LLVM_PROFILE_FILE="target/coverage/%p-%m.profraw"
-RUSTFLAGS="-Cinstrument-coverage" cargo test
-# Example with a single test:
-# RUSTFLAGS="-Cinstrument-coverage" cargo test Languages::zh::tw::units::without_prefix_powers_of_2
-
-# Generate report
-grcov . \
-  --source-dir . \
-  --binary-path ./target/debug/deps \
-  -t html \
-  --branch \
-  --ignore-not-existing \
-  --ignore "target/*" \
-  -o target/coverage/html
-
-open target/coverage/html/index.html
-```
+Rust provides testing support with the command `cargo test`. For more information about testing and test coverage, see the [Developer Guide](developers.md).
 
 
 ## Files

--- a/docs/index.md
+++ b/docs/index.md
@@ -17,7 +17,7 @@ There are many different audiences for MathCAT and each audience has different i
 * AT users: [information about preferences you can set](users.md)
 * AT developers/library users: [information about the API that MathCAT exposes](callers.md)
 * Translators/Rule writers: [information about the files that need to be translated](helpers.md)
-* MathCAT developers: information about MathCAT's design
+* MathCAT developers: [information about development workflow and testing](developers.md)
 
 # Some Technical Details
 MathCAT is written in Rust and can be built to interface with many languages. To date there are interfaces for:


### PR DESCRIPTION
after praising the tests today, I was thinking about how I haven't run any test coverage yet ;)

Somehow, this seems more involved for Rust than I thought it would be.
In _IntellJ_ and _PyCharm_, there are IDE-integrations that immediately let you do it.
_RustRover_ (what a name) doesn't seem to have that (yet).

I managed to get something running with [grcov](https://github.com/mozilla/grcov), which generates a report in `target/coverage/html/index.html` that looks like this:
<img width="600" alt="image" src="https://github.com/user-attachments/assets/fbd769fc-29ba-4a22-bff6-3bce528bf383" />

- Do you already have workflow for test coverage?
- If not, what do you think about this option?
- I'm not sure if this will work on Windows nicely
- If we want to document this workflow, should we add it to the README? It does not have any technical guidance like this so far.
- Do we want to create a `CONTRIBUTING.md` for more technical information instead and add this (and some more basics) to it? I think this would be a good idea if there'll be more new people coming

Edit: I think I figured out how to do it with my IDE, but I think it's still a good idea to have a Rust-only way to do this