### PR TITLE
add 1 week dependency cooldown for uv

### DIFF
--- a/PythonScripts/pyproject.toml
+++ b/PythonScripts/pyproject.toml
@@ -33,6 +33,9 @@ dev = [
 requires = ["uv_build>=0.9.25,<0.10.0"]
 build-backend = "uv_build"
 
+[tool.uv]
+exclude-newer = "1 week"
+
 [tool.uv.build-backend]
 module-name = "audit_translations"
 module-root = ""

--- a/PythonScripts/uv.lock
+++ b/PythonScripts/uv.lock
@@ -2,6 +2,10 @@ version = 1
 revision = 3
 requires-python = ">=3.14"
 
+[options]
+exclude-newer = "0001-01-01T00:00:00Z" # This has no effect and is included for backwards compatibility when using relative exclude-newer values.
+exclude-newer-span = "P1W"
+
 [[package]]
 name = "anyio"
 version = "4.12.1"


### PR DESCRIPTION
the recent bug in a python package regarding Traditional Chinese character encodings got me thinking about how to manage Python packages generally. 

From what I have observed generally, it's a good idea to add a waiting period of a week or so for new package versions, which should avoid most cases where packages have been infiltrated by malware, ship really bad bugs, or similar stuff. This doesn't solve all problems of course, but it's a low effort step that could maybe be really helpful at some point.

Similar logic would apply to Rust crates I think, so maybe we should look into it there at some point as well.