### PR TITLE
add CLI entry-point for uv

### DIFF
--- a/PythonScripts/README.md
+++ b/PythonScripts/README.md
@@ -2,4 +2,10 @@
 
 Project management is done with [uv](https://docs.astral.sh/uv/).
 
-For example, execute `uv run python -m audit_translations de` to see the translation progress for the German language.
+For example, execute `uv run audit-translations de` to see the translation progress for the German language.
+
+If you run from the repo root instead of inside `PythonScripts`, point uv at the project and make sure you've synced once:
+```bash
+uv sync --project PythonScripts
+uv run --project PythonScripts audit-translations de
+```

--- a/PythonScripts/audit_translations/README.md
+++ b/PythonScripts/audit_translations/README.md
@@ -56,8 +56,13 @@ The tool automatically adjusts its matching logic based on the file type:
 
 **Syntax:**
 ```bash
-uv run python -m audit_translations <language> [--file <specific_file>]
-uv run python -m audit_translations --list
+# Preferred: console script (no -m needed)
+uv run audit-translations <language> [--file <specific_file>]
+uv run audit-translations --list
+
+# If running from the repo root, point uv at the project:
+uv run --project PythonScripts audit-translations <language>
+uv run --project PythonScripts audit-translations --list
 ```
 
 **Convenience Features:**
@@ -74,25 +79,34 @@ uv run python -m audit_translations --list
 
 ```bash
 # List available languages
-uv run python -m audit_translations --list
+uv run audit-translations --list
+
+# Same from repo root
+uv run --project PythonScripts audit-translations --list
 
 # Audit all Spanish translation files
-uv run python -m audit_translations es
+uv run audit-translations es
 
 # Audit German translations
-uv run python -m audit_translations de
+uv run audit-translations de
 
 # Audit only a specific file
-uv run python -m audit_translations es --file SharedRules/default.yaml
+uv run audit-translations es --file SharedRules/default.yaml
 
 # Produce JSONL output for automation or AI workflows
-uv run python -m audit_translations es --format jsonl --output es-issues.jsonl
+uv run audit-translations es --format jsonl --output es-issues.jsonl
 
 # Audit a regional variant (merges Rules/Languages/de and Rules/Languages/de/CH)
-uv run python -m audit_translations de-CH
+uv run audit-translations de-CH
 
 # Show detailed output with English/translated snippets for rule differences
-uv run python -m audit_translations es --verbose
+uv run audit-translations es --verbose
+```
+
+**Running from the repo root (without `cd PythonScripts`):**
+```bash
+uv run --project PythonScripts audit-translations es
+uv run --project PythonScripts audit-translations --list
 ```
 
 ### Testing

--- a/PythonScripts/audit_translations/cli.py
+++ b/PythonScripts/audit_translations/cli.py
@@ -18,9 +18,9 @@ def main():
         formatter_class=argparse.RawDescriptionHelpFormatter,
         epilog="""
 Examples:
-    python -m audit_translations es
-    python -m audit_translations de --file SharedRules/default.yaml
-    python -m audit_translations --list
+    uv run audit-translations es
+    uv run audit-translations de --file SharedRules/default.yaml
+    uv run audit-translations --list
         """
     )
 

--- a/PythonScripts/pyproject.toml
+++ b/PythonScripts/pyproject.toml
@@ -6,5 +6,16 @@ readme = "README.md"
 requires-python = ">=3.14"
 dependencies = ["rich", "ruamel.yaml"]
 
+[project.scripts]
+audit-translations = "audit_translations.cli:main"
+
 [dependency-groups]
 dev = ["pytest"]
+
+[build-system]
+requires = ["uv_build>=0.9.25,<0.10.0"]
+build-backend = "uv_build"
+
+[tool.uv.build-backend]
+module-name = "audit_translations"
+module-root = ""

--- a/PythonScripts/uv.lock
+++ b/PythonScripts/uv.lock
@@ -87,7 +87,7 @@ wheels = [
 [[package]]
 name = "pythonscripts"
 version = "0.1.0"
-source = { virtual = "." }
+source = { editable = "." }
 dependencies = [
     { name = "rich" },
     { name = "ruamel-yaml" },


### PR DESCRIPTION
Thinking about the future usage of this tool, I didn't like how you had to use the `-m` flag to execute it as a module. So I added an entry point in our Python project manager `UV` to run it directly so that you can skip some words when calling the CLI.

old way: `uv run python -m foo`
new way: `uv run foo`

also updated docs, and added explanation how to run it from the repo root by using the flag `--project PythonScripts` (idk though if that's really easier than picking up what `cd` does)


next PR, I want to rename it to be consistently called `localization_tool`, like discussed earlier