### PR TITLE
Add CODEOWNERS rule for PythonScripts

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+/PythonScripts/  @moritz-gross


### PR DESCRIPTION
this should allow me to approve PRs touch only files in the `PythonScripts` folder (my own and later on from others).

We could also narrow this down to the folder for the diff-tool, but then README, uv, etc. would be out of reach.