### PR TITLE
Fix `pre-release` job in Github actions to stop PR failures

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -56,6 +56,7 @@ jobs:
   pre-release:
     name: Pre Release
     continue-on-error: false
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main' # otherwise, job fails on pull requests, as GITHUB_TOKEN is not available
     needs: [zip-rules]
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
this should fix the failing jobs we talked about like 2 weeks ago.

the problem is that `GITHUB_TOKEN` seems to not be available in jobs started by a PR.
as pre-release should only be relevant for you if you push to main anyway, I added this as a condition,
so that pre-release is not triggered anymore by pull requests.

I have only limited experience with GitHub actions, but this solution seems correct to me after skimming [the docs](https://docs.github.com/en/actions/reference/workflows-and-actions/contexts). we could also try to check that `github.event_name == 'pull_request'` is not fulfilled, alternatively.

also, for some reason the `marvinpinto/action-automatic-releases` repo that is used has a bunch of Chinese (I think) stuff in it, so if you look at the report generated from the failing job, you're first spammed with a bunch of gibberish, which has nothing to do with the problem (well if so that would make it more interesting)

---

also very interesting to me: the job did not fail for this PR. so apparently the code changes here already influence CI. didn't expect that, and also sounds like an awful security backdoor to me?!? very sus.
on the bright side, my error diagnosis seems correct.