### PR TITLE
Fix chemistry test `merge_bug_274`

### DIFF
--- a/src/chemistry.rs
+++ b/src/chemistry.rs
@@ -3174,7 +3174,7 @@ mod chem_tests {
                     <mo data-changed='added' data-maybe-chemistry='0'>&#x2062;</mo>
                     <mtext data-maybe-chemistry='0'>to</mtext>
                     <mo data-changed='added' data-maybe-chemistry='0'>&#x2062;</mo>
-                    <mtext data-maybe-chemistry='0'>2</mtext>
+                    <mn data-maybe-chemistry='0'>2</mn>
                     <mo data-changed='added' data-maybe-chemistry='0'>&#x2062;</mo>
                     <mi data-maybe-chemistry='1' mathvariant='normal'>H</mi>
                     <mo data-changed='added' data-maybe-chemistry='0'>&#x2062;</mo>


### PR DESCRIPTION
This test is currently failing on the `main` branch.

I'm only somewhat confident that this is the correct fix. It does seem intentional that the underlying `canonicalize` call transforms the `<mtext>2</mtext>` tag into a number representation `<mn ...>2</mn>`. 