### PR TITLE
fix(build): build-deps need both deflate+bzip2 for cross-target wasm builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,10 +49,9 @@ natural-tts = { version = "0.3.1", optional = true }
 
 [build-dependencies]
 bitflags = "2.6"
-[target.'cfg(target_family = "wasm")'.build-dependencies]
-zip = { version = "8.2", default-features = false, features = ["deflate"] }
-[target.'cfg(not(target_family = "wasm"))'.build-dependencies]
-zip = { version = "8.2", default-features = false, features = ["bzip2"] }
+# Build script needs both compression backends regardless of build host —
+# build.rs picks DEFLATE/BZIP2 based on the *target* family, not the host.
+zip = { version = "8.2", default-features = false, features = ["deflate", "bzip2"] }
 
 [lib]
 name = "libmathcat"


### PR DESCRIPTION
## Problem

Building MathCAT for `wasm32-unknown-unknown` from a non-wasm host fails with:

```
error: failed to run custom build command for `mathcat v0.7.6-beta.3`
Caused by:
  process didn't exit successfully: ... build-script-build (exit code: 101)
  --- stderr
  thread 'main' (...) panicked at .../build.rs:189:13:
  Error: unsupported Zip archive: Unsupported compression
```

This affects anyone running `wasm-pack build --target nodejs` (or `--target bundler`, `--target web`) from Windows / Linux / macOS — i.e. the common WASM build path.

## Root cause

`build.rs` selects the zip compression method based on `CARGO_CFG_TARGET_FAMILY`, which Cargo correctly sets to `wasm` when the *target* is wasm:

```rust
// build.rs lines 168–173
let compile_target = std::env::var("CARGO_CFG_TARGET_FAMILY").unwrap();
let compression_method = if compile_target == "wasm" {
    CompressionMethod::DEFLATE
} else {
    CompressionMethod::BZIP2
};
```

But the build-script's `zip` dependency is conditionally configured on the *host's* target family:

```toml
# Cargo.toml
[target.'cfg(target_family = "wasm")'.build-dependencies]
zip = { version = "8.2", default-features = false, features = ["deflate"] }
[target.'cfg(not(target_family = "wasm"))'.build-dependencies]
zip = { version = "8.2", default-features = false, features = ["bzip2"] }
```

`cfg(target_family = ...)` for `[build-dependencies]` resolves against the build host, not the target. So when building for wasm from a non-wasm host:
- `build.rs` sees `CARGO_CFG_TARGET_FAMILY=wasm` → tries to use `CompressionMethod::DEFLATE`
- The `zip` build-dep was resolved with `bzip2` only → DEFLATE feature absent → panic

## Fix

Make `build.rs`'s `zip` dependency unconditionally include both compression backends. Build-deps are not shipped in the runtime artifact, so the size impact is zero.

The runtime `[target.*.dependencies]` blocks (which correctly distinguish host-vs-wasm for the runtime `zip` dep) are unchanged.

## Verification

Confirmed by running `wasm-pack build --target nodejs` from Windows after applying the patch — produces a 3.2 MB `.wasm` with the expected Rules zip embedded. The output works correctly via `WebAssembly.instantiate` in Node.js for round-tripping MathML to Nemeth, UEB-Technical, and CMU braille.

## Context

This unblocks downstream consumers that build MathCAT-WASM bridges. We hit it at New Haptics while integrating MathCAT into a Next.js braille translation app. Happy to tweak this PR if you'd prefer a different shape.