### PR TITLE
run CI on all branches, not only "main"

### DIFF
--- a/.github/workflows/python.yml
+++ b/.github/workflows/python.yml
@@ -1,10 +1,6 @@
 name: Python
 
-on:
-  push:
-    branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
+on: [push, pull_request]
 
 jobs:
   test:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,10 +1,6 @@
 name: Rust
 
-on:
-  push:
-    branches: [ "main" ]
-  pull_request:
-    branches: [ "main" ]
+on: [push, pull_request] # note: pre-release job still only on 'refs/heads/main'
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
from my understanding, `on` is an obligatory attribute (https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#on).

Also, `pre-release` is restricted to _main_ on job-level. should we do the same for `zip-rules`?

For Python CI, there's only the one job for testing, so that file looks finished.