### PR TITLE
Use target language code in rich output labels

### DIFF
--- a/PythonScripts/audit_translations/auditor.py
+++ b/PythonScripts/audit_translations/auditor.py
@@ -392,10 +392,16 @@ class IssueWriter:
         self.stream.write(json.dumps(issue, ensure_ascii=False) + "\n")
 
 
-def print_warnings(result: ComparisonResult, file_name: str, verbose: bool = False) -> int:
+def print_warnings(
+    result: ComparisonResult,
+    file_name: str,
+    verbose: bool = False,
+    target_language: str = "tr",
+) -> int:
     """Print warnings to console. Returns count of issues found."""
     issues = 0
     display_name = Path(file_name).as_posix()
+    target_label = normalize_language(target_language)
 
     has_issues = result.missing_rules or result.untranslated_text or result.extra_rules or result.rule_differences
     if not has_issues:
@@ -497,24 +503,24 @@ def print_warnings(result: ComparisonResult, file_name: str, verbose: bool = Fal
                         issues += 1
                     elif issue_type == "extra_rule":
                         console.print(
-                            f"              [dim]•[/] [dim](line {entry['line_tr']} in translation)[/]"
+                            f"              [dim]•[/] [dim](line {entry['line_tr']} in {target_label})[/]"
                         )
                         issues += 1
                     elif issue_type == "untranslated_text":
                         console.print(
-                            f"              [dim]•[/] [dim](line {entry['line_tr']} tr)[/] "
+                            f"              [dim]•[/] [dim](line {entry['line_tr']} {target_label})[/] "
                             f"[yellow]\"{escape(entry['text'])}\"[/]"
                         )
                         issues += 1
                     else:
                         diff: RuleDifference = entry["diff"]
                         console.print(
-                            f"              [dim]•[/] [dim](line {entry['line_en']} en, {entry['line_tr']} tr)[/]"
+                            f"              [dim]•[/] [dim](line {entry['line_en']} en, {entry['line_tr']} {target_label})[/]"
                         )
                         console.print(f"                  [dim]{diff.description}[/]")
                         if verbose:
                             console.print(f"                  [green]en:[/] {escape(diff.english_snippet)}")
-                            console.print(f"                  [red]tr:[/] {escape(diff.translated_snippet)}")
+                            console.print(f"                  [red]{target_label}:[/] {escape(diff.translated_snippet)}")
                         issues += 1
 
     return issues
@@ -595,7 +601,7 @@ def audit_language(
         has_issues = result.missing_rules or result.untranslated_text or result.extra_rules or result.rule_differences
         if output_format == "rich":
             if has_issues:
-                issues = print_warnings(result, file_name, verbose)
+                issues = print_warnings(result, file_name, verbose, language)
                 if issues > 0:
                     files_with_issues += 1
                 total_issues += issues

--- a/PythonScripts/audit_translations/tests/golden/rich/cli_calculus_verbose.golden
+++ b/PythonScripts/audit_translations/tests/golden/rich/cli_calculus_verbose.golden
@@ -16,46 +16,46 @@
               • (line 4 in English)
       • divergence (divergence)
           Untranslated Text [3]
-              • (line 10 tr) "divergence"
-              • (line 11 tr) "div"
-              • (line 12 tr) "of"
+              • (line 10 es) "divergence"
+              • (line 11 es) "div"
+              • (line 12 es) "of"
           Match Pattern Differences [1]
-              • (line 22 en, 6 tr)
+              • (line 22 en, 6 es)
                   Match pattern differs
                   en: count(*) = 1
-                  tr: .
+                  es: .
           Condition Differences [1]
-              • (line 25 en, 9 tr)
+              • (line 25 en, 9 es)
                   Conditions differ
                   en: $Verbosity='Terse', not(IsNode(*[1], 'leaf'))
-                  tr: $Verbosity='Verbose', not(IsNode(*[1], 'leaf'))
+                  es: $Verbosity='Verbose', not(IsNode(*[1], 'leaf'))
       • curl (curl)
           Untranslated Text [1]
-              • (line 22 tr) "curl of"
+              • (line 22 es) "curl of"
           Match Pattern Differences [1]
-              • (line 35 en, 20 tr)
+              • (line 35 en, 20 es)
                   Match pattern differs
                   en: count(*) = 1
-                  tr: .
+                  es: .
           Condition Differences [1]
-              • (line 39 en, 24 tr)
+              • (line 39 en, 24 es)
                   Conditions differ
                   en: $Verbosity!='Terse', not(IsNode(*[1], 'leaf'))
-                  tr: not(IsNode(*[1], 'leaf'))
+                  es: not(IsNode(*[1], 'leaf'))
           Structure Differences [1]
-              • (line 38 en, 18 tr)
+              • (line 38 en, 18 es)
                   Rule structure differs (test/if/then/else blocks)
                   en: replace: test: if: then: test: if: then:
-                  tr: replace: test: if: then:
+                  es: replace: test: if: then:
       • gradient (gradient)
           Untranslated Text [2]
-              • (line 34 tr) "gradient of"
-              • (line 35 tr) "del"
+              • (line 34 es) "gradient of"
+              • (line 35 es) "del"
           Match Pattern Differences [1]
-              • (line 48 en, 30 tr)
+              • (line 48 en, 30 es)
                   Match pattern differs
                   en: count(*) = 1
-                  tr: .
+                  es: .
 ╭──────────────────────────────────────────────────────────────────────────────╮
 │                 SUMMARY                                                      │
 │   Files checked                     1                                        │


### PR DESCRIPTION
so far, "tr" is hardcoded for the _translated_ language. not very pretty, and also a bit confusing because of Turkey, which I didn't think of at the start. now, a dynamic language label is used.