### PR TITLE
Render basic tables and detect them in rules

### DIFF
--- a/Rules/Intent/general.yaml
+++ b/Rules/Intent/general.yaml
@@ -804,7 +804,7 @@
 -
   name: mtable-array-property
   tag: mtable
-  match: "count(*) > 0 and ((@frame='solid' or @frame='dashed') or child::*[@rowspan]) or child::*/child::*[@rowspan or @colspan]"
+  match: "count(*) > 0 and ((@frame='solid' or @frame='dashed') or child::*[@rowspan]) or child::*/child::*[@rowspan or @colspan or @columnspan]"
   replace:
   - with:
       variables:

--- a/Rules/Intent/general.yaml
+++ b/Rules/Intent/general.yaml
@@ -804,7 +804,7 @@
 -
   name: mtable-array-property
   tag: mtable
-  match: "count(*) > 0 and ((@frame='solid' or @frame='dashed') or descendant::*[@rowspan])"
+  match: "count(*) > 0 and ((@frame='solid' or @frame='dashed') or child::*[@rowspan]) or child::*/child::*[@rowspan or @colspan]"
   replace:
   - with:
       variables:

--- a/Rules/Intent/general.yaml
+++ b/Rules/Intent/general.yaml
@@ -804,7 +804,7 @@
 -
   name: mtable-array-property
   tag: mtable
-  match: "count(*) > 0 and ((@frame='solid' or @frame='dashed') or child::*[@rowspan]) or child::*/child::*[@rowspan or @colspan or @columnspan]"
+  match: "count(*) > 0 and ((@frame='solid' or @frame='dashed') or child::*[@rowspan] or child::*/child::*[@rowspan or @colspan or @columnspan] or  not(preceding-sibling::*[1][self::m:mo and text() != '\u2062']))"
   replace:
   - with:
       variables:

--- a/Rules/Intent/general.yaml
+++ b/Rules/Intent/general.yaml
@@ -801,6 +801,20 @@
           name: "system-of-equations"
           children:
           - x: "*"
+-
+  name: mtable-array-property
+  tag: mtable
+  match: "count(*) > 0 and ((@frame='solid' or @frame='dashed') or descendant::*[@rowspan])"
+  replace:
+  - with:
+      variables:
+      - TableProperty: "'array'"
+      replace:
+      - intent:
+          name: "array"
+          children:
+          - x: "*"
+
 
 -
   name: mtable-lines-property

--- a/Rules/Languages/en/SharedRules/default.yaml
+++ b/Rules/Languages/en/SharedRules/default.yaml
@@ -419,22 +419,23 @@
                           - t: "end scripts"      # phrase(At this point 'end scripts' occurs)
 
 - name: default
-  tag: mtable
+  tag: [mtable, array]
   variables:
   - IsColumnSilent: "false()"
-  - NumColumns: "count(*[1]/*) - IfThenElse(*/self::m:mlabeledtr, 1, 0)"
+  - NumColumns: "CountTableColumns(.)"
+  - NumRows: "CountTableRows(.)"
   match: "."
   replace:
   - t: "table with"      # phrase(the 'table with' 3 rows)
-  - x: count(*)
+  - x: "$NumRows"
   - test:
-      if: count(*)=1
+      if: "$NumRows=1"
       then: [t: "row"]      # phrase(the table with 1 'row')
       else: [t: "rows"]      # phrase(the table with 3 'rows')
   - t: "and"      # phrase(the table with 3 rows 'and' 4 columns)
   - x: "$NumColumns"
   - test:
-      if: "NumColumns=1"
+      if: "$NumColumns=1"
       then: [t: "column"]      # phrase(the table with 3 rows and 1 'column')
       else: [t: "columns"]      # phrase(the table with 3 rows and 4 'columns')
   - pause: long

--- a/src/speech.rs
+++ b/src/speech.rs
@@ -7,6 +7,7 @@ use std::path::PathBuf;
 use std::collections::HashMap;
 use std::cell::{RefCell, RefMut};
 use std::sync::LazyLock;
+use std::fmt::Debug;
 use sxd_document::dom::{ChildOfElement, Document, Element};
 use sxd_document::{Package, QName};
 use sxd_xpath::context::Evaluation;
@@ -311,7 +312,7 @@ pub fn process_include<F>(current_file: &Path, new_file_name: &str, mut read_new
 
 /// As the name says, TreeOrString is either a Tree (Element) or a String
 /// It is used to share code during pattern matching
-pub trait TreeOrString<'c, 'm:'c, T> {
+pub trait TreeOrString<'c, 'm:'c, T: Debug> : Debug {
     fn from_element(e: Element<'m>) -> Result<T>;
     fn from_string(s: String, doc: Document<'m>) -> Result<T>;
     fn replace_tts<'s:'c, 'r>(tts: &TTS, command: &TTSCommandRule, prefs: &PreferenceManager, rules_with_context: &'r mut SpeechRulesWithContext<'c, 's,'m>, mathml: Element<'c>) -> Result<T>;

--- a/src/xpath_functions.rs
+++ b/src/xpath_functions.rs
@@ -22,7 +22,7 @@ use sxd_xpath::{Value, Context, context, function::*, nodeset::*};
 use crate::definitions::{Definitions, SPEECH_DEFINITIONS, BRAILLE_DEFINITIONS};
 use regex::Regex;
 use crate::pretty_print::mml_to_string;
-use std::cell::{Ref, RefCell};
+use std::{cell::{Ref, RefCell}, collections::HashMap};
 use log::{debug, error, warn};
 use std::sync::LazyLock;
 use std::thread::LocalKey;
@@ -333,7 +333,7 @@ static ALL_MATHML_ELEMENTS: phf::Set<&str> = phf_set!{
 };
 
 static MATHML_LEAF_NODES: phf::Set<&str> = phf_set! {
-	"mi", "mo", "mn", "mtext", "ms", "mspace", "mglyph",
+    "mi", "mo", "mn", "mtext", "ms", "mspace", "mglyph",
     "none", "annotation", "ci", "cn", "csymbol",    // content could be inside an annotation-xml (faster to allow here than to check lots of places)
 };
 
@@ -1413,69 +1413,150 @@ impl Function for ReplaceAll {
     }
 }
 
-struct CountTableDims;
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum CTDRowType {
+    Normal,
+    Labeled,
+    Implicit,
+}
+
+/// A single-use structure for computing the proper dimensions of an
+/// `mtable`.
+struct CountTableDims {
+    num_rows: usize,
+    num_cols: usize,
+    /// map from number of remaining in extra row-span to number of
+    /// columns with that value.
+    extended_cells: HashMap<usize, usize>,
+    /// rowspan=0 cells extend for the rest of the table, however
+    /// long that may be as determined by all other finite cells.
+    permanent_cols: usize,
+}
+
 impl CountTableDims {
+
+    fn new() -> CountTableDims {
+        Self { num_rows: 0, num_cols: 0, extended_cells: HashMap::new(), permanent_cols: 0 }
+    }
+
+    /// Returns the number of columns the cell contributes to the
+    /// current row. Also updates `extended_cells` as appropriate.
+    fn process_cell_in_row<'d>(&mut self, mtd: Element<'d>, is_first: bool, row_type: CTDRowType) -> usize {
+        // Rows can only contain `mtd`s.  If this is not an `mtd`, we will just skip it.
+        if name(mtd) != "mtd" {
+            return 0;
+        }
+
+        // Add the contributing columns, taking colspan into account. Don't contribute if
+        // this is the first element of a labeled row.
+        let colspan = mtd.attribute_value("colspan")
+            .or_else(|| mtd.attribute_value("columnspan"))
+            .map_or(1, |e| e.parse::<usize>().unwrap_or(1));
+        if row_type == CTDRowType::Labeled && is_first {
+            // This is a label for the row and does not contibute to
+            // the size of the table. NOTE: Can this label have a
+            // non-trivial rowspan? If so, can it otherwise extend the
+            // size of the table?
+            return 0;
+        }
+
+        let rowspan = mtd.attribute_value("rowspan").map_or(1, |e| {
+            e.parse::<usize>().unwrap_or(1)
+        });
+
+        if rowspan > 1 {
+            *self.extended_cells.entry(rowspan).or_default() += colspan;
+        } else if rowspan == 0 {
+            self.permanent_cols += colspan;
+        }
+
+        colspan
+    }
+
+    /// Update the number of rows, and update the extended cells.
+    /// Returns the total number of columns accross all extended
+    /// cells.
+    fn next_row(&mut self) -> usize {
+        self.num_rows += 1;
+        let mut ext_cols = 0;
+        self.extended_cells = self.extended_cells.iter().filter(|&(k, _)| *k > 1).map(|(k, v)| {
+            ext_cols += *v;
+            (k-1, *v)
+        }).collect();
+        ext_cols
+    }
+
     /// For an `mtable` element, count the number of rows and columns in the table.
     ///
     /// This function is relatively permissive. Non-`mtr` rows are
     /// ignored. The number of columns is determined only from the first
     /// row, if it exists. Within that row, non-`mtd` elements are ignored. 
-    fn count_table_dims<'d>(e: Element<'_>) -> Result<(Value<'d>, Value<'d>), Error> {
-        let mut num_cols = 0;
-        let mut num_rows = 0;
+    fn count_table_dims<'d>(mut self, e: Element<'_>) -> Result<(Value<'d>, Value<'d>), Error> {
         for child in e.children() {
             let ChildOfElement::Element(row) = child else {
                 continue
             };
 
-            // each child of mtable should be an mtr. Ignore non-mtr rows.
+            // Each child of mtable should be an mtr or mlabeledtr. According to the spec, though,
+            // bare `mtd`s should also be treated as having an implicit wrapping `<mtr>`.
+            // Other elements should be ignored.
             let row_name = name(row);
 
-            let labeled_row = if row_name == "mlabeledtr" {
-                true
+            let row_type = if row_name == "mlabeledtr" {
+                CTDRowType::Labeled
             } else if row_name == "mtr" {
-                false
+                CTDRowType::Normal
+            } else if row_name == "mtd" {
+                CTDRowType::Implicit
             } else {
                 continue;
             };
-            num_rows += 1;
 
-            // count columns based on the number of rows.
-            if num_rows == 1 {
-                // count the number of columns, including column spans, in the first row.
-                let mut first_elem = true;
-                for row_child in row.children() {
-                    let ChildOfElement::Element(mtd) = row_child else  {
-                        continue;
-                    };
-                    if name(mtd) != "mtd" {
-                        continue;
+            let ext_cols = self.next_row();
+
+            let mut num_cols_in_row = 0;
+            match row_type {
+                CTDRowType::Normal | CTDRowType::Labeled => {
+                    let mut first_elem = true;
+                    for row_child in row.children() {
+                        let ChildOfElement::Element(mtd) = row_child else  {
+                            continue;
+                        };
+
+                        num_cols_in_row += self.process_cell_in_row(mtd, first_elem, row_type);
+                        first_elem= false;
                     }
-                    // Add the contributing columns, taking colspan into account. Don't contribute if
-                    // this is the first element of a labeled row.
-                    let colspan = mtd.attribute_value("colspan").map_or(1, |e| e.parse::<usize>().unwrap_or(0));
-                    if !(labeled_row && first_elem) {
-                        num_cols += colspan;
-                    }
-                    first_elem = false;
+                }
+                CTDRowType::Implicit => {
+                    num_cols_in_row += self.process_cell_in_row(row, true, row_type)
                 }
             }
+            // update the number of columns based on this row.
+            self.num_cols = self.num_cols.max(num_cols_in_row + ext_cols + self.permanent_cols);
         }
 
-        Ok((Value::Number(num_rows as f64), Value::Number(num_cols as f64)))
+        // At this point, the number of columns is correct. If we have
+        // any leftover rows from rowspan extended cells, we need to
+        // account for them here.
+        //
+        // NOTE: It does not appear that renderers respect these extra
+        // columns, so we will not use them.
+        let _extra_rows = self.extended_cells.keys().max().map(|k| k-1).unwrap_or(0);
+
+        Ok((Value::Number(self.num_rows  as f64), Value::Number(self.num_cols as f64)))
     }
 
-    fn evaluate<'d>(fn_name: &str,
+    fn evaluate<'d>(self, fn_name: &str,
                         args: Vec<Value<'d>>) -> Result<(Value<'d>, Value<'d>), Error> {
         let mut args = Args(args);
         args.exactly(1)?;
         let element = args.pop_nodeset()?;
         let node = validate_one_node(element, fn_name)?;
         if let Node::Element(e) = node {
-            return Self::count_table_dims(e);
+            return self.count_table_dims(e);
         }
 
-        Err( Error::Other("couldn't count table rows".to_string()) )
+        Err( Error::Other("Could not count dimensions of non-Element.".to_string()) )
     }
 }
 
@@ -1484,7 +1565,7 @@ impl Function for CountTableRows {
     fn evaluate<'c, 'd>(&self,
                         _context: &context::Evaluation<'c, 'd>,
                         args: Vec<Value<'d>>) -> Result<Value<'d>, Error> {
-        CountTableDims::evaluate("CountTableRows", args).map(|a| a.0)
+        CountTableDims::new().evaluate("CountTableRows", args).map(|a| a.0)
     }
 }
 
@@ -1493,7 +1574,7 @@ impl Function for CountTableColumns {
     fn evaluate<'c, 'd>(&self,
                         _context: &context::Evaluation<'c, 'd>,
                         args: Vec<Value<'d>>) -> Result<Value<'d>, Error> {
-        CountTableDims::evaluate("CountTableColumns", args).map(|a| a.1)
+        CountTableDims::new().evaluate("CountTableColumns", args).map(|a| a.1)
     }
 }
 
@@ -1693,26 +1774,25 @@ mod tests {
                    
     }
 
+    fn check_table_dims(mathml: &str, dims: (usize, usize)) {
+        let package = parser::parse(mathml).expect("failed to parse XML");
+        let math_elem = get_element(&package);
+        let child = as_element(math_elem.children()[0]);
+        assert!(CountTableDims::new().count_table_dims(child) == Ok((Value::Number(dims.0 as f64), Value::Number(dims.1 as f64))));
+    }
+
     #[test]
-    fn table_row_count() {
-	let mathml = "<math><mtable><mtr><mtd>a</mtd></mtr></mtable></math>";
-	let package = parser::parse(mathml).expect("failed to parse XML");
-	let math_elem = get_element(&package);
-	let child = as_element(math_elem.children()[0]);
-	assert!(CountTableDims::count_table_dims(child) == Ok((Value::Number(1.0), Value::Number(1.0))));
+    fn table_dim() {
+        check_table_dims("<math><mtable><mtr><mtd>a</mtd></mtr></mtable></math>", (1, 1));
+        check_table_dims("<math><mtable><mtr><mtd colspan=\"3\">a</mtd><mtd>b</mtd></mtr><mtr><mtd></mtd></mtr></mtable></math>", (2, 4));
 
-	let mathml = "<math><mtable><mtr><mtd colspan=\"3\">a</mtd><mtd>b</mtd></mtr><mtr><mtd></mtd></mtr></mtable></math>";
-	let package = parser::parse(mathml).expect("failed to parse XML");
-	let math_elem = get_element(&package);
-	let child = as_element(math_elem.children()[0]);
-	assert!(CountTableDims::count_table_dims(child) == Ok((Value::Number(2.0), Value::Number(4.0))));
+        check_table_dims("<math><mtable><mlabeledtr><mtd>label</mtd><mtd>a</mtd><mtd>b</mtd></mlabeledtr><mtr><mtd>c</mtd><mtd>d</mtd></mtr></mtable></math>", (2, 2));
+        // extended rows beyond the `mtr`s do *not* count towards the row count.
+        check_table_dims("<math><mtable><mtr><mtd rowspan=\"3\">a</mtd></mtr></mtable></math>", (1, 1));
 
-	let mathml = "<math><mtable><mlabeledtr><mtd>label</mtd><mtd>a</mtd><mtd>b</mtd></mlabeledtr><mtr><mtd>c</mtd><mtd>d</mtd></mtr></mtable></math>";
-	let package = parser::parse(mathml).expect("failed to parse XML");
-	let math_elem = get_element(&package);
-	let child = as_element(math_elem.children()[0]);
-	let ctd = CountTableDims::count_table_dims(child);
-	assert!(ctd == Ok((Value::Number(2.0), Value::Number(2.0))));
+        check_table_dims("<math><mtable><mtr><mtd rowspan=\"3\">a</mtd></mtr>
+<mtr><mtd columnspan=\"2\">b</mtd></mtr></mtable></math>", (2, 3));
+
     }
 
     #[test]

--- a/src/xpath_functions.rs
+++ b/src/xpath_functions.rs
@@ -1465,17 +1465,17 @@ impl CountTableDims {
 	Ok((Value::Number(num_rows as f64), Value::Number(num_cols as f64)))
     }
 
-    fn evaluate<'c, 'd>(fn_name: &str,
+    fn evaluate<'d>(fn_name: &str,
                         args: Vec<Value<'d>>) -> Result<(Value<'d>, Value<'d>), Error> {
 	let mut args = Args(args);
 	args.exactly(1)?;
 	let element = args.pop_nodeset()?;
 	let node = validate_one_node(element, fn_name)?;
 	if let Node::Element(e) = node {
-	    return Ok(Self::count_table_dims(e)?);
+	    return Self::count_table_dims(e);
 	}
 
-	Err( Error::Other(format!("couldn't count table rows")) )
+	Err( Error::Other("couldn't count table rows".to_string()) )
     }
 }
 

--- a/src/xpath_functions.rs
+++ b/src/xpath_functions.rs
@@ -1421,9 +1421,6 @@ impl CountTableDims {
     /// ignored. The number of columns is determined only from the first
     /// row, if it exists. Within that row, non-`mtd` elements are ignored. 
     fn count_table_dims<'d>(e: Element<'_>) -> Result<(Value<'d>, Value<'d>), Error> {
-	if e.name().local_part() != "mtable" {
-	    return Err(Error::Other(format!("invalid tag {} for CountTableRows", e.name().local_part())));
-	}
 	let mut num_cols = 0;
 	let mut num_rows = 0;
 	for child in e.children() {
@@ -1480,12 +1477,12 @@ impl Function for CountTableRows {
     }
 }
 
-pub struct CountTableCols;
-impl Function for CountTableCols {
+pub struct CountTableColumns;
+impl Function for CountTableColumns {
     fn evaluate<'c, 'd>(&self,
                         _context: &context::Evaluation<'c, 'd>,
                         args: Vec<Value<'d>>) -> Result<Value<'d>, Error> {
-	CountTableDims::evaluate("CountTableCols", args).map(|a| a.1)
+	CountTableDims::evaluate("CountTableColumns", args).map(|a| a.1)
     }
 }
 
@@ -1510,7 +1507,7 @@ pub fn add_builtin_functions(context: &mut Context) {
     context.set_function("GetBracketingIntentName", GetBracketingIntentName);
     context.set_function("GetNavigationPartName", GetNavigationPartName);
     context.set_function("CountTableRows", CountTableRows);
-    context.set_function("CountTableCols", CountTableCols);
+    context.set_function("CountTableColumns", CountTableColumns);
     context.set_function("DEBUG", Debug);
 
     // Not used: remove??
@@ -1687,12 +1684,6 @@ mod tests {
 
     #[test]
     fn table_row_count() {
-	let mathml = "<math><mrow>a</mrow></math>";
-	let package = parser::parse(mathml).expect("failed to parse XML");
-	let math_elem = get_element(&package);
-	let child = as_element(math_elem.children()[0]);
-	assert!(CountTableDims::count_table_dims(child).is_err());
-
 	let mathml = "<math><mtable><mtr><mtd>a</mtd></mtr></mtable></math>";
 	let package = parser::parse(mathml).expect("failed to parse XML");
 	let math_elem = get_element(&package);

--- a/src/xpath_functions.rs
+++ b/src/xpath_functions.rs
@@ -1429,14 +1429,21 @@ impl CountTableDims {
 	    };
 
 	    // each child of mtable should be an mtr. Ignore non-mtr rows.
-	    if name(row) != "mtr" {
+	    let row_name = name(row);
+
+	    let labeled_row = if row_name == "mlabeledtr" {
+		true
+	    } else if row_name == "mtr" {
+		false
+	    } else {
 		continue;
-	    }
+	    };
 	    num_rows += 1;
 
 	    // count columns based on the number of rows.
 	    if num_rows == 1 {
 		// count the number of columns, including column spans, in the first row.
+		let mut first_elem = true;
 		for row_child in row.children() {
 		    let ChildOfElement::Element(mtd) = row_child else  {
 			continue;
@@ -1444,9 +1451,13 @@ impl CountTableDims {
 		    if name(mtd) != "mtd" {
 			continue;
 		    }
-		    // add the contributing columns, taking colspan into account
+		    // Add the contributing columns, taking colspan into account. Don't contribute if
+		    // this is the first element of a labeled row.
 		    let colspan = mtd.attribute_value("colspan").map_or(1, |e| e.parse::<usize>().unwrap_or(0));
-		    num_cols += colspan;
+		    if !(labeled_row && first_elem) {
+			num_cols += colspan;
+		    }
+		    first_elem = false;
 		}
 	    }
 	}
@@ -1695,6 +1706,13 @@ mod tests {
 	let math_elem = get_element(&package);
 	let child = as_element(math_elem.children()[0]);
 	assert!(CountTableDims::count_table_dims(child) == Ok((Value::Number(2.0), Value::Number(4.0))));
+
+	let mathml = "<math><mtable><mlabeledtr><mtd>label</mtd><mtd>a</mtd><mtd>b</mtd></mlabeledtr><mtr><mtd>c</mtd><mtd>d</mtd></mtr></mtable></math>";
+	let package = parser::parse(mathml).expect("failed to parse XML");
+	let math_elem = get_element(&package);
+	let child = as_element(math_elem.children()[0]);
+	let ctd = CountTableDims::count_table_dims(child);
+	assert!(ctd == Ok((Value::Number(2.0), Value::Number(2.0))));
     }
 
     #[test]

--- a/src/xpath_functions.rs
+++ b/src/xpath_functions.rs
@@ -1413,6 +1413,83 @@ impl Function for ReplaceAll {
     }
 }
 
+pub struct CountTableDims;
+impl CountTableDims {
+    /// For an `mtable` element, count the number of rows and columns in the table.
+    ///
+    /// This function is relatively permissive. Non-`mtr` rows are
+    /// ignored. The number of columns is determined only from the first
+    /// row, if it exists. Within that row, non-`mtd` elements are ignored. 
+    fn count_table_dims<'d>(e: Element<'_>) -> Result<(Value<'d>, Value<'d>), Error> {
+	if e.name().local_part() != "mtable" {
+	    return Err(Error::Other(format!("invalid tag {} for CountTableRows", e.name().local_part())));
+	}
+	let mut num_cols = 0;
+	let mut num_rows = 0;
+	for child in e.children() {
+	    let ChildOfElement::Element(row) = child else {
+		continue
+	    };
+
+	    // each child of mtable should be an mtr. Ignore non-mtr rows.
+	    if name(row) != "mtr" {
+		continue;
+	    }
+	    num_rows += 1;
+
+	    // count columns based on the number of rows.
+	    if num_rows == 1 {
+		// count the number of columns, including column spans, in the first row.
+		for row_child in row.children() {
+		    let ChildOfElement::Element(mtd) = row_child else  {
+			continue;
+		    };
+		    if name(mtd) != "mtd" {
+			continue;
+		    }
+		    // add the contributing columns, taking colspan into account
+		    let colspan = mtd.attribute_value("colspan").map_or(1, |e| e.parse::<usize>().unwrap_or(0));
+		    num_cols += colspan;
+		}
+	    }
+	}
+
+	Ok((Value::Number(num_rows as f64), Value::Number(num_cols as f64)))
+    }
+
+    fn evaluate<'c, 'd>(fn_name: &str,
+                        args: Vec<Value<'d>>) -> Result<(Value<'d>, Value<'d>), Error> {
+	let mut args = Args(args);
+	args.exactly(1)?;
+	let element = args.pop_nodeset()?;
+	let node = validate_one_node(element, fn_name)?;
+	if let Node::Element(e) = node {
+	    return Ok(Self::count_table_dims(e)?);
+	}
+
+	Err( Error::Other(format!("couldn't count table rows")) )
+    }
+}
+
+pub struct CountTableRows;
+impl Function for CountTableRows {
+    fn evaluate<'c, 'd>(&self,
+                        _context: &context::Evaluation<'c, 'd>,
+                        args: Vec<Value<'d>>) -> Result<Value<'d>, Error> {
+	CountTableDims::evaluate("CountTableRows", args).map(|a| a.0)
+    }
+}
+
+pub struct CountTableCols;
+impl Function for CountTableCols {
+    fn evaluate<'c, 'd>(&self,
+                        _context: &context::Evaluation<'c, 'd>,
+                        args: Vec<Value<'d>>) -> Result<Value<'d>, Error> {
+	CountTableDims::evaluate("CountTableCols", args).map(|a| a.1)
+    }
+}
+
+
 /// Add all the functions defined in this module to `context`.
 pub fn add_builtin_functions(context: &mut Context) {
     context.set_function("NestingChars", crate::braille::NemethNestingChars);
@@ -1432,6 +1509,8 @@ pub fn add_builtin_functions(context: &mut Context) {
     context.set_function("SpeakIntentName", SpeakIntentName);
     context.set_function("GetBracketingIntentName", GetBracketingIntentName);
     context.set_function("GetNavigationPartName", GetNavigationPartName);
+    context.set_function("CountTableRows", CountTableRows);
+    context.set_function("CountTableCols", CountTableCols);
     context.set_function("DEBUG", Debug);
 
     // Not used: remove??
@@ -1604,6 +1683,27 @@ mod tests {
         test_is_not_simple("C(-2,1,4)",             // github.com/NSoiffer/MathCAT/issues/199
                     "<mrow><mi>C</mi><mrow><mo>(</mo><mo>−</mo><mn>2</mn><mo>,</mo><mn>1</mn><mo>,</mo><mn>4</mn><mo>)</mo></mrow></mrow>");
                    
+    }
+
+    #[test]
+    fn table_row_count() {
+	let mathml = "<math><mrow>a</mrow></math>";
+	let package = parser::parse(mathml).expect("failed to parse XML");
+	let math_elem = get_element(&package);
+	let child = as_element(math_elem.children()[0]);
+	assert!(CountTableDims::count_table_dims(child).is_err());
+
+	let mathml = "<math><mtable><mtr><mtd>a</mtd></mtr></mtable></math>";
+	let package = parser::parse(mathml).expect("failed to parse XML");
+	let math_elem = get_element(&package);
+	let child = as_element(math_elem.children()[0]);
+	assert!(CountTableDims::count_table_dims(child) == Ok((Value::Number(1.0), Value::Number(1.0))));
+
+	let mathml = "<math><mtable><mtr><mtd colspan=\"3\">a</mtd><mtd>b</mtd></mtr><mtr><mtd></mtd></mtr></mtable></math>";
+	let package = parser::parse(mathml).expect("failed to parse XML");
+	let math_elem = get_element(&package);
+	let child = as_element(math_elem.children()[0]);
+	assert!(CountTableDims::count_table_dims(child) == Ok((Value::Number(2.0), Value::Number(4.0))));
     }
 
     #[test]

--- a/src/xpath_functions.rs
+++ b/src/xpath_functions.rs
@@ -1413,7 +1413,7 @@ impl Function for ReplaceAll {
     }
 }
 
-pub struct CountTableDims;
+struct CountTableDims;
 impl CountTableDims {
     /// For an `mtable` element, count the number of rows and columns in the table.
     ///
@@ -1421,79 +1421,79 @@ impl CountTableDims {
     /// ignored. The number of columns is determined only from the first
     /// row, if it exists. Within that row, non-`mtd` elements are ignored. 
     fn count_table_dims<'d>(e: Element<'_>) -> Result<(Value<'d>, Value<'d>), Error> {
-	let mut num_cols = 0;
-	let mut num_rows = 0;
-	for child in e.children() {
-	    let ChildOfElement::Element(row) = child else {
-		continue
-	    };
+        let mut num_cols = 0;
+        let mut num_rows = 0;
+        for child in e.children() {
+            let ChildOfElement::Element(row) = child else {
+                continue
+            };
 
-	    // each child of mtable should be an mtr. Ignore non-mtr rows.
-	    let row_name = name(row);
+            // each child of mtable should be an mtr. Ignore non-mtr rows.
+            let row_name = name(row);
 
-	    let labeled_row = if row_name == "mlabeledtr" {
-		true
-	    } else if row_name == "mtr" {
-		false
-	    } else {
-		continue;
-	    };
-	    num_rows += 1;
+            let labeled_row = if row_name == "mlabeledtr" {
+                true
+            } else if row_name == "mtr" {
+                false
+            } else {
+                continue;
+            };
+            num_rows += 1;
 
-	    // count columns based on the number of rows.
-	    if num_rows == 1 {
-		// count the number of columns, including column spans, in the first row.
-		let mut first_elem = true;
-		for row_child in row.children() {
-		    let ChildOfElement::Element(mtd) = row_child else  {
-			continue;
-		    };
-		    if name(mtd) != "mtd" {
-			continue;
-		    }
-		    // Add the contributing columns, taking colspan into account. Don't contribute if
-		    // this is the first element of a labeled row.
-		    let colspan = mtd.attribute_value("colspan").map_or(1, |e| e.parse::<usize>().unwrap_or(0));
-		    if !(labeled_row && first_elem) {
-			num_cols += colspan;
-		    }
-		    first_elem = false;
-		}
-	    }
-	}
+            // count columns based on the number of rows.
+            if num_rows == 1 {
+                // count the number of columns, including column spans, in the first row.
+                let mut first_elem = true;
+                for row_child in row.children() {
+                    let ChildOfElement::Element(mtd) = row_child else  {
+                        continue;
+                    };
+                    if name(mtd) != "mtd" {
+                        continue;
+                    }
+                    // Add the contributing columns, taking colspan into account. Don't contribute if
+                    // this is the first element of a labeled row.
+                    let colspan = mtd.attribute_value("colspan").map_or(1, |e| e.parse::<usize>().unwrap_or(0));
+                    if !(labeled_row && first_elem) {
+                        num_cols += colspan;
+                    }
+                    first_elem = false;
+                }
+            }
+        }
 
-	Ok((Value::Number(num_rows as f64), Value::Number(num_cols as f64)))
+        Ok((Value::Number(num_rows as f64), Value::Number(num_cols as f64)))
     }
 
     fn evaluate<'d>(fn_name: &str,
                         args: Vec<Value<'d>>) -> Result<(Value<'d>, Value<'d>), Error> {
-	let mut args = Args(args);
-	args.exactly(1)?;
-	let element = args.pop_nodeset()?;
-	let node = validate_one_node(element, fn_name)?;
-	if let Node::Element(e) = node {
-	    return Self::count_table_dims(e);
-	}
+        let mut args = Args(args);
+        args.exactly(1)?;
+        let element = args.pop_nodeset()?;
+        let node = validate_one_node(element, fn_name)?;
+        if let Node::Element(e) = node {
+            return Self::count_table_dims(e);
+        }
 
-	Err( Error::Other("couldn't count table rows".to_string()) )
+        Err( Error::Other("couldn't count table rows".to_string()) )
     }
 }
 
-pub struct CountTableRows;
+struct CountTableRows;
 impl Function for CountTableRows {
     fn evaluate<'c, 'd>(&self,
                         _context: &context::Evaluation<'c, 'd>,
                         args: Vec<Value<'d>>) -> Result<Value<'d>, Error> {
-	CountTableDims::evaluate("CountTableRows", args).map(|a| a.0)
+        CountTableDims::evaluate("CountTableRows", args).map(|a| a.0)
     }
 }
 
-pub struct CountTableColumns;
+struct CountTableColumns;
 impl Function for CountTableColumns {
     fn evaluate<'c, 'd>(&self,
                         _context: &context::Evaluation<'c, 'd>,
                         args: Vec<Value<'d>>) -> Result<Value<'d>, Error> {
-	CountTableDims::evaluate("CountTableColumns", args).map(|a| a.1)
+        CountTableDims::evaluate("CountTableColumns", args).map(|a| a.1)
     }
 }
 

--- a/src/xpath_functions.rs
+++ b/src/xpath_functions.rs
@@ -1502,14 +1502,11 @@ impl CountTableDims {
             // Other elements should be ignored.
             let row_name = name(row);
 
-            let row_type = if row_name == "mlabeledtr" {
-                CTDRowType::Labeled
-            } else if row_name == "mtr" {
-                CTDRowType::Normal
-            } else if row_name == "mtd" {
-                CTDRowType::Implicit
-            } else {
-                continue;
+            let row_type = match row_name {
+		"mlabeledtr" => CTDRowType::Labeled,
+		"mtr" => CTDRowType::Normal,
+		"mtd" => CTDRowType::Implicit,
+		_ => continue
             };
 
             let ext_cols = self.next_row();
@@ -1553,7 +1550,12 @@ impl CountTableDims {
         let element = args.pop_nodeset()?;
         let node = validate_one_node(element, fn_name)?;
         if let Node::Element(e) = node {
-            return self.count_table_dims(e);
+            if is_tag(e, "mtable") {
+                return self.count_table_dims(e);
+            } else {
+                return Err(Error::Other(format!("Input element was a <{}>, not an <mtable>",
+                                                e.name().local_part())));
+            }
         }
 
         Err( Error::Other("Could not count dimensions of non-Element.".to_string()) )

--- a/tests/Languages/en/mtable.rs
+++ b/tests/Languages/en/mtable.rs
@@ -1028,9 +1028,8 @@ let expr = "<math><mrow><mrow><mo>(</mo><mrow>
 test_ClearSpeak("en", "ClearSpeak_Matrix", "EndVector",
         expr, "the 2 by 2 matrix; row 1; column 1; b sub 1 1; column 2; b sub 1 2; \
                                                  row 2; column 1; b sub 2 1; column 2; b sub 2 2; end matrix")?;
-    return Ok(());
-  }
-
+  return Ok(());
+}
 
 
 #[test]
@@ -1041,11 +1040,28 @@ fn matrix_binomial() -> Result<()> {
       </mrow><mo>)</mo>
     </math>";
   test_ClearSpeak("en", "ClearSpeak_Matrix", "Combinatorics", expr, "3 choose 2")?;
-    return Ok(());
-  }
+  return Ok(());
+}
 
 #[test]
-fn matrix_times() -> Result<()> {
+fn matrix_simple_table() {
+  let expr = "<math>
+        <mtable intent=\":array\"><mtr><mtd><mn>3</mn></mtd></mtr><mtr><mtd><mn>2</mn></mtd></mtr></mtable>
+    </math>";
+  test("en", "ClearSpeak", expr, "table with 2 rows and 1 column; row 1; column 1; 3; row 2; column 1; 2");
+}
+
+#[test]
+fn matrix_span_table() {
+  let expr = "<math>
+        <mtable><mtr rowspan=\"1\"><mtd><mn>3</mn></mtd></mtr><mtr><mtd><mn>2</mn></mtd></mtr></mtable>
+    </math>";
+  test("en", "ClearSpeak", expr, "table with 2 rows and 1 column; row 1; column 1; 3; row 2; column 1; 2");
+}
+
+
+#[test]
+fn matrix_times() {
   let expr = "<math>
     <mfenced><mtable><mtr><mtd><mn>1</mn></mtd><mtd><mn>2</mn></mtd></mtr><mtr><mtd><mn>3</mn></mtd><mtd><mn>4</mn></mtd></mtr></mtable></mfenced>
     <mfenced><mtable><mtr><mtd><mi>a</mi></mtd><mtd><mi>b</mi></mtd></mtr><mtr><mtd><mi>c</mi></mtd><mtd><mi>d</mi></mtd></mtr></mtable></mfenced>

--- a/tests/Languages/en/mtable.rs
+++ b/tests/Languages/en/mtable.rs
@@ -1066,6 +1066,16 @@ fn mtable_prefix_op() -> Result<()>{
     Ok(())
 }
 
+#[test]
+fn mtable_blank_op() -> Result<()>{
+    // When a table is prefixed with a blank operator, still assume array intent
+    let expr = "<math>
+        <mo>\u{2062}</mo><mtable><mtr><mtd><mn>3</mn></mtd></mtr><mtr><mtd><mn>2</mn></mtd></mtr></mtable>
+    </math>";
+    test("en", "ClearSpeak", expr, "; table with 2 rows and 1 column; row 1; column 1; 3; row 2; column 1; 2")
+}
+
+
 
 #[test]
 fn mtable_colspan_table() -> Result<()>{

--- a/tests/Languages/en/mtable.rs
+++ b/tests/Languages/en/mtable.rs
@@ -1048,7 +1048,7 @@ fn matrix_simple_table() {
   let expr = "<math>
         <mtable intent=\":array\"><mtr><mtd><mn>3</mn></mtd></mtr><mtr><mtd><mn>2</mn></mtd></mtr></mtable>
     </math>";
-  test("en", "ClearSpeak", expr, "table with 2 rows and 1 column; row 1; column 1; 3; row 2; column 1; 2");
+  let _ = test("en", "ClearSpeak", expr, "table with 2 rows and 1 column; row 1; column 1; 3; row 2; column 1; 2");
 }
 
 #[test]
@@ -1056,7 +1056,7 @@ fn matrix_span_table() {
   let expr = "<math>
         <mtable><mtr rowspan=\"1\"><mtd><mn>3</mn></mtd></mtr><mtr><mtd><mn>2</mn></mtd></mtr></mtable>
     </math>";
-  test("en", "ClearSpeak", expr, "table with 2 rows and 1 column; row 1; column 1; 3; row 2; column 1; 2");
+  let _ = test("en", "ClearSpeak", expr, "table with 2 rows and 1 column; row 1; column 1; 3; row 2; column 1; 2");
 }
 
 
@@ -1066,10 +1066,9 @@ fn matrix_times() {
     <mfenced><mtable><mtr><mtd><mn>1</mn></mtd><mtd><mn>2</mn></mtd></mtr><mtr><mtd><mn>3</mn></mtd><mtd><mn>4</mn></mtd></mtr></mtable></mfenced>
     <mfenced><mtable><mtr><mtd><mi>a</mi></mtd><mtd><mi>b</mi></mtd></mtr><mtr><mtd><mi>c</mi></mtd><mtd><mi>d</mi></mtd></mtr></mtable></mfenced>
   </math>";
-  test("en", "SimpleSpeak", expr,
-    "the 2 by 2 matrix; row 1; 1, 2; row 2; 3, 4; times, the 2 by 2 matrix; row 1; eigh, b; row 2; c, d")?;
-    return Ok(());
-  }
+  let _ = test("en", "SimpleSpeak", expr,
+    "the 2 by 2 matrix; row 1; 1, 2; row 2; 3, 4; times, the 2 by 2 matrix; row 1; eigh, b; row 2; c, d");
+}
 
 #[test]
 fn unknown_mtable_property() -> Result<()> {

--- a/tests/Languages/en/mtable.rs
+++ b/tests/Languages/en/mtable.rs
@@ -1044,20 +1044,58 @@ fn matrix_binomial() -> Result<()> {
 }
 
 #[test]
-fn matrix_simple_table() {
+fn matrix_simple_table() -> Result<()> {
   let expr = "<math>
-        <mtable intent=\":array\"><mtr><mtd><mn>3</mn></mtd></mtr><mtr><mtd><mn>2</mn></mtd></mtr></mtable>
+        <mtable><mtr><mtd><mn>3</mn></mtd></mtr><mtr><mtd><mn>2</mn></mtd></mtr></mtable>
     </math>";
-  let _ = test("en", "ClearSpeak", expr, "table with 2 rows and 1 column; row 1; column 1; 3; row 2; column 1; 2");
+  test("en", "ClearSpeak", expr, "table with 2 rows and 1 column; row 1; column 1; 3; row 2; column 1; 2")
 }
 
 #[test]
-fn matrix_span_table() {
-  let expr = "<math>
-        <mtable><mtr rowspan=\"1\"><mtd><mn>3</mn></mtd></mtr><mtr><mtd><mn>2</mn></mtd></mtr></mtable>
-    </math>";
-  let _ = test("en", "ClearSpeak", expr, "table with 2 rows and 1 column; row 1; column 1; 3; row 2; column 1; 2");
+fn mtable_prefix_op() -> Result<()>{
+    // When a table is prefixed with a non-blank operator, assume it is something besides array intent
+    for (op, speech) in [("(", "open paren"),
+			 ("[", "open bracket"),
+			 ("|", "vertical line"),
+			 ("f", "f")] {
+	let expr = format!("<math>
+        <mo>{op}</mo><mtable><mtr><mtd><mn>3</mn></mtd></mtr><mtr><mtd><mn>2</mn></mtd></mtr></mtable>
+    </math>");
+	test("en", "ClearSpeak", &expr, &format!("{speech}, 2 lines; line 1; 3; line 2; 2"))?;
+    }
+    Ok(())
 }
+
+
+#[test]
+fn mtable_colspan_table() -> Result<()>{
+  let expr = "<math>
+        <mtable><mtr><mtd colspan=\"2\"><mn>3</mn></mtd></mtr><mtr><mtd><mn>2</mn></mtd><mtd><mn>4</mn></mtd></mtr></mtable>
+    </math>";
+  test("en", "ClearSpeak", expr, "table with 2 rows and 2 columns; row 1; column 1; 3; row 2; column 1; 2, column 2; 4")
+}
+
+#[test]
+fn bug_mtable_rowspan_colspan() -> Result<()>{
+  // Currently, the code correctly computes the number of rows and
+  // columns, but it does not correctly compute the column number whnen
+  // colspans are involved.
+  let expr = "<math>
+        <mtable>
+           <mtr>
+             <mtd rowspan=\"2\" colspan=\"2\"><mi>a</mi></mtd>
+             <mtd rowspan=\"2\"><mi>b</mi></mtd>
+             <mtd colspan=\"2\"><mi>c</mi></mtd>
+           </mtr>
+           <mtr>
+             <mtd><mi>d</mi></mtd><mtd><mi>e</mi></mtd>
+           </mtr>
+        </mtable>
+    </math>";
+    test("en", "ClearSpeak", expr,
+	 "table with 2 rows and 5 columns; row 1; column 1; eigh, column 2; b, column 3; c; row 2; column 1; d, column 2; e")
+}
+
 
 
 #[test]

--- a/tests/Languages/intent/tables.rs
+++ b/tests/Languages/intent/tables.rs
@@ -329,18 +329,16 @@ fn mlabelledtr_bug_526() -> Result<()> {
             </mlabeledtr>
             </mtable></math>"#;
     let intent = "<math data-from-mathml='math'>
-    <lines data-from-mathml='mtable'>
+    <array data-from-mathml='mtable'>
       <mlabeledtr data-from-mathml='mlabeledtr'>
-        <TEMP_NAME>
+        <mtd data-from-mathml='mtd'>
           <mtext data-from-mathml='mtext'>foo</mtext>
-        </TEMP_NAME>
-        <mtd data-from-mathml='mlabeledtr'>
-          <mrow data-from-mathml='mlabeledtr'>
-            <mi data-from-mathml='mi'>m</mi>
-          </mrow>
+        </mtd>
+        <mtd data-from-mathml='mtd'>
+          <mi data-from-mathml='mi'>m</mi>
         </mtd>
       </mlabeledtr>
-    </lines>
+    </array>
    </math>";
     test_intent(mathml, intent, vec![])?;
     return Ok(());


### PR DESCRIPTION
Addresses issue #283 . 

This PR adds some internal functions to compute table dimensions (rows and columns) taking `rowspan`s and `colspan`s into account, and uses them to render tables with the `:array` intent as "table with m rows and n columns".

I'm not super happy with the current logic to detect that an unspecified `mtable` should have an `:array` intent. Right now, it assumes that any `mtable` that either renders its frame as `solid` or `dashed` or has an `mrow` or `mtd` that specifies a `rowspan` or `colspan` should be an `:array`. I think we want something more general, though. 