### PR TITLE
basic testing of `shim_filesystem.rs` using tempfile dev-dep

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,6 +53,9 @@ zip = { version = "7.0", default-features = false, features = ["deflate"] }
 [target.'cfg(not(target_family = "wasm"))'.build-dependencies]
 zip = { version = "7.0", default-features = false, features = ["bzip2"] }
 
+[dev-dependencies]
+tempfile = "3.23"
+
 [lib]
 name = "libmathcat"
 crate-type = ["rlib", "cdylib"]


### PR DESCRIPTION
`cargo test --lib shim_filesystem::tests:` passes


I've only heard the word "shim" once in a video game, so I thought it was made up 😬


test coverage showed 0% for this file (can that really be correct?), so I figured it makes sense to start.
adding `tempfile` as dev dependency looks like the easiest way to me.

not sure about the `cfg` part that I added. but it follows the earlier parts of the file.
`wasm` is _WebAssembly_ I assume? haven't worked with that yet, so I have only very surface level knowledge.
It looks like a hard requirement to use zip for wasm, but how/why are zip files used for other platforms? 