### PR TITLE
handle canonicalize failure in containerized environments

### DIFF
--- a/src/prefs.rs
+++ b/src/prefs.rs
@@ -259,9 +259,23 @@ impl PreferenceManager {
     /// 
     /// If rules_dir is an empty PathBuf, the existing rules_dir is used (an error if it doesn't exist)
     pub fn initialize(&mut self, rules_dir: PathBuf) -> Result<()> {
+        // Resolve the rules directory to an absolute, canonical path.
+        // If canonicalize() fails (e.g., ACCESS_DENIED in containers), fall back to:
+        //   - returning the path as-is if it is already absolute,
+        //   - prepending the current working directory if it is relative.
+        // Note: if current_dir() also fails, unwrap_or_default yields an empty PathBuf,
+        //       and the result may remain relative.
         #[cfg(not(feature = "include-zip"))]
         let rules_dir = match rules_dir.canonicalize() {
-            Err(e) => bail!("set_rules_dir: could not canonicalize path {}: {}", rules_dir.display(), e),
+            Err(_e) => {
+                if rules_dir.is_absolute() {
+                    rules_dir
+                } else {
+                    std::env::current_dir()
+                        .unwrap_or_default()
+                        .join(&rules_dir)
+                }
+            },
             Ok(rules_dir) =>  rules_dir,
         };
 

--- a/src/shim_filesystem.rs
+++ b/src/shim_filesystem.rs
@@ -340,14 +340,31 @@ cfg_if! {
             }
         }
         
+        /// Resolves the path to an absolute, canonical form using the OS.
+        /// If `canonicalize()` fails (e.g., ACCESS_DENIED in containers), falls back to:
+        ///   - returning the path as-is if it is already absolute,
+        ///   - prepending the current working directory if it is relative.
+        /// Note: the fallback does not resolve symlinks or normalize `..`/`.` segments.
         pub fn canonicalize_shim(path: &Path) -> std::io::Result<PathBuf> {
-            return path.canonicalize();
+            match path.canonicalize() {
+                Ok(p) => Ok(p),
+                Err(_) => {
+                    if path.is_absolute() {
+                        Ok(path.to_path_buf())
+                    } else {
+                        // Prepend cwd to make the relative path absolute.
+                        // unwrap_or_default yields an empty PathBuf if cwd is unavailable,
+                        // in which case the returned path will still be relative.
+                        Ok(std::env::current_dir().unwrap_or_default().join(path))
+                    }
+                }
+            }
         }
         
         pub fn read_to_string_shim(path: &Path) -> Result<String> {
             let path = match path.canonicalize() {
                 Ok(path) => path,
-                Err(e) => bail!("Read error while trying to canonicalize in read_to_string_shim {}: {}", path.display(), e),
+                Err(_) => path.to_path_buf(),
             };
             debug!("Reading file '{}'", &path.display());
             match std::fs::read_to_string(&path) {


### PR DESCRIPTION
### Description

Fixes https://github.com/daisy/MathCAT/issues/516

path.canonicalize() can fail with ACCESS_DENIED in containerized or sandboxed environments. This caused MathCAT to
bail out entirely when loading rules or reading files.

### Changes

 - canonicalize_shim (shim_filesystem.rs): Instead of hard-failing, falls back to returning the path as-is (if 
absolute) or prepending cwd (if relative).
 - read_to_string_shim (shim_filesystem.rs): Replaces the hard bail!() on canonicalize failure with a fallback to 
the original path, letting read_to_string attempt the read anyway.
 - PreferenceManager::initialize (prefs.rs): Same fallback logic applied to rules_dir canonicalization.