### PR TITLE
Add Polish (pl) language localization

### DIFF
--- a/Rules/Languages/pl/ClearSpeak_Rules.yaml
+++ b/Rules/Languages/pl/ClearSpeak_Rules.yaml
@@ -1,0 +1,803 @@
+---
+# Polska wymowa operatorow arg max / arg min / ess sup. Operator (mo, mi lub mrow[arg,max])
+# jest emitowany przez x: w regule named-under-operator (SharedRules/default.yaml) - emisja
+# czyni go nawigowalnym; tutaj nadajemy mu wlasciwa nazwe PL zamiast doslownego "arg max".
+- name: op-arg-max-min-ess-sup
+  tag: [mo, mi, mrow]
+  match:
+    - "( (self::m:mo or self::m:mi) or"
+    - "  (self::m:mrow and parent::*[self::m:munder or self::m:munderover or self::m:msub]) ) and"
+    - "( (contains(., 'arg') and (contains(., 'max') or contains(., 'min'))) or (contains(., 'ess') and contains(., 'sup')) )"
+  replace:
+  - test:
+    - if: "contains(., 'arg') and contains(., 'max')"
+      then: [T: "arg maksimum"]
+    - else_if: "contains(., 'arg') and contains(., 'min')"
+      then: [T: "arg minimum"]
+    - else:
+      - T: "supremum istotne"
+
+- name: pause
+  tag: "!*"
+  match: "not(self::m:math) and not($MatchingPause) and @data-intent-property[contains(., ':pause')]"
+  replace:
+   - with:
+      variables: [MatchingPause: "true()"]
+      replace:
+      - test:
+        - if: "contains(@data-intent-property, ':pause-long')"
+          then: [pause: long]
+        - else_if: "contains(@data-intent-property, ':pause-short')"
+          then: [pause: short]
+          else: [pause: medium]
+      - x: "."
+
+- name: intent-literal-silent
+  tag: [mi, mo, mn]
+  match: "contains(@data-intent-property, ':silent:')"
+  # say nothing
+  replace: []
+
+# handling of negative numbers that come from 'intent' is hard -- we do something that is close to right here 
+- name: intent-literal-negative-number
+  tag: mn
+  match: "starts-with(text(), '-')"
+  replace:
+  - T: "minus"      # phrase(10 'minus' 4 equals 6)
+  - x: "translate(text(), '-_', '')"
+
+- name: default
+  tag: square-root
+  match: "."
+  replace:
+  - test:
+      if: "$ClearSpeak_Roots = 'PosNegSqRoot' or $ClearSpeak_Roots = 'PosNegSqRootEnd'"
+      then:
+      - bookmark: "*[1]/@id"
+      - test:
+          if: "parent::*[self::m:minus and count(*)=1]"
+          then: [T: "minus"]      # phrase(minus 4 is a 'negative' number)
+          else: [T: "plus"]      # phrase(10 is a 'positive' number)
+  - T: "pierwiastek kwadratowy"      # phrase(8 is the 'square root' of 64)
+  - test:
+      if: "$Verbosity!='Terse'"
+      then: [T: "z"]      # phrase(the square root 'of' 5)
+      else: [pause: short]
+  - x: "*[1]"
+  - test:
+    - if: "$ClearSpeak_Roots = 'RootEnd' or $ClearSpeak_Roots = 'PosNegSqRootEnd'"
+      then:
+      - pause: short
+      - T: "koniec pierwiastka"      # phrase(the square root of x 'end root')
+      - pause: medium
+    - else_if: "IsNode(*[1], 'simple')"
+      then: [pause: short]
+      else: [pause: long]
+
+- name: default
+  tag: root
+  match: "."
+  replace:
+  - test:
+      if: "$ClearSpeak_Roots = 'PosNegSqRoot' or $ClearSpeak_Roots = 'PosNegSqRootEnd'"
+      then:
+      - test:
+          if: "parent::*[(self::m:minus or self::m:plus) and count(*)=1]"
+          then: [bookmark: "parent/@id"]
+      - test:
+          if: "parent::m:minus"
+          then: [T: "minus"]      # phrase(minus 6 is a 'negative' number)
+          else: [T: "plus"]      # phrase(10 is a 'positive' number)
+  - test:
+      if: "*[2][self::m:mn and not(contains(., '.'))]"
+      then_test:
+      - if: "*[2][.='2']"
+        then: [T: "pierwiastek kwadratowy"]      # phrase(5 is the 'square root' of 25)
+      - else_if: "*[2][.='3']"
+        then: [T: "pierwiastek sześcienny"]      # phrase(5 is the 'cube root' of 625)
+      - else: [x: "ToOrdinal(*[2])", T: "pierwiastek"]      # phrase(the square 'root' of 25)
+      else:
+      - test:
+          if: "*[2][self::m:mi][string-length(.)=1]"
+          then:
+          - x: "*[2]"
+          else: [x: "*[2]"]
+      - T: "pierwiastek"      # phrase(the square 'root' of 36)
+  - test:
+      if: "$Verbosity!='Terse'"
+      then: [T: "z"]      # phrase(the square root 'of' 36)
+  - x: "*[1]"
+  - test:
+      if: "$ClearSpeak_Roots = 'RootEnd' or $ClearSpeak_Roots = 'PosNegSqRootEnd'"
+      then:
+      - pause: short
+      - T: "koniec pierwiastka"      # phrase(start the fifth root of x 'end root')
+      - pause: medium
+      else_test:
+        if: "IsNode(*[1], 'simple')"
+        then: [pause: short]
+        else: [pause: long]
+
+# The 'negative' rule interacts with the msqrt/mroot rules as those might pick off this case ("the negative square root of x")
+- name: negative_and_positive
+  tag: [plus, minus]
+  match: "count(*)=1 and contains(@data-intent-property, ':prefix:')"
+  replace:
+  - test:
+      if:
+      - "*[1][self::m:square-root or self::m:root] and"
+      - "($ClearSpeak_Roots = 'PosNegSqRoot' or $ClearSpeak_Roots = 'PosNegSqRootEnd')"
+      then: [t: ""]
+      else:
+      - bookmark: "@id"
+      - test:
+          if: "self::m:minus"
+          then: [T: "minus"]      # phrase(minus 5 is a 'negative' number)
+          else: [T: "plus"]      # phrase(7 is a 'positive' number)
+  - x: "*[1]"
+
+# Fraction rules
+# Mixed numbers mostly "just work" because the invisible char reads as "and" and other parts read properly on their own
+
+# Units (e.g., meters per second)
+- name: per-fraction
+  tag: fraction
+  match:
+  - "$ClearSpeak_Fractions='Per' or"
+  - "(BaseNode(*[1])[contains(@data-intent-property, ':unit') or"
+  - "                ( self::m:mrow and count(*)=3 and"  # maybe a bit paranoid checking the structure...
+  - "                 *[1][self::m:mn] and *[2][.='\u2062'] and BaseNode(*[3])[contains(@data-intent-property, ':unit')] ) ] and"
+  - " BaseNode(*[2])[contains(@data-intent-property, ':unit')] )"
+  replace:
+  - x: "*[1]"
+  - T: "na"      # phrase('5 meters 'per' second)
+  - x: "*[2]"
+
+- name: common-fraction
+  tag: fraction
+  match:
+  - "($ClearSpeak_Fractions='Auto' or $ClearSpeak_Fractions='Ordinal' or $ClearSpeak_Fractions='EndFrac') and"
+  - "*[1][self::m:mn][not(contains(., $DecimalSeparators)) and ($ClearSpeak_Fractions='Ordinal' or text()<20)]   and"
+  - "*[2][self::m:mn][not(contains(., $DecimalSeparators)) and ($ClearSpeak_Fractions='Ordinal' or (2<= text() and text()<=10))]"
+  variables: [IsPlural: "*[1]!=1"]
+  replace:
+  - test:
+      if: "*[1][.='1']"
+      then:
+      - T: "jedna"      # phrase(one half)
+      else:
+      - test:
+          if: "*[1][.='2']"
+          then:
+          - T: "dwie"      # phrase(two thirds)
+          else:
+          - x: "*[1]"
+  - x: "ToOrdinal(*[2], true(), $IsPlural)"   # extra args specify fractional ordinal and whether it is plural
+
+- name: fraction-over-simple
+  tag: fraction
+  match:
+  - "($ClearSpeak_Fractions='Over' or $ClearSpeak_Fractions='FracOver' or $ClearSpeak_Fractions='OverEndFrac') or"
+  - "( not($ClearSpeak_Fractions='General' or $ClearSpeak_Fractions='GeneralEndFrac') and"
+  - "  (IsNode(*[1],'simple') and IsNode(*[2],'simple')) )" # simple fraction in ClearSpeak spec
+  replace:
+  - test:
+      if: "$ClearSpeak_Fractions='FracOver'"
+      then:
+      - T: "ułamek"      # phrase(the 'fraction' with 3 over 4)
+  - x: "*[1]"
+  - T: "przez"      # phrase(the fraction 3 'over' 4)
+  - x: "*[2]"
+  - test:
+      # very ugly!!! -- replicate nested ordinal fraction as they are an exception
+      if: "$ClearSpeak_Fractions='OverEndFrac' or ($ClearSpeak_Fractions='EndFrac' and not( ($ClearSpeak_Fractions='Auto' or $ClearSpeak_Fractions='Ordinal' or $ClearSpeak_Fractions='EndFrac') and *[1][*[1][self::m:mn][not(contains(., '.')) and ($ClearSpeak_Fractions='Ordinal' or text()<20)]   and *[2][self::m:mn][not(contains(., '.')) and ($ClearSpeak_Fractions='Ordinal' or (2<= text() and text()<=10))] ] and *[2][*[1][self::m:mn][not(contains(., '.')) and ($ClearSpeak_Fractions='Ordinal' or text()<20)]   and *[2][self::m:mn][not(contains(., '.')) and ($ClearSpeak_Fractions='Ordinal' or (2<= text() and text()<=10))] ] ) )"
+      then:
+      - pause: short
+      - T: "koniec ułamka"      # phrase(7 over 8 'end fraction')
+      - pause: short
+
+- # fraction with text or numbers followed by text in both numerator and denominator
+  name: fraction-over-text
+  tag: fraction
+  match:
+  - "not($ClearSpeak_Fractions='General' or $ClearSpeak_Fractions='GeneralEndFrac') and"
+  - "( "
+  - "  ((*[1][self::m:mi or self::m:mtext][string-length(.)>1]) or " # fractions with text
+  - "   (*[1][self::m:mrow][count(*)=3][ "
+  - "        *[1][self::m:mn] and "
+  - "        *[2][self::m:mo][.='⁢'] and " # invisible times
+  - "        *[3][self::m:mi or self::m:mtext][string-length(.)>1] ]) ) and"
+  - "  ((*[2][self::m:mi or self::m:mtext][string-length(.)>1]) or " # fractions with text
+  - "   (*[2][self::m:mrow][count(*)=3][ "
+  - "        *[1][self::m:mn] and "
+  - "        *[2][self::m:mo][.='⁢'] and " # invisible times
+  - "        *[3][self::m:mi or self::m:mtext][string-length(.)>1] ]) )"
+  - ")"
+  replace:
+  - x: "*[1]"
+  - T: "przez"      # phrase(the fraction 3 'over' 4)
+  - x: "*[2]"
+  - test:
+      if: "$ClearSpeak_Fractions='EndFrac' or $ClearSpeak_Fractions='OverEndFrac'"
+      then:
+      - pause: short
+      - T: "koniec ułamka"      # phrase(7 over 8 'end fraction')
+      - pause: short
+
+- name: default
+  tag: fraction
+  match: "."
+  replace:
+  - t: "ułamek z licznikiem"      # phrase(the 'fraction with numerator' 6)
+  - test:
+      if: "not(IsNode(*[1], 'simple'))"
+      then: [pause: medium]
+  - x: "*[1]"
+  - pause: medium
+  - t: "i mianownikiem"      # phrase(the fraction with numerator 5 'and denominator' 8)
+  - x: "*[2]"
+  - pause: long
+  - test:
+      if: "$ClearSpeak_Fractions='EndFrac' or $ClearSpeak_Fractions='GeneralEndFrac'"
+      then:
+      - pause: short
+      - T: "koniec ułamka"      # phrase(the fraction with 3 over 4 'end fraction')
+      - pause: short
+
+# rules for functions raised to a power
+# these could have been written on 'mrow' but putting them on msup seems more specific
+# to see if it is a function, we look right to see if the following sibling is apply-function
+- name: ClearSpeak-function-inverse
+  tag: inverse-function
+  match: "."
+  replace:
+  - test:
+      if: "$ClearSpeak_Trig = 'TrigInverse'"
+      then: [x: "*[1]", bookmark: "*[2]/@id", T: "odwrotność"]      # phrase(8 over 5 is the 'inverse' of 5 over 8)
+      else_test:
+        if: "$ClearSpeak_Trig = 'ArcTrig'"
+        then: [bookmark: "*[2]/@id", T: "łuk", x: "*[1]"]      # phrase(the 'arc' of a circle)
+        else: [bookmark: "*[2]/@id", T: "odwrotność", x: "*[1]"] # default/Auto      # phrase(8 over 5 is the 'inverse' of 5 over 8)
+
+- name: closing-subscripted-norm-squared-or-cubed
+  tag: power
+  match: "*[1][self::m:indexed-by and *[1][self::m:mo and .='∥']] and preceding-sibling::*[self::m:mo and .='∥'] and *[2][self::m:mn][.='2' or .='3']"
+  replace:
+  - bookmark: "*[2]/@id"
+  - test:
+      if: "*[2][.='2']"
+      then: [T: "do kwadratu"]      # phrase(25 equals 5 'squared')
+      else: [T: "do sześcianu"]      # phrase(625 equals 5 'cubed')
+
+# Potega normy zbudowanej jako intent power[subscripted-norm, wykladnik] (pl/intent.yaml).
+# Wykladnik MUSI byc emitowany przez x: (bookmark NIE wystarcza dla nawigacji w tej strukturze!),
+# inaczej sam wykladnik jest nienawigowalny (NVDA "blad wyrazenia matematycznego").
+# Uzywamy "do potegi" + emisja, zamiast "do kwadratu" (bez emisji), by zachowac nawigowalnosc.
+- name: norm-power-general
+  tag: power
+  match: "*[1][self::m:subscripted-norm]"
+  replace:
+  - x: "*[1]"
+  - T: "do potęgi"
+  - x: "*[2]"      # wykladnik emitowany (nawigowalny)
+  - pause: short
+
+- name: closing-subscripted-norm-power
+  tag: power
+  match: "*[1][self::m:indexed-by and *[1][self::m:mo and .='∥']] and preceding-sibling::*[self::m:mo and .='∥']"
+  replace:
+  - T: "do potęgi"
+  - bookmark: "*[2]/@id"
+  - test:
+      if: "*[2][self::m:mn][not(contains(., '.'))]"
+      then: [x: "ToOrdinal(*[2])"]
+      else: [x: "*[2]"]
+  - pause: short
+
+- name: function-squared-or-cubed
+  tag: power
+  match:
+  - "*[2][self::m:mn][.='2' or .='3'] and"
+  - "following-sibling::*[1][self::m:mo][.='⁡']" #invisible function apply
+  replace:
+  - x: "*[1]"
+  - bookmark: "*[2]/@id"
+  - test:
+      if: "*[2][.='2']"
+      then: [T: "do kwadratu"]      # phrase(25 equals 5 'squared')
+      else: [T: "do sześcianu"]      # phrase(625 equals 5 'cubed')
+
+- name: function-power
+  tag: power
+  match:
+  - "following-sibling::*[1][self::m:mo][.='⁡']" #invisible function apply
+  replace:
+  - x: "*[1]"
+  - T: "do potęgi"
+  - bookmark: "*[2]/@id"
+  - test:
+      if: "*[2][self::m:mn][not(contains(., '.'))]"
+      then: [x: "ToOrdinal(*[2])"]
+      else: [x: "*[2]"]
+  - pause: short
+
+- name: AfterPower-nested
+  tag: power
+  match: # directly a superscript or an mrow that contains a superscript
+  - "$ClearSpeak_Exponents = 'AfterPower' and"
+  - "*[2][self::m:power or self::m:power or self::m:mrow[m:power]]"
+  replace:
+  - x: "*[1]"
+  - T: "do wykładnika"      # phrase(5 'raised to the exponent' x plus 1)
+  - pause: short
+  - x: "*[2]"
+  - pause: short
+  - T: "koniec wykładnika"      # phrase(5 raised to the exponent x plus 1 'end exponent')
+
+- name: AfterPower-default
+  tag: power
+  match: "$ClearSpeak_Exponents = 'AfterPower'"
+  replace:
+  - x: "*[1]"
+  - T: "do potęgi"      # phrase(x is 'raised to the power' 4)
+  - x: "*[2]"
+  - pause: short
+
+- name: squared
+  tag: power
+  match: "*[2][self::m:mn][.='2'] and $ClearSpeak_Exponents = 'Auto'"
+  replace:
+  - x: "*[1]"
+  - bookmark: "*[2]/@id"
+  - T: "do kwadratu"      # phrase(7 'squared' equals 49)
+
+- name: cubed
+  tag: power
+  match: "*[2][self::m:mn][.='3'] and $ClearSpeak_Exponents = 'Auto'"
+  replace:
+  - x: "*[1]"
+  - bookmark: "*[2]/@id"
+  - T: "do sześcianu"      # phrase(5 'cubed' equals 125)
+
+- name: simple-integer
+  tag: power
+  match: "*[2][self::m:mn][not(contains(., '.'))]"
+  replace:
+  - x: "*[1]"
+  - T: "do potęgi"      # phrase(2 raised 'to the' power 7)
+  - test:
+      if: "*[2][.>0]"
+      then: [x: "ToOrdinal(*[2])"]
+      else: [x: "*[2]"]
+
+- name: simple-negative-integer
+  tag: power
+  match:
+  - "*[2][self::m:minus and count(*)=1 and "
+  - "     *[1][self::m:mn][not(contains(., '.'))]"
+  - "    ]"
+  replace:
+  - x: "*[1]"
+  - T: "do potęgi"      # phrase(2 raised 'to the' power 7)
+  - x: "*[2]"
+
+- name: simple-var
+  tag: power
+  match: "*[2][self::m:mi][string-length(.)=1]"
+  replace:
+  - x: "*[1]"
+  - T: "do potęgi"      # phrase(3 raised 'to the' power 7)
+  - x: "*[2]"
+
+# match nested exponent, where the nested exponent is has the power 2 or 3 (n below)
+#   [xxx]^n, - [xxx]^n, [xxx] var^n, -[xxx] var^n
+# where xxx is a number or common fraction (or a var in the first two forms)
+# short of creating a specialized built-in function, I don't see a way to eliminate a lot of repetition in the matches
+# also really bad is that the test of a common fraction is replicated here (four times!)
+# Note: the ClearSpeak doc doesn't say these only apply when the pref is "Auto",
+#   but the test cases all fall back to "raised to the exponent" when not "Auto"
+#   If these are allowed for non-Auto values, then you end up with "...power power...".
+- # [xxx]^n
+  name: nested-squared-or-cubed
+  tag: power
+  match:
+  - "$ClearSpeak_Exponents = 'Auto' and"
+  - "*[2][self::m:power]["
+  - "     *[2][self::m:mn][.='2' or .='3'] and " # exp is 2 or 3
+  # base is mn, mi, common fraction ([xxx] case)
+  - "     *[1][self::m:mn or self::m:mi or "
+  - "          self::m:fraction[*[1][self::m:mn][not(contains(., '.')) and text()<20]   and"
+  - "                        *[2][self::m:mn][not(contains(., '.')) and 2<= text() and text()<=10]]"
+  - "         ]"
+  - "    ]"
+  replace:
+  - x: "*[1]"
+  - T: "do potęgi"      # phrase(x 'raised to the' second power)
+  - x: "*[2]"
+
+- # - [xxx]^n
+  name: nested-negative-squared-or-cubed
+  tag: power
+  match:
+  - "$ClearSpeak_Exponents = 'Auto' and"
+  - " *[2][self::m:minus and count(*)=1 and "
+  - "      *[1]/*[1][self::m:power]["
+  - "                *[2][self::m:mn][.='2' or .='3'] and " # exp is 2 or 3"
+  # base is mn, mi, common fraction ([xxx] case)
+  - "                *[1][self::m:mn or self::m:mi or "
+  - "                     self::m:fraction[*[1][self::m:mn][not(contains(., '.')) and text()<20]   and"
+  - "                                   *[2][self::m:mn][not(contains(., '.')) and 2<= text() and text()<=10]]"
+  - "               ]"
+  - "          ]"
+  - "     ]"
+  replace:
+  - x: "*[1]"
+  - T: "do potęgi"      # phrase(x 'raised to the' second power)
+  - x: "*[2]"
+
+- # [xxx] var^n
+  name: nested-var-squared-or-cubed
+  tag: power
+  match:
+  - "$ClearSpeak_Exponents = 'Auto' and"
+  - "  *[2][self::m:mrow][count(*)=3][ "
+  - "       *[3][self::m:power]["
+  - "            *[2][self::m:mn][.='2' or .='3'] and " # exp is 2 or 3
+  - "            *[1][self::m:mi]"
+  - "           ] and "
+  - "       *[2][self::m:mo][.='⁢'] and " # invisible times
+  # base is mn, or common fraction ([xxx] case)
+  - "       *[1][self::m:mn or "
+  - "            self::m:fraction[*[1][self::m:mn][not(contains(., '.')) and text()<20]   and"
+  - "                          *[2][self::m:mn][not(contains(., '.')) and 2<= text() and text()<=10]]"
+  - "           ]"
+  - "      ]"
+  replace:
+  - x: "*[1]"
+  - T: "do potęgi"      # phrase(x 'raised to the' second power)
+  - x: "*[2]"
+
+- # -[xxx] var^n
+  name: nested-negative-var-squared-or-cubed
+  tag: power
+  match:
+  - "$ClearSpeak_Exponents = 'Auto' and"
+  - "  *[2][self::m:mrow][count(*)=3][ "
+  - "       *[3][self::m:power]["
+  - "            *[2][self::m:mn][.='2' or .='3'] and " # exp is 2 or 3
+  - "            *[1][self::m:mi]"
+  - "           ] and "
+  - "       *[2][self::m:mo][.='⁢'] and " # invisible times
+  - "       *[1][self::m:minus and count(*)=1 and "
+  # base is mn, or common fraction ([xxx] case)
+  - "            *[1][self::m:mn or "
+  - "                 self::m:fraction[*[1][self::m:mn][not(contains(., '.')) and text()<20]   and"
+  - "                                  *[2][self::m:mn][not(contains(., '.')) and 2<= text() and text()<=10]]"
+  - "                ]"
+  - "           ]"
+  - "      ]"
+  replace:
+  - x: "*[1]"
+  - T: "do potęgi"      # phrase(x 'raised to the' second power)
+  - x: "*[2]"
+
+- name: default-exponent-power
+  tag: power
+  match: # directly a superscript or an mrow that contains a superscript
+  - "*[2][self::m:power or self::m:power or self::m:mrow[m:power]]"
+  replace:
+  - x: "*[1]"
+  - T: "do wykładnika"      # phrase(x is 'raised to the exponent')
+  - pause: short
+  - x: "*[2]"
+  - pause: short
+  - T: "koniec wykładnika"      # phrase(and now 'end exponent' has been reached)
+
+- name: default
+  tag: power
+  match: "."
+  replace:
+  - x: "*[1]"
+  - T: "do potęgi"      # phrase(x 'raised to the' second power)
+  - x: "*[2]"
+
+- # the inference rules lump absolute value and cardinality together, so those rules are implemented here
+  name: ClearSpeak-absolute-value
+  tag: absolute-value
+  match: "."
+  replace:
+  - test:
+    - if: "$ClearSpeak_AbsoluteValue = 'Cardinality'"
+      then: [T: "moc"]
+      else: [T: "wartość bezwzględna"]
+  - T: "z"      # phrase(the absolute value 'of' 25)
+  - x: "*[1]"
+  - test:
+      if: "$ClearSpeak_AbsoluteValue = 'AbsEnd'"
+      then:
+      - pause: short
+      - T: "koniec wartości bezwzględnej"      # phrase('end' absolute value)
+  - pause: short
+
+- name: set
+  tag: set
+  match: "."
+  replace:
+  - test:
+    - if: "count(*)=0"
+      then: [t: "zbiór pusty"]      # phrase('the empty set')
+    - else_if: "count(*)=2"
+      then:
+      - test:
+          if: "$Verbosity!='Terse'"
+          then: [T: ""]      # phrase('the' empty set)
+      - T: "zbiór pusty"      # phrase(the 'empty set')
+    - else_if: "count(*[1]/*)=3 and *[1]/*[2][self::m:mo][.=':' or .='|' or .='∣']"
+      then:
+      - test:
+          if: "$Verbosity!='Terse'"
+          then: [T: ""]      # phrase('the' set of all integers)
+      - t: "zbiór"      # phrase(this is a 'set of' numbers)
+      - test:
+          if: "$ClearSpeak_Sets != 'woAll'"
+          then: [t: "wszystkie"]      # phrase(the set of 'all' integers)
+      - x: "*[1]/*[1]"
+      - T: "takich że"      # phrase(the set S 'such that' x is less than y)
+      - x: "*[1]/*[3]"
+      else:
+      - test:
+          if: "$ClearSpeak_Sets != 'SilentBracket'"
+          then:
+          - test:
+              if: "$Verbosity!='Terse'"
+              then: [T: ""]      # phrase('the' set of integers)
+          - T: "zbiór"      # phrase(this is a 'set' of integers)
+      - x: "*[1]"
+
+- # intervals are controlled by a ClearSpeak Preference -- parens/brackets don't have to match, so we avoid IsBracketed
+  # alternatively, we could have four (or ten) rules, but there is a lot of duplication if we do that
+  # this one rule handles all ten cases listed as part $ClearSpeak_Paren = 'Interval'
+  # note that *[2] is an mrow with X, ",", Y, so getting X or Y is a double index
+  name: ClearSpeak-intervals # avoid overriding with default "intervals" name
+  variables:
+  - is_intervals_start_infinity: "*[1][self::m:minus and count(*)=1 and *[1][.='∞']]"
+  - is_intervals_end_infinity: "*[2][.='∞'or (self::m:plus and count(*)=1 and *[1][.='∞'])]"
+  tag: [open-interval, open-closed-interval, closed-interval, closed-open-interval]
+  match: "."
+  replace:
+  - test:
+    - if: "name(.)='open-interval'"
+      then: [T: "przedział otwarty"]
+    - else_if: "name(.)='closed-interval'"
+      then: [T: "przedział domknięty"]
+    - else_if: "name(.)='open-closed-interval'"
+      then: [T: "przedział lewostronnie otwarty prawostronnie domknięty"]
+      else: [T: "przedział lewostronnie domknięty prawostronnie otwarty"]
+  - T: "od"      # phrase('the interval from' a to b)
+  - x: "*[1]"
+  - T: "do"      # phrase(the interval from a 'to' b)
+  - x: "*[2]"
+  - pause: short
+
+    # onto the [not] [including]... part
+- name: binomial-frac-vector
+  tag: matrix
+  match:
+  - "$ClearSpeak_Matrix = 'Combinatorics' and "
+  - "count(*[1]/*)=1 and count(*)=2"
+  replace:
+  - x: "*[1]/*[1]/*" # mtable/mtr/mtd
+  - T: "po"      # phrase(the binomial coefficient n 'choose' m)
+  - x: "*[2]/*[1]/*"
+
+- name: ClearSpeak-default
+  tag: [mtr, mlabeledtr]
+  match: "parent::m:matrix or parent::m:determinant"
+  variables: [NextLineIsContinuedRow: "following-sibling::*[1][contains(@data-intent-property, ':continued-row:')]"]
+  replace:
+  - pause: medium
+  - T: "wiersz"      # phrase(the first 'row' of a matrix)
+  - x: "count(preceding-sibling::*)+1"
+  - test:
+      if: ".[self::m:mlabeledtr]"
+      then:
+      - T: "z etykietą"      # phrase(the line 'with label' first equation)
+      - x: "*[1]/*"
+      - pause: short
+  - pause: medium
+  - test:
+      if: ".[self::m:mlabeledtr]"
+      then: [x: "*[position()>1]"]
+      else: [x: "*"]
+
+- # handle both log and ln
+  name: ClearSpeak-log
+  tag: mi
+  match: ".='log' or .='ln'"
+  replace:
+  - bookmark: "@id"
+  - test:
+    - if: ".='log'"
+      then: [T: "logarytm"]
+    - else_if: "$ClearSpeak_Log = 'LnAsNaturalLog'"
+      then: [T: "logarytm naturalny"]      # phrase(the 'natural log' of x)
+      else: [spell: "'ln'"]
+
+- name: ClearSpeak-multi-line
+  tag: [piecewise, system-of-equations, lines] # these are ignored in favor of the ClearSpeak prefs
+  match: "."
+  variables:
+    # Wikipedia has some tables where all the entire first column is empty (e.g., https://en.wikipedia.org/wiki/List_of_trigonometric_identities)
+  - LineCount: "count(*[not(contains(@data-intent-property, ':continued-row:'))])"
+  - NextLineIsContinuedRow: "false()"   # default value
+  - IsColumnSilent: true()
+  replace:
+  - test:
+    - if: "$ClearSpeak_MultiLineOverview = 'Auto'"
+      then:
+      - x: "$LineCount"
+      - test:
+        - if: "$LineCount != 1 and (($ClearSpeak_MultiLineLabel = 'Auto' and self::m:piecewise) or $ClearSpeak_MultiLineLabel = 'Case')"
+          then: [t: "przypadki"]      # phrase(this is the first 'case' of three cases)
+        - else_if: "$LineCount != 1 and ($ClearSpeak_MultiLineLabel = 'Auto' or $ClearSpeak_MultiLineLabel = 'Line' or $ClearSpeak_MultiLineLabel = 'None')"
+          then: [t: "linie"]      # phrase(this is the first 'line' of three lines)
+        - else_if: "$LineCount != 1 and $ClearSpeak_MultiLineLabel = 'Constraint'"
+          then: [t: "warunki"]      # phrase(this is the first 'constraint' of three constraints)
+        - else_if: "$LineCount != 1 and $ClearSpeak_MultiLineLabel = 'Equation'"
+          then: [t: "równania"]      # phrase(this is the first 'equation' of three equations)
+        - else_if: "$LineCount != 1 and $ClearSpeak_MultiLineLabel = 'Row'"
+          then: [T: "wiersze"]      # phrase(this is the first 'row' of three rows)
+        - else_if: "$LineCount != 1 and $ClearSpeak_MultiLineLabel = 'Step'"
+          then: [t: "kroki"]      # phrase(this is the first 'step' of three steps)
+        - else_if: "($ClearSpeak_MultiLineLabel = 'Auto' and self::m:piecewise) or $ClearSpeak_MultiLineLabel = 'Case'"
+          then: [t: "przypadek"]      # phrase(this is the first 'case' of three cases)
+        - else_if: "$ClearSpeak_MultiLineLabel = 'Auto' or $ClearSpeak_MultiLineLabel = 'Line' or $ClearSpeak_MultiLineLabel = 'None'" # already dealt with Auto/Case
+          then: [t: "linia"]      # phrase(this is the first 'line' of three lines)
+        - else_if: "$ClearSpeak_MultiLineLabel = 'Constraint'"
+          then: [t: "warunek"]      # phrase(this is the first 'constraint' of three constraints)
+        - else_if: "$ClearSpeak_MultiLineLabel = 'Equation'"
+          then: [t: "równanie"]      # phrase(this is the first 'equation' of three equations)
+        - else_if: "$ClearSpeak_MultiLineLabel = 'Row'"
+          then: [T: "wiersz"]      # phrase(this is the first 'row' of three rows)
+        - else_if: "$ClearSpeak_MultiLineLabel = 'Step'"
+          then: [t: "krok"]      # phrase(this is the first 'step' of three steps)
+          # else 'None -- don't say anything'
+      - pause: short
+  - x: "*"
+  - pause: long
+
+- name: ClearSpeak-default-multiline
+  tag: [mtr, mlabeledtr]
+  match: "parent::m:piecewise or parent::m:system-of-equations or parent::m:lines"
+  variables: [NextLineIsContinuedRow: "following-sibling::*[1][contains(@data-intent-property, ':continued-row:')]"]
+  replace:
+  - test:
+      if: "not($LineCount=1 or $ClearSpeak_MultiLineLabel='None' or contains(@data-intent-property, ':continued-row:'))"
+      then:
+      - pause: medium
+      - test:
+        - if: "($ClearSpeak_MultiLineLabel = 'Auto' and parent::m:piecewise) or $ClearSpeak_MultiLineLabel = 'Case'"
+          then: [t: "przypadek"]      # phrase(in this  'case' x is not equal to y)
+        - else_if: "$ClearSpeak_MultiLineLabel = 'Auto' or $ClearSpeak_MultiLineLabel = 'Line'" # already dealt with Auto/Case
+          then: [t: "linia"]      # phrase(the straight 'line' between x and y)
+        - else_if: "$ClearSpeak_MultiLineLabel = 'Constraint'"
+          then: [t: "warunek"]      # phrase(there is a 'constraint' on possible values)
+        - else_if: "$ClearSpeak_MultiLineLabel = 'Equation'"
+          then: [t: "równanie"]      # phrase(the 'equation' pi r squared gives the area of a circle)
+        - else_if: "$ClearSpeak_MultiLineLabel = 'Row'"
+          then: [T: "wiersz"]      # phrase(the values on the top 'row' are relevant)
+        - else_if: "$ClearSpeak_MultiLineLabel = 'Step'"
+          then: [t: "krok"]      # phrase(this is a 'step' by step process)
+          # else 'None -- don't say anything'
+      - x: "count(preceding-sibling::*[not(contains(@data-intent-property, ':continued-row:'))]) + 1"
+  - test:
+      if: "self::m:mlabeledtr"
+      then:
+      - T: "z etykietą"      # phrase(the diagram is complete 'with label')
+      - x: "*[1]/*"
+  - test:
+    - if: "$ClearSpeak_MultiLineLabel='None'"
+      then: [pause: xlong]   # need a very long pause with no line labels
+    - else_if: "not(contains(@data-intent-property, ':continued-row:'))"
+      then: [pause: medium]
+  - test:
+      if: "self::m:mlabeledtr"
+      then: [x: "*[position()>1]"]
+      else: [x: "*"]
+
+- name: subscripted-function-application
+  tag: mo
+  match:
+  - "(.='⁢' or .='⁡') and"
+  - "not(ancestor-or-self::*[contains(@data-intent-property, ':literal:')]) and"
+  - "preceding-sibling::*[1][(self::m:indexed-by or self::m:msub or self::m:msubsup) and *[1][self::m:mi]] and"
+  - "(following-sibling::*[1][IsBracketed(., '(', ')') or IsBracketed(., '[', ']')] or"
+  - " .='⁡' and following-sibling::*[1][IsNode(., 'simple')])"
+  replace:
+  - T: "z"      # phrase(function 'of' one variable)
+
+- name: large-operator-subscripted-function-application
+  tag: mo
+  match:
+  - ".='⁢' and"
+  - "not(ancestor-or-self::*[contains(@data-intent-property, ':literal:')]) and"
+  - "(preceding-sibling::*[1][.//m:mo[.='∑' or .='∏' or .='∐'] and"
+  - "  .//*[(self::m:indexed-by or self::m:msub or self::m:msubsup) and *[1][self::m:mi]]] or"
+  - " parent::*[self::m:mrow and preceding-sibling::*[1][.//m:mo[.='∑' or .='∏' or .='∐'] and"
+  - "   .//*[(self::m:indexed-by or self::m:msub or self::m:msubsup) and *[1][self::m:mi]]]]) and"
+  - "following-sibling::*[1][IsBracketed(., '(', ')') or IsBracketed(., '[', ']')]"
+  replace:
+  - T: "z"      # phrase(function 'of' one variable)
+
+- name: ClearSpeak_Functions_None
+  tag: mo
+  match:
+  - ".='⁡' and $ClearSpeak_Functions = 'None' and"
+  - "not(preceding-sibling::*[1][IsInDefinition(., 'TrigFunctionNames')])" # Functions=None does not apply to "trig" functions
+  replace:
+    test:
+      if: "$ClearSpeak_ImpliedTimes = 'None'"
+      then: [t: ""]
+      else: [T: "razy"]      # phrase(5 'times' 3 equals 15)
+
+- name: no-times
+  tag: mo
+  match:
+  # Note: this rule is also part of the paren rule so that the parens speak
+  - ".='⁢' and $ClearSpeak_ImpliedTimes = 'None'"
+  replace:
+  - t: ""
+
+- name: ClearSpeak-times
+  tag: mo
+  match:
+  # say "times" when invisible times is followed by parens or a superscript that has a base with parens or "|"s
+  # if we aren't sure if it is times or not, don't say anything
+  - ".='⁢' and (not(@data-function-guess) or $ClearSpeak_Functions = 'None') and"
+  - "not(ancestor-or-self::*[contains(@data-intent-property, ':literal:')]) and ("
+  - "  $ClearSpeak_ImpliedTimes = 'MoreImpliedTimes'"
+  - " or "
+  - "  following-sibling::*[1]["
+  - "    IsBracketed(., '(', ')') or IsBracketed(., '[', ']') or IsBracketed(., '|', '|') or "
+  # most of these aren't mentioned in ClearSpeak spec, but are (I think) expected uses of "times"
+  - "    self::m:matrix or self::m:determinant or self::m:binomial or" # followed by parens
+  - "    self::m:square-root or self::m:msqrt or self::m:root or self::m:mroot or"
+  - "    (self::m:msub or self::m:msubsup or"
+  - "    ((self::m:msup or self::m:power) and not(IsNode(*[1], 'leaf') and *[2][self::m:mn and (.=2 or '.=3')]))) and " # followed by msup, etc.
+  - "     (*[1][self::m:mrow[IsBracketed(., '(', ')') or IsBracketed(., '[', ']') or IsBracketed(., '|', '|')] or "
+  - "           self::m:matrix or self::m:determinant] or" # base has parens
+  - "      not(IsNode(*[2], 'simple')) or "
+  - "      (self::m:msubsup and not(IsNode(*[3], 'simple')))"
+  - "     )"
+  - "  ]"
+  # other possibility is the preceding element has parens (but not the following)
+  # this is not mentioned in the ClearSpeak rules or examples but seems like it should say "times". E.g, |x| y
+  - " or "
+  - "  preceding-sibling::*[1]["
+  - "    self::m:binomial or IsBracketed(., '(', ')') or IsBracketed(., '[', ']') or IsBracketed(., '|', '|')]" # followed by parens or a binomial coefficient
+  - " )"
+  replace:
+  - T: "razy"      # phrase(5 'times' 3 equals 15)
+
+- name: no-say-parens
+  tag: mrow
+  match:
+  - "parent::*[not(self::m:msup) and not(self::m:msub) and not(self::m:msubsup) and not(self::m:power) and"
+  - "          not(self::m:math) ] and "       # rule out [x] standing alone
+  - "( IsBracketed(., '(', ')') or IsBracketed(., '[', ']') ) and "
+  - "not( $ClearSpeak_Functions = 'None' and "
+  - "     (preceding-sibling::*[1][.='⁡'] or following-sibling::*[1][.='⁡']) ) and "
+  - "not( $ClearSpeak_ImpliedTimes = 'None' and "
+  - "     (preceding-sibling::*[1][.='⁢'] or following-sibling::*[1][.='⁢']) ) and "
+  - "IsNode(*[2], 'simple') and"
+  - "not(preceding-sibling::*[1][.='\u2062' and @data-function-guess]) and"
+  - "not(ancestor-or-self::*[contains(@data-intent-property, ':literal:')])"
+  # missing clause: 'a positive fraction that is spoken as an ordinal
+  #   (either by the Ordinal preference or by the default rules)'
+  replace:
+  - x: "*[2]"
+
+- include: "SharedRules/geometry.yaml"
+- include: "SharedRules/linear-algebra.yaml"
+- include: "SharedRules/general.yaml"
+- include: "SharedRules/default.yaml"

--- a/Rules/Languages/pl/SharedRules/calculus.yaml
+++ b/Rules/Languages/pl/SharedRules/calculus.yaml
@@ -1,0 +1,56 @@
+---
+
+- name: laplacian
+  tag: laplacian
+  match: "count(*) <= 1"   # can be on ∇^2 or on enclosing mrow
+  replace:
+  - t: "laplasjan"      # phrase('laplacian' of x)  -- "LahPlahsian" sounds better with speech engines tested
+  - test:
+      if: "count(*) = 1"
+      then:
+      - test:
+          if: "$Verbosity!='Terse'"
+          then: [T: "z"]             # phrase(function 'of' one variable) -- note OneCore voices spell out "div"
+      - test:
+          if: "not(IsNode(*[1], 'leaf'))"
+          then: [pause: short]
+      - x: "*[1]"
+
+- name: divergence
+  tag: divergence
+  match: "count(*) = 1"
+  replace:
+  - test:
+      if: "$Verbosity='Terse'"
+      then: [t: "dywergencja"]             # phrase('div' is short for divergence) -- note OneCore voices spell out "div"
+      else: [t: "dywergencja z"]      # phrase('divergence of' this function from the mean)
+  - test:
+      if: "not(IsNode(*[1], 'leaf'))"
+      then: [pause: short]
+  - x: "*[1]"
+
+- name: curl
+  tag: curl
+  match: "count(*) = 1"
+  replace:
+  - t: "rotacja"      # phrase(the 'curl of' a field)
+  - test:
+      if: "$Verbosity!='Terse'"
+      then: [T: "z"]             # phrase(function 'of' one variable) -- note OneCore voices spell out "div"
+  - test:
+      if: "not(IsNode(*[1], 'leaf'))"
+      then: [pause: short]
+  - x: "*[1]"
+
+- name: gradient
+  tag: gradient
+  match: "count(*) = 1"
+  replace:
+  - test:
+      if: "$Verbosity!='Terse'"
+      then: [t: "gradient z"]      # phrase(the hill has a 'gradient of' five percent)
+      else: [t: "gradient"]      # phrase(the delete key is labeled 'del')
+  - test:
+      if: "not(IsNode(*[1], 'leaf'))"
+      then: [pause: short]
+  - x: "*[1]"

--- a/Rules/Languages/pl/SharedRules/default.yaml
+++ b/Rules/Languages/pl/SharedRules/default.yaml
@@ -1,0 +1,777 @@
+---
+#default rules shared among several speech rules
+- name: default
+  tag: math
+  match: "."
+  replace:
+  - with:
+      variables:
+      - ClearSpeak_Fractions: "IfThenElse($Verbosity='Verbose' and $ClearSpeak_Fractions='Auto', 'EndFrac', $ClearSpeak_Fractions)"
+      - ClearSpeak_AbsoluteValue: "IfThenElse($Verbosity='Verbose' and $ClearSpeak_AbsoluteValue='Auto', 'AbsEnd', $ClearSpeak_AbsoluteValue)"
+      - ClearSpeak_Roots: "IfThenElse($Verbosity='Verbose' and $ClearSpeak_Roots='Auto', 'RootEnd', $ClearSpeak_Roots)"
+      - ClearSpeak_Matrix: "IfThenElse($Verbosity='Verbose' and $ClearSpeak_Matrix='Auto', 'EndMatrix', $ClearSpeak_Matrix)"
+
+      - MatchingPause: false()
+      # should be set at mtable level, but unknown intents make that impossible to know
+      - IsColumnSilent: false()
+      replace:
+      - test:
+          if: "$MathRate = 100"
+          then: [x: "*"]
+          else:
+          - rate:
+              value: "$MathRate"
+              replace: [x: "*"]
+
+- name: empty-mrow
+  tag: mrow
+  match: "not(*)"
+  replace:
+  - t: " " # say nothing -- placeholder
+
+- name: bracketed-under-function-power-base
+  tag: mrow
+  match:
+  - "(parent::m:power or parent::m:msup) and"
+  - "*[1][.='(' or .='['] and *[last()][.=')' or .=']'] and"
+  - "*[2][self::m:large-op or self::m:munder or descendant::m:large-op or descendant::m:munder]"
+  replace:
+  - x: "*"
+
+- name: default
+  tag: mrow
+  match: "."
+  replace:
+  - insert:
+      nodes: "*"
+      replace: [pause: auto]
+
+- name: default
+  tag: mn
+  match: "."
+  replace:
+  - bookmark: "@id"
+  - test:
+    - if: "@data-roman-numeral" 
+      then: [spell: "text()", pause: "short"]
+      else: [x: "translate(., $BlockSeparators, '')"]  # remove digit block separators
+
+- name: text-prime
+  tag: [mi, mtext]
+  match: "normalize-space(.)='prime' or normalize-space(.)='primes'"
+  replace:
+  - bookmark: "@id"
+  - T: "pierwsze"
+
+- name: function-rank
+  tag: mi
+  match: ".='rank' or .='Rank'"
+  replace:
+  - bookmark: "@id"
+  - T: "rząd"
+
+- name: function-nullity
+  tag: mi
+  match: ".='nullity' or .='Nullity'"
+  replace:
+  - bookmark: "@id"
+  - T: "wymiar jądra"
+
+- name: default
+  tag: [mo, mtext]
+  match: "."
+  replace:
+  - bookmark: "@id"
+  - x: "text()"
+
+- name: default
+  tag: mi
+  match: "."
+  replace:
+  - bookmark: "@id"
+  - test:
+    - if: "string-length(.) = 1 and text() != '_'"       # need unicode.tdl to kick in for single letter tokens
+      then: [x: "text()"]
+    - else_if: "@data-chem-element or @data-roman-numeral"                      # NavMode=Character needs this
+      then: [spell: "text()", pause: "short"]
+      else: [x: "translate(., '-_\u00A0', '  ')"]   # from intent literals or from extra spaces added (which get deleted)
+
+- name: default
+  tag: ms
+  match: "."
+  replace:
+  - t: "string"      # phrase('the string' is long)
+  - pause: short
+  - x: "text()"
+
+- name: default
+  tag: mstyle
+  match: "."
+  replace: [x: "*"]
+
+
+- name: literal-simple
+  # don't include nested fractions. E.g, fraction a plus b over c + 1 end fraction" is ambiguous
+  # by simplistic SimpleSpeak's rules "b over c" is a fraction, but if we say nested fractions
+  # are never simple, then any 'over' applies only to enclosing "fraction...end fraction" pair.
+  tag: mfrac
+  match:
+  - "(IsNode(*[1],'leaf') and IsNode(*[2],'leaf')) and"
+  - "not(ancestor::*[name() != 'mrow'][1]/self::m:fraction)" # FIX: can't test for mrow -- what should be used???
+  replace:
+  - x: "*[1]"
+  - T: "przez"               # phrase("the fraction x 'over' y")
+  - x: "*[2]"
+  - pause: short
+
+- name: literal-default
+  tag: mfrac
+  match: "."
+  replace:
+  - T: "początek"              # phrase("'start'  fraction x over y end of fraction")
+  - pause: short
+  - x: "*[1]"
+  - test:
+      if: "not(IsNode(*[1],'leaf'))"
+      then: [pause: short]
+  - T: "przez"               # phrase("the fraction x 'over' y")
+  - test:
+      if: "not(IsNode(*[2],'leaf'))"
+      then: [pause: short]
+  - x: "*[2]"
+  - pause: short
+  - test:
+      if: "$Impairment = 'Blindness'"
+      then: [t: "koniec ułamka"]          # phrase("start of fraction x over y 'end over'")
+  - pause: medium
+
+
+# not sure what really should be said for these since we should not assume they are square roots
+- name: literal-default
+  tag: msqrt
+  match: "."
+  replace:
+  - T: "pierwiastek"
+  - test:
+      if: "$Verbosity!='Terse'"
+      then: [T: "z"]    # phrase("the root 'of' x")
+  - x: "*[1]"
+  - pause: short
+  - test:
+      if: "not(IsNode(*[1],'leaf')) or $Impairment = 'Blindness'"
+      then: [T: "koniec pierwiastka", pause: medium] # phrase("root of x 'end root symbol'")
+
+# not sure what really should be said for these since we should not assume they are square roots
+- name: literal-default
+  tag: mroot
+  match: "."
+  replace:
+  - T: "pierwiastek stopnia" # phrase("the 'root with index' 3 of 5")
+  - x: "*[1]"
+  - pause: short
+  - T: "z"              # phrase("the root 'of' x")
+  - x: "*[2]"
+  - pause: short
+  - test:
+      if: "not(IsNode(*[2],'leaf'))"
+      then: [T: "koniec pierwiastka"] # phrase("root of x 'end root symbol'")
+
+
+- name: simple-sub
+  tag: indexed-by
+  # invisible comma -- want "x 1 when subscript is an integer"
+  match: "count(*)=2 and $Verbosity='Terse' and *[2][self::m:mn and translate(., '.,', '')=.]"
+  replace:
+  - x: "*[1]"
+  - x: "*[2]"
+  - pause: short
+
+- name: no-end-sub
+  tag: indexed-by
+  match: "count(*)=2 and *[2][self::m:mrow and *[2][.='⁣']]"
+  replace:
+  - x: "*[1]"
+  - T: "indeks dolny"               # phrase(x 'sub' 2)
+  - x: "*[2]"
+  - pause: short
+
+- name: power-indexed-by
+  tag: power-indexed-by
+  match: "."
+  replace:
+  - x: "*[1]"
+  - T: "indeks dolny"               # phrase(x 'sub' 2)
+  - x: "*[2]"
+  - pause: short
+
+# otherwise let definitions/default infix handle it
+
+- name: literal
+  tag: msub
+  match: "."
+  replace:
+  - x: "*[1]"
+  - test:
+      if: "not($Verbosity='Terse' and *[2][self::m:mn and not(translate(., '.,', '')!=.)])"  # just say "x 1" for terse vs "x sub 1"
+      then: [T: "indeks dolny"]      # phrase(x 'sub' 2)
+  - x: "*[2]"
+
+
+- name: literal
+  tag: [msup, msubsup]
+  match: "."
+  replace:
+  - x: "*[1]"
+  - test:
+      if: "name(.)='msubsup'"
+      then:
+      - T: "indeks dolny"          # phrase(x 'sub' 2)
+      - x: "*[2]"
+  - test:
+      if: "*[last()][translate(., '′″‴⁗†‡°*', '')='']"
+      then:  [x: "*[last()]"]
+      else_test:
+          if: "ancestor-or-self::*[contains(@data-intent-property, ':literal:')]"  # FIX: is this test necessary?
+          then:
+          - T: "indeks górny"      # phrase(x 'super' 2)
+          - x: "*[last()]"
+          - test:
+              if: "not(IsNode(*[last()], 'simple')) or $Impairment = 'Blindness'"
+              then: [T: "koniec indeksu górnego"]      # phrase(x super 2 'end of super')
+          else:
+          - test:
+              if: "$Verbosity='Verbose'"
+              then: [T: "indeks górny"]
+              else: [T: "indeks górny"]
+          - x: "*[last()]"
+          - test:
+              if: "$Verbosity='Verbose'"
+              then: [T: "koniec indeksu górnego"]
+              else: [T: "koniec indeksu górnego"]
+
+# Polska wymowa operatorow arg max / arg min / ess sup: realizowana regula 'mo' w
+# ClearSpeak_Rules.yaml (wyzszy priorytet). Operator jest emitowany przez x: ponizej (nawigowalny).
+- name: named-under-operator
+  tag: munder
+  match: "*[1][contains(., 'arg') and (contains(., 'max') or contains(., 'min'))] or *[1][contains(., 'ess') and contains(., 'sup')]"
+  replace:
+  - x: "*[1]"      # operator (arg max / arg min / ess sup) - emisja czyni go nawigowalnym
+  - T: "z"      # phrase(x 'with' z below it)
+  - x: "*[2]"
+  - T: "pod"      # phrase(x with z 'below' it)
+
+- name: default
+  tag: munder
+  match: "."
+  replace:
+  - test:
+      if: "not(IsNode(*[1], 'leaf'))"
+      then: [T: "wyrażenie"]      # phrase(phrase(x 'quantity' with y above it)
+  - x: "*[1]"
+  - T: "z"      # phrase(x 'with' z below it)
+  - x: "*[2]"
+  - T: "pod"      # phrase(x with z 'below' it)
+
+- name: diacriticals
+  tag: mover
+  match: "*[1][self::m:mi] and *[2][translate(., '\u0306\u030c.\u00A8\u02D9\u20DB\u20DC`^ˇ~→¯_', '')='']"
+  replace:
+  - x: "*[1]"
+  - x: "*[2]"
+
+- name: default
+  tag: mover
+  match: "."
+  replace:
+  - test:
+      if: "not(IsNode(*[1], 'leaf'))"
+      then: [T: "wyrażenie"]      # phrase(phrase(the 'quantity' x plus 1 with y above it)
+  - x: "*[1]"
+  - T: "z"         # phrase(x modified 'with' y above it)
+  - x: "*[2]"
+  - T: "nad"        # phrase(x modified 'with' y above it)
+
+- name: default
+  tag: munderover
+  match: "."
+  replace:
+  - test:
+      if: "not(IsNode(*[1], 'leaf'))"
+      then: [T: "wyrażenie"]      # phrase(the 'quantity' x plus 1 with y above it)
+  - x: "*[1]"
+  - T: "z"         # phrase(x modified 'with' y above it)
+  - x: "*[2]"
+  - T: "pod oraz"    # phrase(x modified with y 'below and' y above it)
+  - x: "*[3]"
+  - T: "nad"        # phrase(x modified with y 'above' it)
+
+- name: default
+  #   Here we support up to 2 prescripts and up to 4 postscripts -- that should cover all reasonable cases
+  #   If there are more, we just dump them out without regard to sup/super :-(
+  # FIX: this could use more special cases 
+  # There is (currently) no way in MathCAT to deal with n-ary arguments other than "all" ('*') or an individual entry ('*[1]').
+  tag: mmultiscripts
+  match: "."
+  variables:
+  # computing the number of postscripts is messy because of <mprescripts> being optionally present -- we use "mod" to get the count right
+  - Prescripts: "m:mprescripts/following-sibling::*"
+  - NumChildren: "count(*)" # need to stash this since the count is wrong inside '*[...]' below
+  - Postscripts: "*[position()>1 and position() < (last() + ($NumChildren mod 2) -count($Prescripts))]"
+  replace:
+  - x: "*[1]"
+  - test:
+      if: "$Prescripts" # more common case
+      then:
+      - with:
+          variables:
+          - PreSubscript: "IfThenElse($Verbosity='Verbose', 'lewy indeks dolny', 'lewy indeks dolny')"
+          - PreSuperscript: "IfThenElse($Verbosity='Verbose', 'lewy indeks górny', 'lewy indeks górny')"
+          replace:
+          - test: # only bother announcing if there is more than one prescript
+              if: "count($Prescripts) > 2"
+              then:
+              - T: "z"      # phrase(substitute x 'with' y)
+              - x: "count($Prescripts) div 2"
+              - t: "lewe indeksy"      # phrase(in this equation certain 'prescripts' apply)
+              - pause: short
+          - test:
+              if: "not($Prescripts[1][self::m:none])"
+              then:
+              - x: "$PreSubscript"
+              - x: "$Prescripts[1]"
+          - test:
+              if: "not($Prescripts[1][self::m:none] or $Prescripts[2][self::m:none])"
+              then: [T: "i"]      # phrase(10 is greater than 8 'and' less than 15)
+          - test:
+              if: "not($Prescripts[2][self::m:none])"
+              then:
+              - x: "$PreSuperscript"
+              - x: "$Prescripts[2]"
+          - pause: short
+          - test:
+              if: "count($Prescripts) > 2" # more common case
+              then:
+              - test:
+                  if: "not($Prescripts[3][self::m:none])"
+                  then:
+                  - x: "$PreSubscript"
+                  - x: "$Prescripts[3]"
+              - test:
+                  if: "not($Prescripts[3][self::m:none] or $Prescripts[4][self::m:none])"
+                  then: [T: "i"]      # phrase(10 is grater than 8 'and' less than 15)
+              - test:
+                  if: "not($Prescripts[4][self::m:none])"
+                  then:
+                  - x: "$PreSuperscript"
+                  - x: "$Prescripts[4]"
+              - test:
+                  if: "count($Prescripts) > 4" # give up and just dump them out so at least the content is there
+                  then:
+                  - t: "i kolejne lewe indeksy"      # phrase(in this case there are values 'and alternating prescripts')
+                  - x: "$Prescripts[position() > 4]"
+                  - t: "koniec lewych indeksów"      # phrase(This is where 'end prescripts' occurs)
+  - test:
+      if: "$Postscripts"
+      then:
+      - with:
+          variables:
+          - PostSubscript: "IfThenElse($Verbosity='Verbose', 'indeks dolny', 'indeks dolny')"
+          - PostSuperscript: "IfThenElse($Verbosity='Verbose', 'indeks górny', 'indeks górny')"
+          replace:
+          - test: # only bother announcing if there is more than one postscript
+              if: "count($Postscripts) > 2"
+              then:
+              - test:
+                  if: "$Prescripts"
+                  then: [T: "i"]      # phrase(10 is greater than 8 'and' less than 15)
+              - T: "z"      # phrase(substitute x 'with' y)
+              - x: "count($Postscripts) div 2"
+              - t: "prawe indeksy"      # phrase(this material includes several 'postscripts')
+              - pause: short
+          - test:
+              if: "not($Postscripts[1][self::m:none])"
+              then:
+              - x: "$PostSubscript"
+              - x: "$Postscripts[1]"
+          - test:
+              if: "not($Postscripts[1][self::m:none] or $Postscripts[2][self::m:none])"
+              then: [T: "i"]      # phrase(10 is greater than 8 'and' less than 15)
+          - test:
+              if: "not($Postscripts[2][self::m:none])"
+              then:
+              - x: "$PostSuperscript"
+              - x: "$Postscripts[2]"
+          - test:
+              if: "count($Postscripts) > 2"
+              then:
+              - test:
+                  if: "not($Postscripts[3][self::m:none])"
+                  then:
+                  - x: "$PostSubscript"
+                  - x: "$Postscripts[3]"
+              - test:
+                  if: "not($Postscripts[3][self::m:none] or $Postscripts[4][self::m:none])"
+                  then: [T: "i"]      # phrase(10 is greater than 8 'and' less than 15)
+              - test:
+                  if: "not($Postscripts[4][self::m:none])"
+                  then:
+                  - x: "$PostSuperscript"
+                  - x: "$Postscripts[4]"
+              - test:
+                  if: "count($Postscripts) > 4"
+                  then:
+                  - test:
+                      if: "not($Postscripts[5][self::m:none])"
+                      then:
+                      - x: "$PostSubscript"
+                      - x: "$Postscripts[5]"
+                  - test:
+                      if: "not($Postscripts[5][self::m:none] or $Postscripts[6][self::m:none])"
+                      then: [T: "i"]      # phrase(10 is greater than 8 'and' less than 15)
+                  - test:
+                      if: "not($Postscripts[6][self::m:none])"
+                      then:
+                      - x: "$PostSuperscript"
+                      - x: "$Postscripts[6]"
+                  - test:
+                      if: "count($Postscripts) > 6"
+                      then:
+                      - test:
+                          if: "not($Postscripts[7][self::m:none])"
+                          then:
+                          - x: "$PostSubscript"
+                          - x: "$Postscripts[7]"
+                      - test:
+                          if: "not($Postscripts[7][self::m:none] or $Postscripts[8][self::m:none])"
+                          then: [T: "i"]      # phrase(10 is less than 15 'and' greater than 5)
+                      - test:
+                          if: "not($Postscripts[8][self::m:none])"
+                          then:
+                          - x: "$PostSuperscript"
+                          - x: "$Postscripts[8]"
+                      - test:
+                          if: "count($Postscripts) > 8" # give up and just dump them out so at least the content is there
+                          then:
+                          - t: "i kolejne indeksy"      # phrase(this situation involves complexities 'and alternating scripts')
+                          - x: "$Postscripts[position() > 8]"
+                          - t: "koniec indeksów"      # phrase(At this point 'end scripts' occurs)
+
+- name: default
+  tag: mtable
+  variables:
+  - IsColumnSilent: "false()"
+  - NumColumns: "count(*[1]/*) - IfThenElse(*/self::m:mlabeledtr, 1, 0)"
+  match: "."
+  replace:
+  - T: "tabela z"      # phrase(the 'table with' 3 rows)
+  - x: count(*)
+  - test:
+      if: count(*)=1
+      then: [T: "wiersz"]      # phrase(the table with 1 'row')
+      else: [T: "wiersze"]      # phrase(the table with 3 'rows')
+  - T: "i"      # phrase(the table with 3 rows 'and' 4 columns)
+  - x: "$NumColumns"
+  - test:
+      if: "NumColumns=1"
+      then: [T: "kolumna"]      # phrase(the table with 3 rows and 1 'column')
+      else: [T: "kolumny"]      # phrase(the table with 3 rows and 4 'columns')
+  - pause: long
+  - x: "*"
+
+- name: default
+  # callers/context should do that.
+  # this may get called from navigation -- in that case, there is no context to speak the row #, so don't do it
+  tag: [mtr, mlabeledtr]
+  match: "."
+  replace:
+  - pause: medium
+  - T: "wiersz"      # phrase(the first 'row' of a matrix)
+  - x: "count(preceding-sibling::*)+1"
+  - test:
+      if: "self::m:mlabeledtr"
+      then:
+      - T: "z etykietą"      # phrase(the line 'with label' first equation)
+      - x: "*[1]/*"
+      - pause: short
+  - pause: medium
+  - test:
+      if: "self::m:mlabeledtr"
+      then: [x: "*[position()>1]"]
+      else: [x: "*"]
+
+- name: default
+  tag: mtd
+  match: "."
+  replace:
+  - test:
+      #  ClearSpeak normally speaks "column 1" even though it says the row number, which is a waste...
+      #  The following is commented out but the count(...)!=0 probably belongs in other rule sets
+      #   if: not($IsColumnSilent) and ($ClearSpeak_Matrix = 'SpeakColNum' or count(preceding-sibling::*) != 0)
+      if: "not($IsColumnSilent)"
+      then:
+      - T: "kolumna"      # phrase(the first 'column' of the matrix)
+      - x: "count(preceding-sibling::*)+IfThenElse(parent::m:mlabeledtr, 0, 1)"
+      - pause: medium
+  - x: "*"
+  - test:
+    # short pause after each element; medium pause if last element in a row; long pause for last element in matrix
+    - if: count(following-sibling::*) > 0
+      then: [pause: short]
+    - else_if: count(../following-sibling::*) > 0
+      then: [pause: medium]
+      else: [pause: long]
+
+
+- name: empty-box
+  # The ordering below is the order in which words come out when there is more than one value
+  # Note: @notation can contain more than one value
+  tag: menclose
+  match: "@notation='box' and *[self::m:mtext and .=' ']"
+  replace:
+  - t: "pusta ramka"      # phrase(the 'empty box' contains no values)
+
+- name: default
+  # The ordering below is the order in which words come out when there is more than one value
+  # Note: @notation can contain more than one value
+  tag: menclose
+  match: "."
+  replace:
+  - test:
+      if: ".[contains(concat(' ', normalize-space(@notation), ' '), ' box ')]"
+      then: [t: "ramka", pause: short]      # phrase(the 'box' around the expression)
+  - test:
+      if: ".[contains(@notation,'roundedbox')]"
+      then: [t: "zaokrąglona ramka", pause: short]      # phrase(the 'round box' around the expression)
+  - test:
+      if: ".[contains(@notation,'circle')]"
+      then: [t: "okrąg", pause: short]      # phrase(the 'circle' around the expression)
+  - test:
+      if: ".[ contains(concat(' ', normalize-space(@notation), ' '), ' left ') or contains(concat(' ', normalize-space(@notation), ' '), ' right ') or contains(@notation,'top') or contains(@notation,'bottom') ]"
+      then:
+      - t: "linia na"      # phrase(draw a straight 'line' on the page)
+      - test:
+          if: ".[contains(concat(' ', normalize-space(@notation), ' '), ' left ')]"
+          then: [t: "lewo", pause: short]      # phrase(line on 'left' of the expression)
+      - test:
+          if: ".[contains(concat(' ', normalize-space(@notation), ' '), ' right ')]"
+          then: [t: "prawo", pause: short]      # phrase(line on 'right' of the expression)
+      - test:
+          if: ".[contains(@notation,'top')]"
+          then: [t: "góra", pause: short]      # phrase(line on 'top' of the expression)
+      - test:
+          if: ".[contains(@notation,'bottom')]"
+          then: [t: "dół", pause: short]      # phrase(line on the 'bottom' of the expression)
+  - test:
+      if: ".[ contains(@notation,'updiagonalstrike') or contains(@notation,'downdiagonalstrike') or contains(@notation,'verticalstrike') or contains(@notation,'horizontalstrike') ]"
+      then:
+      - test:
+          if: ".[contains(@notation,'updiagonalstrike') and contains(@notation,'downdiagonalstrike')]"
+          then: [spell: "'x'", pause: short] # seems better to say 'x cross out' than 'up diagonal, down diagonal cross out'
+          else:
+          - test:
+              if: ".[contains(@notation,'updiagonalstrike')]"
+              then: [t: "ukośnie w górę", pause: short]      # phrase(the line runs 'up diagonal')
+          - test:
+              if: ".[contains(@notation,'downdiagonalstrike')]"
+              then: [t: "ukośnie w dół", pause: short]      # phrase(the line runs 'down diagonal')
+      - test:
+          if: ".[contains(@notation,'verticalstrike')]"
+          then: [t: "pionowy", pause: short]      # phrase(the line is  'vertical')
+      - test:
+          if: ".[contains(@notation,'horizontalstrike')]"
+          then: [t: "poziomy", pause: short]      # phrase(the line is 'horizontal')
+      - t: "krzyż na zewnątrz"      # phrase(please 'cross out' the incorrect answer)
+      - pause: short
+  - test:
+      if: ".[contains(@notation,'uparrow')]"
+      then: [t: "strzałka w górę", pause: short]      # phrase(direction is shown by the 'up arrow')
+  - test:
+      if: ".[contains(concat(' ', normalize-space(@notation), ' '), ' downarrow ')]"
+      then: [t: "strzałka w dół", pause: short]      # phrase(the trend is shown by the 'down arrow')
+  - test:
+      if: ".[contains(@notation,'leftarrow')]"
+      then: [t: "strzałka w lewo", pause: short]      # phrase(the 'left arrow' indicates going back)
+  - test:
+      if: ".[contains(concat(' ', normalize-space(@notation), ' '), ' rightarrow ')]"
+      then: [t: "strzałka w prawo", pause: short]      # phrase(the 'right arrow' indicates moving forward)
+  - test:
+      if: ".[contains(@notation,'northeastarrow')]"
+      then: [t: "strzałka na północny wschód", pause: short]      # phrase(direction is indicated by the 'northeast arrow')
+  - test:
+      if: ".[contains(concat(' ', normalize-space(@notation), ' '), ' southeastarrow ')]"
+      then: [t: "strzałka na południowy wschód", pause: short]      # phrase(direction is shown by the 'southeast arrow')
+  - test:
+      if: ".[contains(concat(' ', normalize-space(@notation), ' '), ' southwestarrow ')]"
+      then: [t: "strzałka na południowy zachód", pause: short]      # phrase(direction is shown by the 'southwest arrow')
+  - test:
+      if: ".[contains(@notation,'northwestarrow')]"
+      then: [t: "strzałka na północny zachód", pause: short]      # phrase(direction is shown by the 'northwest arrow')
+  - test:
+      if: ".[contains(@notation,'updownarrow')]"
+      then: [t: "strzałka dwukierunkowa pionowa", pause: short]      # phrase(upward movement is indicated by the 'double ended vertical arrow')
+  - test:
+      if: ".[contains(@notation,'leftrightarrow')]"
+      then: [t: "strzałka dwukierunkowa pozioma", pause: short]      # phrase(progress is indicated by the 'double ended horizontal arrow')
+  - test:
+      if: ".[contains(@notation,'northeastsouthwestarrow')]"
+      then: [t: "strzałka dwukierunkowa ukośna w górę", pause: short]      # phrase(trend is indicated by the 'double ended up diagonal arrow')
+  - test:
+      if: ".[contains(@notation,'northwestsoutheastarrow')]"
+      then: [t: "strzałka dwukierunkowa ukośna w dół", pause: short]      # phrase(trend is indicated by the 'double ended down diagonal arrow')
+  - test:
+      if: ".[contains(@notation,'actuarial')]"
+      then: [t: "symbol aktuarialny", pause: short]      # phrase(the 'actuarial symbol' represents a specific quantity)
+  - test:
+      if: ".[contains(@notation,'madrub')]"
+      then: [t: "arabski symbol silni", pause: short]      # phrase(the 'arabic factorial symbol' represents a factorial operation)
+  - test:
+      if: ".[contains(@notation,'phasorangle')]"
+      then: [t: "kąt fazowy", pause: short]      # phrase(the 'phasor angle' is used to measure electrical current)
+  - test:
+      if: ".[contains(@notation,'longdiv') or not(@notation) or normalize-space(@notation) ='']" # default
+      then: [t: "znak dzielenia pisemnego", pause: short]      # phrase(the 'long division symbol' indicates  a long division calculation)
+  - test:
+      if: ".[contains(@notation,'radical')]"
+      then: [T: "pierwiastek kwadratowy", pause: short]      # phrase(5 is the 'square root' of 25)
+  - t: "obejmujący"      # phrase(parentheses are 'enclosing' part of the equation)
+  - test:
+      if: "*[self::m:mtext and .=' ']"
+      then: [T: "spacja"]     # otherwise there is complete silence      # phrase(there is a 'space' between the words)
+      else: [x: "*"]
+  - test:
+      if: "$Impairment = 'Blindness' and ( $SpeechStyle != 'SimpleSpeak' or not(IsNode(*[1], 'leaf')) )"
+      then: [t: "koniec obramowania"]      # phrase(reached the 'end enclosure' point)
+  - pause: short
+
+- name: semantics
+  tag: "semantics"
+  match: "*[@encoding='MathML-Presentation']"
+  replace:
+  - x: "*[@encoding='MathML-Presentation']/*[1]"
+
+- name: semantics-default
+  tag: "semantics"
+  match: .
+  replace:
+  - x: "*[1]"
+
+- name: apply-function
+  tag: "apply-function"
+  match: .
+  replace:
+  - x: "*[1]"
+  - T: "z"      # phrase(the sine 'of' x )
+  - pause: auto
+  - x: "*[position() > 1]"
+ 
+# Here are the intent hints that need to be handled: 'prefix' | 'infix' | 'postfix' | 'function' | 'silent'
+- name: silent-intent
+  # uncaught intent -- the args have been inserted in the order of speech 
+  tag: "*"
+  match: "count(*)>0 and (contains(@data-intent-property, ':silent:') or translate(name(.), '-_', '')='')"
+  replace:
+  - x: "*"
+  - test:
+      if: "IsNode(., '2D')"
+      then: [pause: short]
+      else: [pause: auto]
+
+- name: nofix-intent
+  # uncaught intent -- the args have been inserted in the order of speech 
+  tag: "*"
+  match: "contains(@data-intent-property, ':nofix:') "
+  replace:
+  - x: "SpeakIntentName(name(.), $Verbosity, 'nofix')"
+
+- name: prefix-intent
+  # uncaught intent -- the args have been inserted in the order of speech 
+  tag: "*"
+  match: "count(*)>0 and contains(@data-intent-property, ':prefix:')"
+  replace:
+  - x: "SpeakIntentName(name(.), $Verbosity, 'prefix')"
+  - x: "*"
+  - test:
+      if: "not( IsBracketed(., '', '') or IsNode(*[last()], 'simple') )"
+      then: [x: "GetBracketingIntentName(name(.), $Verbosity, 'prefix', 'end')"]
+  - test:
+      if: "IsNode(., '2D')"
+      then: [pause: short]
+      else: [pause: auto]
+
+- name: postfix-intent
+  # uncaught intent -- the args have been inserted in the order of speech                
+  tag: "*"
+  match: "count(*)>0 and contains(@data-intent-property, ':postfix:')"
+  replace:
+  - test:
+      if: "$Impairment = 'Blindness' and not( IsBracketed(., '', '') or IsNode(*[1], 'simple') )"
+      then: [x: "GetBracketingIntentName(name(.), $Verbosity, 'postfix', 'start')"]
+  - x: "*"
+  - x: "SpeakIntentName(name(.), $Verbosity, 'postfix')"
+
+- name: infix-intent
+  # uncaught intent -- the args have been inserted in the order of speech 
+  tag: "*"
+  match: "count(*)>0 and contains(@data-intent-property, ':infix:')"
+  replace:
+  - test:
+      if: "$Impairment = 'Blindness' and not( IsBracketed(., '', '') or IsNode(*[1], 'simple') )"
+      then: [x: "GetBracketingIntentName(name(.), $Verbosity, 'infix', 'start')"]
+  - test:
+      if: "count(*) = 1"  # in cases such as continued-row, plus/minus might have just one child
+      then:
+      - x: "SpeakIntentName(name(.), $Verbosity, 'infix')"
+      - pause: auto
+      - x: "*[1]"
+      else:
+      - insert:
+          nodes: "*"
+          replace: [x: "SpeakIntentName(name(.), $Verbosity, 'infix')", pause: auto]
+  - test:
+      if: "$Impairment = 'Blindness' and not( IsBracketed(., '', '') or IsNode(*[last()], 'simple') )"
+      then: [x: "GetBracketingIntentName(name(.), $Verbosity, 'infix', 'end')"]
+  - test:
+      if: "IsNode(., '2D')"   # add (probably) a slightly longer pause if this came from a 2D node
+      then: [pause: short]
+      else: [pause: auto]
+
+- name: function-intent
+  # uncaught intent -- speak as foo of arg1 comma arg2 .... The MathML spec requires arguments to functions
+  tag: "*"
+  match: "count(*)>0"
+  replace:
+  - x: "SpeakIntentName(name(.), $Verbosity, 'function')"
+  - test:
+      if: "$Verbosity != 'Terse' and not(contains(@data-intent-property, ':literal:')) and
+           not(count(*)=2 and (IsInDefinition(*[1], 'TrigFunctionNames') or IsInDefinition(name(.), 'TerseFunctionNames')) and IsNode(*[2], 'simple'))"
+      then: [T: "z", pause: auto]      # phrase(sine 'of' 5)
+  - insert:
+      nodes: "*"
+      replace:
+      - test:
+          if: "not(contains(@data-intent-property, ':literal:'))"
+          then: [x: "','"]
+      - pause: auto
+  - test:
+      # speak "end ..." if not bracketed or last child is not simple and not last node
+      if: "$Impairment = 'Blindness' and not(*[last()][IsBracketed(., '', '') or IsNode(., 'simple')] )"
+      then: [x: "GetBracketingIntentName(name(.), $Verbosity, 'function', 'end')"]
+  - test:
+      if: "IsNode(., '2D')"
+      then: [pause: short]
+      else: [pause: auto]
+
+
+- name: leaf-infix-intent
+  # unknown leaf -- just speak the text -- could be a literal intent
+  tag: "*"
+  match: "name(.)='dot-product' or name(.)='cross-product'"
+  replace:
+  - x: "SpeakIntentName(name(.), $Verbosity, 'infix')"
+
+- name: default-text
+  # unknown leaf -- just speak the text -- could be a literal intent
+  tag: "*"
+  match: "."
+  replace:
+  - x: "translate(name(), '-_', ' ')"

--- a/Rules/Languages/pl/SharedRules/general.yaml
+++ b/Rules/Languages/pl/SharedRules/general.yaml
@@ -1,0 +1,1131 @@
+---
+
+# number-sets are a little messy in that the base was converted to a number-set, so we have to match that (simple) case last
+- name: pos-neg-number-sets
+  tag: number-sets
+  match: "count(*)=2 and *[2][.='+' or .='-']"
+  replace:
+  - test:
+      if: "$Verbosity!='Terse'"
+      then:
+      - T: ""      # phrase('the' square root of 25 equals 5)
+  - bookmark: "*[2]/@id"
+  - test:
+    - if: "*[2][.='+']"
+      then: [T: "plus"]      # phrase(set of all 'positive' integers less than 10)
+      else: [T: "minus"]      # phrase(set of all 'negative' integers less than minus 10)
+  - bookmark: "*[1]/@id"
+  - test:
+    - if: "*[1][.='ℂ']"
+      then: [t: "liczby zespolone"]      # phrase('complex numbers' consist of two parts)
+    - else_if: "*[1][.='ℕ']"
+      then: [t: "liczby naturalne"]      # phrase('natural numbers' are numbers from 1 to infinity)
+    - else_if: "*[1][.='ℚ']"
+      then: [t: "liczby wymierne"]      # phrase('rational numbers' are the fraction of 2 integers)
+    - else_if: "*[1][.='ℝ']"
+      then: [t: "liczby rzeczywiste"]      # phrase('real numbers' can be both positive and negative)
+    - else_if: "*[1][.='ℤ']"
+      then: [t: "liczby całkowite"]      # phrase(positive 'integers' are natural numbers above 0)
+      else: [x: "*[1][text()]"] # shouldn't happen
+
+- name: dimension-number-sets
+
+  # should be single digit integer at this point (e.g, R^3)
+  tag: number-sets
+  match: "count(*)=2"
+  replace:
+  - bookmark: "*[1]/@id"
+  - test:
+    - if: "*[1][.='ℂ']"
+      then: [t: "C"]      # phrase(the letter 'C' used to represent complex number)
+    - else_if: "*[1][.='ℕ']"
+      then: [t: "N"]      # phrase(the letter 'N' may represent natural numbers)
+    - else_if: "*[1][.='ℚ']"
+      then: [t: "Q"]      # phrase(the letter 'Q' may represent rational numbers)
+    - else_if: "*[1][.='ℝ']"
+      then: [t: "R"]      # phrase(the letter 'R' may represent real numbers)
+    - else_if: "*[1][.='ℤ']"
+      then: [t: "Z"]      # phrase(the letter 'Z' may represent integers)
+      else: [x: "*[1][text()]"] # shouldn't happen
+  - bookmark: "*[2]/@id"
+  - x: "*[2]"
+
+- name: simple-number-sets
+  tag: number-sets
+  match: "count(*)=0"
+  replace:
+  - bookmark: "@id"
+  - test:
+    - if: ".='ℂ'"
+      then: [t: "liczby zespolone"]      # phrase('the complex numbers' include 2 parts)
+    - else_if: ".='ℕ'"
+      then: [t: "liczby naturalne"]      # phrase('the natural numbers' begin at 1)
+    - else_if: ".='ℚ'"
+      then: [t: "liczby wymierne"]      # phrase('the rational numbers' are the fraction of 2 integers)
+    - else_if: ".='ℝ'"
+      then: [t: "liczby rzeczywiste"]      # phrase('the real numbers' can be both positive and negative)
+    - else_if: ".='ℤ'"
+      then: [t: "liczby całkowite"]      # phrase('the integers' are natural numbers above 0)
+      else: [x: "text()"] # shouldn't happen
+
+- name: word-degree-celsius-fahrenheit-unit
+  tag: mrow
+  match:
+  - "count(*)=3 and *[1][self::m:mn] and *[2][.='\u2062'] and "
+  - "*[3][self::m:mmultiscripts and *[1][self::m:mi and (.='C' or .='F')] and "
+  - "     m:mprescripts/following-sibling::*[2][.='°' or .='∘']]"
+  variables:
+  - Number: "number(*[1])"
+  - TakesPaucal: "$Number mod 10 >= 2 and $Number mod 10 <= 4 and not($Number mod 100 >= 12 and $Number mod 100 <= 14)"
+  replace:
+  - x: "*[1]"
+  - test:
+    - if: "*[3]/*[1][.='C']"
+      then:
+      - test:
+        - if: "$Number = 1"
+          then: [T: "stopień Celsjusza"]
+        - else_if: "$TakesPaucal"
+          then: [T: "stopnie Celsjusza"]
+          else: [T: "stopni Celsjusza"]
+      else:
+      - test:
+        - if: "$Number = 1"
+          then: [T: "stopień Fahrenheita"]
+        - else_if: "$TakesPaucal"
+          then: [T: "stopnie Fahrenheita"]
+          else: [T: "stopni Fahrenheita"]
+
+- name: real-part
+  tag: real-part
+  match: "."
+  replace:
+  - bookmark: "@id"
+  - t: "część rzeczywista"      # phrase('the real part' of a complex number does not include the imaginary part)
+
+- name: imaginary-part
+  tag: imaginary-part
+  match: "."
+  replace:
+  - bookmark: "@id"
+  - t: "część urojona"      # phrase('the imaginary part' is part of a complex number)
+
+# rules on scripted vertical bars ('evaluated at')
+- name: evaluated-at-2
+  tag: evaluate
+  match: "count(*)=2"
+  replace:
+  - x: "*[1]"
+  - pause: auto
+  - t: "obliczone w"      # phrase(results were 'evaluated at' a given point)
+  - pause: auto
+  - x: "*[2]"
+
+- name: evaluated-at-3
+  tag: evaluate
+  match: "count(*)=3"
+  replace:
+  - x: "*[1]"
+  - pause: auto
+  - t: "obliczone w"      # phrase(results were 'evaluated at' this point)
+  - pause: auto
+  - x: "*[3]"
+  - t: "minus to samo wyrażenie obliczone w"      # phrase(this result is 'minus the same expression evaluated at' an earlier point)
+  - x: "*[2]"
+
+- name: permutation
+  # Not a default because the order of the args is reversed
+  tag: pochhammer
+  match: "count(*)=2 and contains(@data-intent-property, ':infix:')"
+  replace:
+  - x: "*[2]"
+  - t: "permutacji z"      # phrase(the solution involves several 'permutations of' values)
+  - x: "*[1]"
+
+- name: intervals
+  tag: [open-interval, open-closed-interval, closed-interval, closed-open-interval]
+  match: "count(*)=2"
+  replace:
+  - test:
+      if: "$Verbosity!='Terse'"
+      then:
+      - T: ""      # phrase('the' square root of 25 equals 5)
+  - test:
+    - if: "name(.)='open-interval'"
+      then: [T: "przedział otwarty"]
+    - else_if: "name(.)='closed-interval'"
+      then: [T: "przedział domknięty"]
+    - else_if: "name(.)='open-closed-interval'"
+      then: [T: "przedział lewostronnie otwarty prawostronnie domknięty"]
+      else: [T: "przedział lewostronnie domknięty prawostronnie otwarty"]
+  - test:
+      if: "$Verbosity!='Terse'"
+      then:
+      - T: "od"      # phrase(subtracting 5 'from' 10 gives 5)
+      - x: "*[1]"
+      - T: "do"      # phrase(adding 6 'to' 6 equals  12)
+      - x: "*[2]"
+      else:
+      - x: "*[1]"
+      - T: "przecinek"      # phrase(use a 'comma' to divide large numbers or as a decimal point)
+      - x: "*[2]"
+
+- name: default-point
+  tag: point
+  match: "count(*)=2"
+  replace:
+  - test:
+      if: "$Verbosity!='Terse'"
+      then:
+      - T: ""      # phrase('the' square root of 25 equals 5)
+  - T: "przecinek"      # phrase(a decimal 'point' indicates the fraction component of a number)
+  - x: "*[1]"
+  - T: "przecinek"      # phrase(use a 'comma' to divide large numbers or as a decimal point)
+  - x: "*[2]"
+
+- name: bigop-both
+  tag: large-op
+  match: "count(*) = 3"
+  replace:
+  - x: "*[1]"
+  - T: "od"      # phrase(subtracting 5 'from' 10 gives 5)
+  - x: "*[2]"
+  - pause: short
+  - T: "do"      # phrase(adding 6 'to' 6 equals  12)
+  - x: "*[3]"
+  - test:
+      if: "following-sibling::*"
+      then: [pause: medium]
+
+- name: bigop-under
+  tag: large-op
+  match: "count(*)=2"
+  replace:
+  - x: "*[1]"
+  - T: "przez"      # phrase(2 'over' 3 equals two thirds)
+  - x: "*[2]"
+  - test:
+      if: "following-sibling::*"
+      then: [T: "z"]      # phrase(the square root 'of' 25 equals 5)
+
+- name: largeop
+  tag: mrow
+  match: "count(*)=2 and IsInDefinition(*[1], 'LargeOperators')"
+  replace:
+  - x: "*[1]"
+  - pause: short
+  - x: "*[2]"
+
+- name: repeating-decimal
+  tag: repeating-decimal
+  match: "."
+  replace:
+  - x: "*[1]"
+  - t: "z okresem"      # phrase('with repeating digits')
+  - spell: "*[2]"
+
+- name: msubsup-skip-super
+  # handles single, double, etc., prime
+  tag: [skip-super, say-super]
+  match: "count(*)=3"
+  replace:
+  - x: "*[1]"
+  - test:
+      if: "$Verbosity='Verbose'"
+      then: [T: "indeks dolny"]      # phrase(a 'subscript' may be used to indicate an index)
+      else: [T: "indeks dolny"]      # phrase(the result is 'sub' optimal)
+  - x: "*[2]"
+  - test:
+      if: "not(IsNode(*[2],'leaf') and $Impairment = 'Blindness')"
+      then:
+      - test:
+          if: "$Verbosity='Verbose'"
+          then: [T: "koniec indeksu dolnego"]      # phrase(this is the 'end subscript' position)
+          else: [T: "koniec indeksu dolnego"]      # phrase(this is the 'end sub' position)
+      - pause: short
+      else_test:
+          if: "*[2][self::m:mi]"   # need a pause in "x sub k prime" so the prime is not associated with the 'k'
+          then: [pause: short]
+  - test:
+      if: "name(.)='say-super'"
+      then_test:
+        if: "$Verbosity='Verbose'"
+        then: [T: "indeks górny"]      # phrase(a 'superscript' number indicates raised to a power)
+        else: [T: "indeks górny"]      # phrase(this is a 'super' set of numbers)
+  - x: "*[3]"
+  - pause: short
+
+# in terse mode, we just say "m" or "s", etc., not meters or seconds
+- name: unit-terse
+  tag: unit
+  match: "$Verbosity = 'Terse' and string-length(.)=1"
+  replace:
+  - bookmark: "@id"
+  - spell: "text()"
+
+# the order of matching is
+# 1. does it match the base of an SI unit
+# 2. does it match an English unit (if in an English language)
+# 3. does it match an SI prefix followed by an SI that accepts SI prefixes
+# Due to this order, some things like "ft" and "cd" mean "feet" vs "femto-tonnes" and "pints" vs "pico-tonnes"
+- name: unit
+  tag: unit
+  match: "."
+  variables:
+    # If the coefficient is singular, we don't add the plural ending. Finding the coefficient is tricky
+    # Normal case (A) "3m" (parents is mrow), but could also be (B) "3 m^2" (etc.) (parent is power/mrow)
+    # But it might be in a fraction as (C) "3 m/s" (parent is fraction/mrow) or (D) "3 m^2/s^2" (parent is power/fraction/mrow)
+    #   or even (E) {3 m^2}/s (parent is power/mrow)
+    # If in a fraction, only look in the numerator to find the coefficient
+    # Note: we have a special case for pseudo-scripts like "°" (degrees) which are not powers -- they are essentially "1^°"
+    # The following "IfThenElse" logic returns the mrow that potentially contains the coefficient, if it exists
+    # The tests are in the order A, B & E, C, D
+  - MRowForCoefficient: "IfThenElse(parent::m:mrow, parent::m:mrow,
+                         IfThenElse(parent::m:power, ancestor::*[2][self::m:mrow],
+                         IfThenElse(parent::m:fraction and not(preceding-sibling::*), ancestor::*[2][self::m:mrow],
+                         IfThenElse(parent::m:power[parent::m:fraction and not(preceding-sibling::*)], ancestor::*[3][self::m:mrow], false()) ) ) )"
+  - IsSingular: "(not($MRowForCoefficient) and parent::*[name(.)!='skip-super' or *[1][.=1]]) or
+                 ($MRowForCoefficient and $MRowForCoefficient[(count(*) = 3 and *[1][self::m:mn and .=1] and *[2]='\u2062')])"
+  - Prefix: "''"
+  - Word: "''"  
+  replace:
+  - bookmark: "@id"
+  - test:
+    # is the whole string match a SI Unit without a prefix?
+    - if: "DefinitionValue(., 'Speech', 'SIUnits') != ''"
+      then:
+      - set_variables: [Word: "DefinitionValue(., 'Speech', 'SIUnits')"]
+    - else_if: "DefinitionValue(., 'Speech', 'UnitsWithoutPrefixes') != ''"
+      then:
+      - set_variables: [Word: "DefinitionValue(., 'Speech', 'UnitsWithoutPrefixes')"]
+    - else_if: "DefinitionValue(., 'Speech', 'EnglishUnits') != ''"
+      then:
+      - set_variables: [Word: "DefinitionValue(., 'Speech', 'EnglishUnits')"]
+
+    # do the first two chars match "da" and the remainder match an SIUnit
+    - else_if: "string-length(.) >= 3 and 
+                substring(., 1, 2) = 'da' and
+                DefinitionValue(substring(., 3), 'Speech', 'SIUnits') != ''"
+      then:
+      - set_variables:
+        - Prefix: "DefinitionValue('da', 'Speech', 'SIPrefixes')"
+        - Word: "DefinitionValue(substring(., 3), 'Speech', 'SIUnits')"
+
+    # does the first char match a prefix and the remainder match an SIUnit
+    - else_if: "string-length(.) >= 2 and 
+                DefinitionValue(substring(., 1, 1), 'Speech', 'SIPrefixes') != ''  and
+                DefinitionValue(substring(., 2), 'Speech', 'SIUnits') != ''"
+      then:
+      - set_variables:
+        - Prefix: "DefinitionValue(substring(., 1, 1), 'Speech', 'SIPrefixes')"
+        - Word: "DefinitionValue(substring(., 2), 'Speech', 'SIUnits')"
+
+    # not a known unit -- just speak the text, possibly as a plural
+    - else:
+      - set_variables:
+        - Word: "text()"
+
+  # somewhat complicated logic to avoid spaces around "-" as in "centi-grams" vs "centi - grams" -- probably doesn't matter
+  - test:
+      if: "$Prefix = ''"
+      then:
+      - test:
+        - if: "$IsSingular"
+          # HACK: '\uF8FE' is used internally for the concatenation char by 'ct' -- this gets the prefix concatenated to the base
+          then: [x: "$Word"]
+        - else_if: "DefinitionValue($Word, 'Speech', 'PluralForms') != ''"
+          then: [x: "DefinitionValue($Word, 'Speech', 'PluralForms')"]
+          else: [x: "$Word", ct: "s"]
+      else:
+      - x: "$Prefix"
+      - ct: "-"
+      - test:
+        - if: "$IsSingular"
+          # HACK: '\uF8FE' is used internally for the concatenation char by 'ct' -- this gets the prefix concatenated to the base
+          then: [x: "concat('\uF8FE', $Word)"]
+        - else_if: "DefinitionValue($Word, 'Speech', 'PluralForms') != ''"
+          then: [x: "concat('\uF8FE', DefinitionValue($Word, 'Speech', 'PluralForms'))"]
+          else: [x: "concat('\uF8FE', $Word)", ct: "s"]
+
+# need to reverse the order of speech: $ 3 -> 3 dollars
+- name: currency
+  tag: mrow
+  match: "count(*)=3 and DefinitionValue(*[1], 'Speech', 'CurrencySymbols') != ''"
+  variables:
+    # If the amount is singular, we don't add the plural ending.
+  - IsSingular: "*[3][self::m:mn and .=1] and *[2]='\u2062'"
+  - CurrencyWord: "DefinitionValue(*[1], 'Speech', 'CurrencySymbols')"
+  replace:
+  - bookmark: "*[3]/@id"
+  - x: "*[3]"
+  - test:
+    - if: "$IsSingular"
+      then: [x: "$CurrencyWord"]
+    - else_if: "DefinitionValue($CurrencyWord, 'Speech', 'PluralForms') != ''"
+      then: [x: "DefinitionValue($CurrencyWord, 'Speech', 'PluralForms')"]
+      else: [x: "DefinitionValue(*[1], 'Speech', 'CurrencySymbols')", ct: "s"]
+
+- name: sin
+  tag: mi
+  match: ".='sin'"
+  replace:
+  - bookmark: "@id"
+  - T: "sinus"      # phrase(the 'sine' of the angle)
+- name: cos
+  tag: mi
+  match: ".='cos'"
+  replace:
+  - bookmark: "@id"
+  - test:
+      if: "$Verbosity='Terse'"
+      then: [t: "cosinus"]      # phrase('cos' is the abbreviation for cosine)
+      else: [T: "cosinus"]      # phrase(find the 'cosine' in a right-angle triangle)
+- name: tan
+  tag: mi
+  match: ".='tan' or .='tg'"
+  replace:
+  - bookmark: "@id"
+  - test:
+      if: "$Verbosity='Terse'"
+      then: [t: "tangens"]      # phrase(the 'tan' is the ratio of the opposite to the adjacent side of a right-angled triangle)
+      else: [T: "tangens"]      # phrase(a 'tangent' is a straight line that touches a curve)
+- name: sec
+  tag: mi
+  match: ".='sec'"
+  replace:
+  - bookmark: "@id"
+  - test:
+      if: "$Verbosity='Terse'"
+      then: [t: "sekans"]      # phrase(to 'seek' a solution)
+      else: [t: "sekans"]      # phrase(a 'secant' intersects a curve at two or more points)
+- name: csc
+  tag: mi
+  match: ".='csc'"
+  replace:
+  - bookmark: "@id"
+  - test:
+      if: "$Verbosity='Terse'"
+      then: [t: "kosekans"]      # phrase(we will 'cosecant' a solution)
+      else: [t: "kosekans"]      # phrase(the 'cosecant' is the reciprocal of the secant)
+- name: cot
+  tag: mi
+  match: ".='cot'"
+  replace:
+  - bookmark: "@id"
+  - test:
+      if: "$Verbosity='Terse'"
+      then: [t: "cotangens"]      # phrase(find the 'cotangent' in a right-angle triangle)
+      else: [t: "cotangens"]      # phrase(the 'cotangent' is the reciprocal of the tangent)
+
+- name: sinh
+  tag: mi
+  match: ".='sinh'"
+  replace:
+  - bookmark: "@id"
+  - test:
+      if: "$Verbosity='Terse'"
+      then: [t: "sinus hiperboliczny"]      # phrase(the word 'sinch' is an abbreviation for hyperbolic sine)
+      else: [t: "sinus hiperboliczny"]      # phrase(the 'hyperbolic sine' is used in mathematics)
+- name: cosh
+  tag: mi
+  match: ".='cosh'"
+  replace:
+  - bookmark: "@id"
+  - test:
+      if: "$Verbosity='Terse'"
+      then: [t: "cosinus hiperboliczny"]      # phrase('cosh' is an abbreviation of hyperbolic cosine)
+      else: [t: "cosinus hiperboliczny"]      # phrase(the 'hyperbolic cosine' is a mathematical function)
+- name: tanh
+  tag: mi
+  match: ".='tanh'"
+  replace:
+  - bookmark: "@id"
+  - test:
+      if: "$Verbosity='Terse'"
+      then: [t: "tangens hiperboliczny"]      # phrase('tanch' is shorthand for hyperbolic tangent)
+      else: [t: "tangens hiperboliczny"]      # phrase('hyperbolic tangent' is a mathematical function)
+- name: sech
+  tag: mi
+  match: ".='sech'"
+  replace:
+  - bookmark: "@id"
+  - test:
+      if: "$Verbosity='Terse'"
+      then: [t: "sekans hiperboliczny"]      # phrase('sheck' is shorthand for hyperbolic secant)
+      else: [t: "sekans hiperboliczny"]      # phrase('hyperbolic secant' is a mathematical function)
+- name: csch
+  tag: mi
+  match: ".='csch'"
+  replace:
+  - bookmark: "@id"
+  - test:
+      if: "$Verbosity='Terse'"
+      then: [t: "kosekans hiperboliczny"]      # phrase('cosheck' is shorthand for hyperbolic cosecant)
+      else: [t: "kosekans hiperboliczny"]      # phrase('hyperbolic cosecant' is a mathematical function)
+- name: coth
+  tag: mi
+  match: ".='coth'"
+  replace:
+  - bookmark: "@id"
+  - test:
+      if: "$Verbosity='Terse'"
+      then: [t: "cotangens hiperboliczny"]      # phrase('cotanch' is shorthand for hyperbolic cotangent)
+      else: [t: "cotangens hiperboliczny"]      # phrase(the 'hyperbolic cotangent' is a mathematical function)
+- name: exponential
+  tag: mi
+  match: ".='exp'"
+  replace:
+  - bookmark: "@id"
+  - test:
+      if: "$Verbosity='Terse'"
+      then: [t: "eksponenta"]      # phrase('exp' means exponential function)
+      else: [t: "funkcja wykładnicza"]      # phrase('exponential' function)
+- name: covariance
+  tag: mi
+  match: ".='Cov'"
+  replace:
+  - bookmark: "@id"
+  - test:
+      if: "$Verbosity='Terse'"
+      then: [t: "kowariancja"]      # phrase('Cov' is shorthand for the covariance function)
+      else: [t: "kowariancja"]      # phrase('covariance' function)
+
+- name: maximum
+  tag: mi
+  match: ".='max'"
+  replace:
+  - bookmark: "@id"
+  - T: "maksimum"
+
+- name: minimum
+  tag: mi
+  match: ".='min'"
+  replace:
+  - bookmark: "@id"
+  - T: "minimum"
+
+- name: supremum
+  tag: mi
+  match: ".='sup'"
+  replace:
+  - bookmark: "@id"
+  - T: "supremum"
+
+- name: infimum
+  tag: mi
+  match: ".='inf'"
+  replace:
+  - bookmark: "@id"
+  - T: "infimum"
+
+-
+  name: log    # handle both log and ln (if in an mrow, 'intents' are used)
+  tag: mi
+  match: ".='log' or .='ln'"
+  replace:
+  - bookmark: "@id"
+  - test:
+    - if: ".= 'log'"
+      then: [T: "logarytm"]      # phrase(the 'log' function is used in mathematics)
+    - else_if: "$Verbosity='Terse'"
+      then: [spell: "'ln'"]
+      else: [T: "logarytm naturalny"]      # phrase(the 'natural log' function is used in mathematics)
+
+
+- name: multi-line
+  #   that eliminates the need for the if: else_if: ...
+  # IDEA:  set a variable with the word to say for the row (e.g., RowLabel = Row/Case/Line/...)
+  tag: [piecewise, system-of-equations, lines]
+  match: "."
+  variables:
+    # Wikipedia has some tables where all the entire first column is empty (e.g., https://en.wikipedia.org/wiki/List_of_trigonometric_identities)
+  - LineCount: "count(*[not(contains(@data-intent-property, ':continued-row:'))])"
+  - NextLineIsContinuedRow: "false()"   # default value
+  - IsColumnSilent: true()
+  replace:
+  - x: "$LineCount"
+  - test:
+    - if: "self::m:piecewise"
+      then: [t: "przypadek"]      # phrase(this is the first 'case' of three cases)
+    - else_if: "self::m:system-of-equations"
+      then: [t: "równanie"]      # phrase(this is the first 'equation' of three equations)
+      else: [t: "linia"]      # phrase(this is the first 'line' of three lines)
+  - test:
+    - if: "$LineCount != 1"
+      then: [ct: "s"] # plural
+  - pause: short
+  - x: "*"
+  - pause: long
+
+
+- name: default-multiline
+  tag: [mtr, mlabeledtr]
+  match: "parent::m:piecewise or parent::m:system-of-equations or parent::m:lines"
+  variables: [NextLineIsContinuedRow: "following-sibling::*[1][contains(@data-intent-property, ':continued-row:')]"]
+  replace:
+  - test:
+      if: "not($LineCount=1 or contains(@data-intent-property, ':continued-row:'))"
+      then:
+      - pause: medium
+      - test:
+        - if: "parent::m:piecewise"
+          then: [t: "przypadek"]     # phrase('case' 1 of 10 cases)
+        - else_if: "parent::m:system-of-equations"
+          then: [t: "równanie"] # phrase('equation' 1 of 10 equations)
+          else: [t: "linia"]     # phrase('line 1 of 10 lines)
+      - x: "count(preceding-sibling::*[not(contains(@data-intent-property, ':continued-row:'))]) + 1"
+  - test:
+      if: "self::m:mlabeledtr"
+      then:
+      - T: "z etykietą"      # phrase(the diagram is complete 'with label')
+      - x: "*[1]/*"
+  - test:
+      if: "not(contains(@data-intent-property, ':continued-row:'))"
+      then: [pause: medium]
+  - test:
+      if: "self::m:mlabeledtr"
+      then: [x: "*[position()>1]"]
+      else: [x: "*"]
+
+- name: default-multiline
+  tag: mtd
+  match: "parent::*[parent::m:piecewise or parent::m:system-of-equations or parent::m:lines]"
+  variables: [LongPause: "$SpeechStyle = 'ClearSpeak' and $ClearSpeak_MultiLinePausesBetweenColumns = 'Long'"]
+  replace:
+  - test:
+      if: "IsInDefinition(*[1], 'ComparisonOperators')"
+      then: [pause: short]
+  - test:
+      if: "*[1][@data-added!='missing-content']"
+      then: [x: "*"]
+  - test:
+    # no pause after each element; medium pause if last element in a row; long pause for last element in matrix unless ClearSpeak override
+    - if: "count(following-sibling::*) = 0 and not($NextLineIsContinuedRow)"
+      then_test:
+          if: "count(../following-sibling::*) > 0"
+          then_test:
+              if: "$LongPause"
+              then: [pause: long]
+              else: [pause: medium]
+      else_test:
+          if: "IsInDefinition(*[1], 'ComparisonOperators')"
+          then: [pause: short]
+          else: [pause: auto]
+
+# Matrix/Determinant rules
+# matrix and determinant are the same other than "matrix"/"determinant" based on the bracketing chars
+# the pausing logic is pushed down to the <mtd>
+# the rules either speak the <mtr>s (to get "row n") or the <mtd>s. "column n" spoken if $IsColumnSilent is false
+- name: 1x1-matrix
+  tag: [matrix, determinant]
+  variables: [IsColumnSilent: true()]
+  match: "count(*)=1 and *[self::m:mtr][count(*) = 1]"
+  replace:
+  - t: "jeden na jeden"      # phrase(the '1 by 1' matrix)
+  - test:
+      if: "self::m:determinant" # just need to check the first bracket since we know it must be (, [, or |
+      then: [T: "wyznacznik"]      # phrase(the 2 by 2 'determinant'))
+      else: [T: "macierz"]      # phrase(the 2 by 2 'matrix')
+      
+  - t: "z elementem"      # phrase(the 2 by 2 matrix 'with entry' x)
+  - x: "*[1]/*"
+
+# simpler reading methods for special case matrices
+- name: zero-matrix
+  tag: matrix
+  # select all the non-zero entries -- if there are none of them, then it is a zero matrix
+  match: "not( */*/*[not(self::m:mn and .= 0)] )"
+  replace:
+  - T: ""      # phrase('the' 1 by 2 matrix M)
+  - x: count(*)
+  - T: "na"       # phrase(the 1 'by' 2 matrix)
+  - x: count(*[self::m:mtr][1]/*)
+  - t: "macierz zerowa"   # phrase(the 2 by 2 'zero matrix')
+  - pause: long
+
+- name: identity-matrix
+  tag: matrix
+  # every diagonal entry must be a literal 1, and every off-diagonal entry must be a literal 0
+  match:
+  - "count(*) = count(*[1]/*) and " # matrix is square
+  - "not( */*[count(preceding-sibling::*) = count(../preceding-sibling::*)]/*[not(self::m:mn and .= 1)] ) and " # on-diagonal
+  - "not( */*[count(preceding-sibling::*) != count(../preceding-sibling::*)]/*[not(self::m:mn and .= 0)] )" # off-diagonal
+  replace:
+  - T: ""      # phrase('the' 1 by 2 matrix M)
+  - x: count(*)
+  - T: "na"       # phrase(the 1 'by' 2 matrix)
+  - x: count(*[self::m:mtr][1]/*)
+  - t: "macierz jednostkowa"   # phrase(the 2 by 2 'identity matrix')
+  - pause: long
+
+- name: diagonal-matrix
+  tag: matrix
+  # select all the non-zero entries...if they are not on the diagonal
+  #   if there are any of them, then this isn't an identity matrix
+  match:
+  - "count(*) = count(*[1]/*) and "
+  - "not( */*/*[not(self::m:mn and .= 0)]"
+  - "          [count(../preceding-sibling::*)!=count(../../preceding-sibling::*)]"
+  - "    )"
+  replace:
+  - T: ""      # phrase('the' 1 by 2 matrix)
+  - x: count(*)
+  - T: "na"       # phrase(the 1 'by' 2 matrix)
+  - x: count(*[self::m:mtr][1]/*)
+  - t: "macierz diagonalna"   # phrase(the 2 by 2 'diagonal matrix')
+  - pause: long
+  - insert:
+      # this lists the diagonal 'mtd's to be read, and they say "column nnn" before reading the contents
+      # there seems to be an xpath bug -- without the parens, the match fails for the
+      #   test Languages::en::mtable::diagonal_matrix due to match failure (the third matching element seems to be missing)
+      nodes: "(*/*/*[not(self::m:mn and .= 0)]/..)"
+      replace: [pause: auto]
+  - pause: long
+
+# simpler reading methods for smaller matrices if the entries are simple
+- name: 2-or-3x1-matrix
+  tag: matrix
+  variables: [IsColumnSilent: true()]
+  match:
+  - "$ClearSpeak_Matrix != 'SpeakColNum' and " # "simple" isn't used for this preference
+  - "*[self::m:mtr][count(*) = 1] and " # one column
+  - count(*)<=3 and # at least two rows
+  - IsNode(*/*/*,'simple') # IsNode() returns true if all the nodes are simple
+  replace:
+  - T: ""      # phrase('the' 2 by 2 matrix M)
+  - x: count(*)
+  - t: "na jedną kolumnę"      # phrase(the 2 'by 1 column' matrix)
+  - test:
+      if: "$ClearSpeak_Matrix = 'Vector' or $ClearSpeak_Matrix = 'EndVector'"
+      then: [T: "wektor"]      # phrase(the 2 by 2 'vector')
+      else: [T: "macierz"]      # phrase(the 2 by 2 'matrix')
+  - pause: long
+  - x: "*/*"
+  - test:
+      if: "$ClearSpeak_Matrix = 'EndMatrix' or $ClearSpeak_Matrix = 'EndVector'"
+      then:
+      - test:
+          if: $ClearSpeak_Matrix = 'EndVector'
+          then: [T: "koniec wektora"]      # phrase(the 2 column 'vector')
+          else: [T: "koniec macierzy"]      # phrase(the 2 by 2 'matrix')
+
+- name: default-column-matrix
+  tag: matrix
+  variables: [IsColumnSilent: true()]
+  match: "*[self::m:mtr][count(*) = 1]"
+  replace:
+  - T: ""      # phrase('the' 2 by 2 matrix M)
+  - x: "count(*)"
+  - t: "na jedną kolumnę"      # phrase(the 2 'by 1 column' matrix)
+  - test:
+      if: "$ClearSpeak_Matrix = 'Vector' or $ClearSpeak_Matrix = 'EndVector'"
+      then: [T: "wektor"]      # phrase(the 2 column 'vector')
+      else: [T: "macierz"]      # phrase(the 2 by 2 'matrix')
+  - pause: long
+  - x: "*" # select the rows (mtr)
+  - test:
+      if: "$ClearSpeak_Matrix = 'EndMatrix' or $ClearSpeak_Matrix = 'EndVector'"
+      then: [t: "koniec macierzy"]      # phrase(the 'end of matrix' has been reached)
+
+- name: 1x2-or-3-matrix
+  tag: matrix
+  variables: [IsColumnSilent: "$SpeechStyle = 'SimpleSpeak' or ($SpeechStyle = 'ClearSpeak' and $ClearSpeak_Matrix != 'SpeakColNum')"]
+  match:
+  - "$ClearSpeak_Matrix != 'SpeakColNum' and " # "simple" isn't used for this preference
+  - count(*)=1  and # one row
+  - count(*[1]/*)<=3 and # at least two cols
+  - IsNode(*/*/*,'simple') # IsNode() returns true if all the nodes are simple
+  replace:
+  - t: "jeden na"      # phrase('the 1 by' 2 matrix)
+  - x: count(*/*)
+  - T: "wiersz"      # phrase(the 1 by 4 'row' matrix)
+  - test:
+      if: "$ClearSpeak_Matrix = 'Vector' or $ClearSpeak_Matrix = 'EndVector'"
+      then: [T: "wektor"]      # phrase('the 1 by' 2 row 'vector')
+      else: [T: "macierz"]      # phrase('the 1 by' 2 'matrix')
+  - pause: long
+  - x: "*/*"
+  - test:
+      if: "$ClearSpeak_Matrix = 'EndMatrix' or $ClearSpeak_Matrix = 'EndVector'"
+      then:
+      - test:
+          if: $ClearSpeak_Matrix = 'EndMatrix'
+          then: [T: "koniec macierzy"]      # phrase(the 2 by 2 'matrix')
+          else: [T: "koniec wektora"]      # phrase(the 2 by 1 'vector')
+
+- name: default-row-matrix
+  tag: matrix
+  variables: [IsColumnSilent: "$SpeechStyle = 'ClearSpeak' and $ClearSpeak_Matrix = 'SilentColNum'"]
+  match: "count(*)=1" # one row
+  replace:
+  - t: "jeden na"      # phrase('the 1 by' 2 matrix)
+  - x: "count(*/*)"
+  - T: "wiersz"      # phrase(the 1 by 2 'row' matrix)
+  - test:
+      if: "$ClearSpeak_Matrix = 'Vector' or $ClearSpeak_Matrix = 'EndVector'"
+      then: [T: "wektor"]      # phrase(the 2 by 1 'vector')
+      else: [T: "macierz"]      # phrase(the 2 by 2 'matrix')
+  - pause: long
+  - pause: medium
+  - x: "*/*" # select the cols (mtd)
+  - test:
+      if: "$ClearSpeak_Matrix = 'EndMatrix' or $ClearSpeak_Matrix = 'EndVector'"
+      then:
+      - test:
+          if: $ClearSpeak_Matrix = 'EndMatrix'
+          then: [T: "koniec macierzy"]      # phrase(the 2 by 2 'matrix')
+          else: [T: "koniec wektora"]      # phrase(the 2 by 1 'vector')
+
+- name: simple-small-matrix
+  tag: [matrix, determinant]
+  match:
+  - "$ClearSpeak_Matrix != 'SpeakColNum' and " # "simple" isn't used for this preference
+  - (count(*)<=3 and count(*[1]/*)<=3) and # no bigger than a 3x3 matrix
+  - IsNode(*/*/*,'simple') # IsNode() returns true if all the nodes are simple
+  variables: [IsColumnSilent: "$SpeechStyle = 'SimpleSpeak' or ($SpeechStyle = 'ClearSpeak' and $ClearSpeak_Matrix != 'SpeakColNum')"]
+  replace:
+  - T: ""      # phrase('the' 1 by 2 matrix M)
+  - x: count(*)
+  - T: "na"      # phrase(the 1 'by' 2 matrix)
+  - x: count(*[self::m:mtr][1]/*)
+  - test:
+      if: "self::m:determinant"
+      then: [T: "wyznacznik"]      # phrase(the 2 by 2 'determinant')
+      else:
+      - test:
+          if: "@columnlines and (contains(normalize-space(@columnlines), 'solid') or contains(normalize-space(@columnlines), 'dashed'))"
+          then: [t: "macierz rozszerzona"]      # phrase(the 2 by 2 'augmented matrix')
+          else: [T: "macierz"]      # phrase(the 2 by 2 'matrix')
+  - pause: long
+  - x: "*"
+  - test:
+      if: "$ClearSpeak_Matrix = 'EndMatrix' or $ClearSpeak_Matrix = 'EndVector'"
+      then:
+      - test:
+          if: "self::m:determinant"
+          then: [T: "koniec wyznacznika"]      # phrase(the 2 by 2 'determinant')
+          else: [T: "koniec macierzy"]      # phrase(the 2 by 2 'matrix')
+
+- name: default-matrix
+  tag: [matrix, determinant]
+  variables: [IsColumnSilent: "$SpeechStyle = 'ClearSpeak' and $ClearSpeak_Matrix = 'SilentColNum'"]
+  match: "."
+  replace:
+  - T: ""      # phrase('the' 1 by 2 matrix M)
+  - x: "count(*)"
+  - T: "na"      # phrase(the 1 'by' 2 matrix)
+  - x: "count(*[self::m:mtr][1]/*)"
+  - test:
+      if: "self::m:determinant"
+      then: [T: "wyznacznik"]      # phrase(the 2 by 2 'determinant')
+      else:
+      - test:
+          if: "@columnlines and (contains(normalize-space(@columnlines), 'solid') or contains(normalize-space(@columnlines), 'dashed'))"
+          then: [t: "macierz rozszerzona"]      # phrase(the 2 by 2 'augmented matrix')
+          else: [T: "macierz"]      # phrase(the 2 by 2 'matrix')
+  - pause: long
+  - x: "*"
+  - test:
+      if: "$ClearSpeak_Matrix = 'EndMatrix' or $ClearSpeak_Matrix = 'EndVector'"
+      then:
+      - test:
+          if: "self::m:determinant"
+          then: [T: "koniec wyznacznika"]      # phrase(the 2 by 2 'determinant')
+          else: [T: "koniec macierzy"]      # phrase(the 2 by 2 'matrix's)
+
+- name: chemistry-msub
+  tag: [chemical-formula]
+  match: "*[1][.='msub']"
+  replace:
+  - x: "*[2]"
+  - test:
+      if: "$Verbosity='Verbose'"
+      then: [T: "indeks dolny"]      # phrase(H 'subscript' 2)
+      else_test:
+        if: "$Verbosity='Medium'"
+        then: [T: "indeks dolny"]      # phrase(H 'sub' 2)
+  - x: "*[3]"
+
+- name: dimension-by
+  tag: mrow
+  match: dimension-product
+  replace:
+  - insert:
+      nodes: "*"
+      replace: [T: "na", pause: auto]      # phrase(3 'by' 5 matrix)
+
+- name: chemistry-msup
+  tag: [chemical-formula]
+  match: "count(*)=3 and *[1][.='msup']"
+  replace:
+  - x: "*[2]"
+  - test:
+      if: "$Verbosity='Verbose'"
+      then: [T: "indeks górny"]      # phrase(H 'superscript' 2)
+      else_test:
+        if: "$Verbosity='Medium'"
+        then: [T: "indeks górny"]      # phrase(H 'super' 2)
+  - x: "*[3]"
+  - test:
+      if: "following-sibling::*[1][.='+' or .='-']" # a little lazy -- assumes chemistry superscripts end with + or -
+      then: [pause: medium]
+
+-
+  # There currently is no way to do sub/super for n-ary number of args
+  # Instead, we just deal with up to two prescripts and up to four postscripts (repeating blocks of similar code [UGLY!])
+  # This hopefully covers all reasonable cases...
+  name: chemistry-scripts
+  tag: [chemical-formula, chemical-nuclide]
+  variables:
+  # computing the number of postscripts is messy because of <mprescripts> being optionally present -- we use "mod" to get the count right
+  - Prescripts: "m:mprescripts/following-sibling::*"
+  - NumChildren: "count(*)" # need to stash this since the count is wrong inside '*[...]' below
+  - Postscripts: "*[position()>1 and position() < (last() + ($NumChildren mod 2) -count($Prescripts))]"
+  match: . # should only be msubsup or mmultiscripts at this point
+  replace:
+  - test:
+      if: "$Prescripts" # we have at least one pre sub/super 
+      then:
+      # nuclide: speak the superscript first
+      - test:
+          if: "not($Prescripts[2][self::m:none])"
+          then:
+          - test:
+              if: "$Verbosity='Verbose'"
+              then: [T: "indeks górny"]      # phrase(H 'superscript' 2)
+              else_test:
+                if: "$Verbosity='Medium'"
+                then: [T: "indeks górny"]      # phrase(H 'super' 2)
+          - x: "$Prescripts[2]"
+          - pause: "short"
+      - test:
+          if: "not($Prescripts[1][self::m:none])"
+          then:
+          - test:
+              if: "$Verbosity='Verbose'"
+              then: [T: "indeks dolny"]      # phrase(a 'subscript' may be used to indicate an index)
+              else_test:
+                if: "$Verbosity='Medium'"
+                then: [T: "indeks dolny"]      # phrase(here is a 'sub' total)
+          - x: "$Prescripts[1]"
+          - pause: "short"
+      - test:
+          if: "count($Prescripts) > 2" # can this happen for chemistry??? we allow for one *extra* pre sub/super pair
+          then:
+          - test:
+              if: "not($Prescripts[4][self::m:none])"
+              then:
+              - test:
+                  if: "$Verbosity='Verbose'"
+                  then: [T: "indeks górny"]      # phrase(H 'superscript' 2)
+                  else_test:
+                    if: "$Verbosity='Medium'"
+                    then: [T: "indeks górny"]      # phrase(H 'super' 2)
+              - x: "$Prescripts[4]"
+              - pause: "short"
+          - test:
+              if: "not($Prescripts[3][self::m:none])"
+              then:
+              - test:
+                  if: "$Verbosity='Verbose'"
+                  then: [T: "indeks dolny"]      # phrase(H 'subscript' 2)
+                  else_test:
+                    if: "$Verbosity='Medium'"
+                    then: [T: "indeks dolny"]      # phrase(H 'sub' 2)
+              - x: "$Prescripts[3]"
+              - pause: "short"
+  - x: "*[1]" # base
+  - test:
+      if: "$Postscripts"
+      then:
+      - test:
+          if: "not($Postscripts[1][self::m:none])"
+          then:
+          - test:
+              if: "$Verbosity='Verbose'"
+              then: [T: "indeks dolny"]      # phrase(phrase(H 'subscript' 2)
+              else_test:
+                if: "$Verbosity='Medium'"
+                then: [T: "indeks dolny"]      # phrase(phrase(H 'sub' 2)
+          - x: "$Postscripts[1]"
+          - pause: "short"
+      - test:
+          if: "not($Postscripts[2][self::m:none])"
+          then:
+          - test:
+              if: "$Verbosity='Verbose'"
+              then: [T: "indeks górny"]      # phrase(H 'superscript' 2)
+              else_test:
+                if: "$Verbosity='Medium'"
+                then: [T: "indeks górny"]          # phrase(H 'super' 2)
+          - x: "$Postscripts[2]"
+          - pause: "short"
+      - test:
+          if: "count($Postscripts) > 2"
+          then:
+          - test:
+              if: "not($Postscripts[3][self::m:none])"
+              then:
+              - test:
+                  if: "$Verbosity='Verbose'"
+                  then: [T: "indeks dolny"]      # phrase(H 'subscript' 2)
+                  else_test:
+                    if: "$Verbosity='Medium'"
+                    then: [T: "indeks dolny"]          # phrase(H 'sub' 2)
+              - x: "$Postscripts[3]"
+              - pause: "short"
+          - test:
+              if: "not($Postscripts[4][self::m:none])"
+              then:
+              - test:
+                  if: "$Verbosity='Verbose'"
+                  then: [T: "indeks górny"]      # phrase(H 'superscript' 2)
+                  else_test:
+                    if: "$Verbosity='Medium'"
+                    then: [T: "indeks górny"]          # phrase(H 'super' 2)
+              - x: "$Postscripts[4]"
+              - pause: "short"
+          - test:
+              if: "count($Postscripts) > 4"
+              then:
+              - test:
+                  if: "not($Postscripts[5][self::m:none])"
+                  then:
+                  - test:
+                      if: "$Verbosity='Verbose'"
+                      then: [T: "indeks dolny"]    # phrase(H 'subscript' 2)
+                      else_test:
+                        if: "$Verbosity='Medium'"
+                        then: [T: "indeks dolny"]        # phrase(H 'sub' 2)
+                  - x: "$Postscripts[5]"
+                  - pause: "short"
+              - test:
+                  if: "not($Postscripts[6][self::m:none])"
+                  then:
+                  - test:
+                      if: "$Verbosity='Verbose'"
+                      then: [T: "indeks górny"]  # phrase(H 'superscript' 2)
+                      else_test:
+                        if: "$Verbosity='Medium'"
+                        then: [T: "indeks górny"]      # phrase(H 'super' 2)
+                  - x: "$Postscripts[6]"
+                  - pause: "short"
+              - test:
+                  if: "count($Postscripts) > 6"
+                  then:
+                  - test:
+                      if: "not($Postscripts[7][self::m:none])"
+                      then:
+                      - test:
+                          if: "$Verbosity='Verbose'"
+                          then: [T: "indeks dolny"]      # phrase(H 'subscript' 2)
+                          else_test:
+                            if: "$Verbosity='Medium'"
+                            then: [T: "indeks dolny"]      # phrase(H 'sub' 2)
+                      - x: "$Postscripts[7]"
+                      - pause: "short"
+                  - test:
+                      if: "not($Postscripts[8][self::m:none])"
+                      then:
+                      - test:
+                          if: "$Verbosity='Verbose'"
+                          then: [T: "indeks górny"]      # phrase(H 'superscript' 2)
+                          else_test:
+                            if: "$Verbosity='Medium'"
+                            then: [T: "indeks górny"]      # phrase(H 'super' 2)
+                      - x: "$Postscripts[8]"
+                      - pause: "short"
+      - test:
+          if: "$Postscripts[last()][not(self::m:none)] and following-sibling::*[1][.='+' or .='-']"
+          then: [pause: medium]
+
+- name: chemistry
+  tag: chemical-equation
+  match: "."
+  replace:
+  - x: "*"
+
+- name: chemical-element
+  tag: chemical-element
+  match: "."
+  replace:
+  - bookmark: "@id"
+  - spell: text()
+  - pause: short
+
+- name: chemical-state
+  tag: chemical-state
+  match: "count(*)=1"
+  replace:
+  - bookmark: "*[1]/@id"
+  - test:
+    - if: ".='s'"
+      then: [t: "ciało stałe"]      # phrase(Boron is a 'solid' in its natural state)
+    - else_if: ".='l'"
+      then: [t: "ciecz"]      # phrase(water is a 'liquid')
+    - else_if: ".='g'"
+      then: [t: "gaz"]      # phrase(hydrogen is a 'gas' )
+      else: [t: "wodny"]      # phrase(an 'aqueous' solution is contained in water)
+  - pause: short
+
+- name: chemical-formula-operator-bond
+  tag: chemical-formula-operator
+  match: "@data-chemical-bond"
+  replace:
+  # FIX: this might be better/more efficient if in unicode.yaml
+  - bookmark: "@id"
+  - test:
+    - if: ".='-' or .=':'"
+      then: [t: "wiązanie pojedyncze"]      # phrase(a 'single bond' is formed when two atoms share one pair of electrons)
+    - else_if: ".='=' or .='∷'"
+      then: [t: "wiązanie podwójne"]      # phrase(a 'double bond' may occur when two atoms share two pairs of electrons)
+    - else_if: ".='≡'"
+      then: [t: "wiązanie potrójne"]      # phrase(a 'triple bond' occurs when two atoms share three pairs of electrons)
+    - else_if: ".='≣'"
+      then: [t: "wiązanie poczwórne"]      # phrase(a 'quadruple bond' occurs when two atoms share four pairs of electrons)
+      else: [x: "text()"]
+
+- name: chemical-formula-operator
+  tag: chemical-formula-operator
+  match: "."
+  replace:
+    x: "text()"
+
+- name: chemical-arrow-operator
+  tag: chemical-arrow-operator
+  match: "."
+  replace:
+  # FIX: this might be better/more efficient if in unicode.yaml
+  - bookmark: "@id"
+  - test:
+    - if: ".='→' or .='⟶'"
+      then_test:
+        if: "$Verbosity='Terse'"
+        then: [t: "tworzy"]      # phrase(hydrogen and oxygen 'forms' water )
+        else: [t: "reaguje tworząc"]      # phrase(hydrogen and oxygen 'reacts to form' water)
+    - else_if: ".='⇌' or .='🣑'" # U+01F8D1
+      then: [t: "jest w równowadze z"]      # phrase(a reactant 'is in equilibrium with' a product)
+    - else_if: ".='🣓'" # U+1F8D3
+      then: [t: "jest w równowadze przesuniętej w lewo z"]      # phrase(the reactant 'is in equilibrium biased to the left with' the product)
+    - else_if: ".='🣒'" # U+1F8D2
+      then: [t: "jest w równowadze przesuniętej w prawo z"]      # phrase(the reactant 'is in equilibrium biased to the right with' the product)
+      else: [x: "*"]
+
+- name: chemical-equation-operator
+  tag: chemical-equation-operator
+  match: "."
+  replace:
+  - bookmark: "@id"
+  - x: "text()"
+
+- name: none
+  tag: none
+  match: "../../*[self::m:chemical-formula or self::m:chemical-nuclide]"
+  replace:
+  - t: "" # don't say anything
+
+- name: ignore-intent-wrapper
+  tag: intent-wrapper
+  match: "."
+  replace:
+  - x: "*"

--- a/Rules/Languages/pl/SharedRules/geometry.yaml
+++ b/Rules/Languages/pl/SharedRules/geometry.yaml
@@ -1,0 +1,73 @@
+---
+
+- name: line-segment
+  tag: line-segment
+  match: "count(*)=2"
+  replace:
+  - test:
+      if: "$Verbosity='Verbose'"
+      then:
+      - t: "odcinek od"      # phrase('the line segment from' A to B)
+      - x: "*[1]"
+      - T: "do"                         # phrase(the line segment from A 'to' B)
+      - x: "*[2]"
+      else:
+      - t: "odcinek"               # phrase(the 'line segment' A  B)
+      - x: "*[1]"
+      - x: "*[2]"
+
+- name: geometry-ray
+  tag: ray
+  match: "count(*)=2"
+  replace:
+  - test:
+      if: "$Verbosity='Verbose'"
+      then:
+      - t: "półprosta od"             # phrase('the ray from' A to B)
+      - x: "*[1]"
+      - T: "do"                       # phrase(the ray from A 'to' B)
+      - x: "*[2]"
+      else:
+      - t: "półprosta"                      # phrase(the 'ray'A  B)
+      - x: "*[1]"
+      - x: "*[2]"
+
+- name: geometry-arc
+  tag: arc
+  match: "count(*)=2"
+  replace:
+  - T: "łuk"                        # phrase(the 'arc' A B C)
+  - x: "*[1]"
+  - x: "*[2]"
+
+- name: measure-of-angle
+  tag: measure-of-angle
+  match: "count(*)=3"
+  replace:
+  - test:
+      if: "$Verbosity='Verbose'"
+      then:
+      - t: "miara kąta"      # phrase('the measure of the angle' ABC)
+      else:
+      - t: "miara kąta"      # phrase('measure of angle' ABC)
+  - x: "*[1]"
+  - x: "*[2]"
+  - x: "*[3]"
+
+
+- name: coordinate
+  tag: coordinate
+  match: "."
+  replace:
+  - T: "przecinek"      # phrase(the 'point' at 1, 2)
+  - test:
+      if: "$Verbosity='Verbose'"
+      then: [t: "w"]      # phrase('the' point at 1, 2)
+  - pause: short
+  - insert:
+      nodes: "*"
+      replace: [T: "przecinek", pause: auto]      # phrase(f of x 'comma' y)
+  - pause: short
+  - test:
+      if: "($SpeechStyle='ClearSpeak' and $Verbosity='Verbose') or not(IsNode(*[last()],'leaf'))"
+      then: [t: "punkt końcowy"]      # phrase(start point, 'end point')

--- a/Rules/Languages/pl/SharedRules/linear-algebra.yaml
+++ b/Rules/Languages/pl/SharedRules/linear-algebra.yaml
@@ -1,0 +1,321 @@
+---
+
+# Indeks normy operatorowej ‖·‖_{p→q}: mrow[p, →, q] jako dziecko subscripted-norm.
+# Emitowany przez x: w regule subscripted-norm (nawigowalny); tu nadajemy mowe "od p do q"
+# (→ czyta sie "do" dzieki regule unicode w kontekscie subscripted-norm).
+- name: norm-operator-index
+  tag: mrow
+  match: "parent::*[self::m:subscripted-norm] and *[2][self::m:mo and .='→']"
+  replace:
+  - T: "od"
+  - x: "*[1]"
+  - x: "*[2]"      # → -> "do"
+  - x: "*[3]"
+
+# Litera F jako indeks normy Frobeniusa: emitowana przez x: (nawigowalna),
+# a tutaj nadajemy jej wlasciwa wymowe "Frobeniusa" zamiast "wielka f".
+- name: norm-index-frobenius
+  tag: mi
+  match: ".='F' and parent::*[self::m:subscripted-norm]"
+  replace:
+  - T: "Frobeniusa"      # phrase(the 'Frobenius' norm)
+
+- name: scalar-determinant
+  tag: determinant
+  match: "count(*)=1 and not(*[1][self::m:mtr])"
+  replace:
+  - test:
+      if: "$Verbosity='Verbose'"
+      then:
+      - T: ""      # phrase('the' square root of 25 equals 5)
+  - T: "wyznacznik"      # phrase(the 'determinant' of a matrix)
+  - test:
+      if: "$Verbosity!='Terse'"
+      then:
+      - T: "z"      # phrase(systems 'of' linear equations)
+  - x: "*[1]"
+  - test:
+      if: "not(IsNode(*[1], 'simple')) and $Impairment = 'Blindness'"
+      then: [t: "koniec wyznacznika"]      # phrase('end determinant' of a matrix)
+
+
+- name: subscripted-norm
+  tag: subscripted-norm
+  match: "count(*)=2"
+  replace:
+  - test:
+      if: "$Verbosity='Verbose'"
+      then:
+      - T: ""      # phrase('the' square root of 25 equals 5)
+  - test:
+      if: "*[2][.='∞']"
+      then:
+      - T: "norma"
+      - x: "*[2]"      # ∞ -> "nieskończoność"; emisja czyni indeks nawigowalnym (marker [[...]])
+      - test:
+          if: "$Verbosity!='Terse'"
+          then:
+          - T: "z"      # phrase(systems 'of' linear equations)
+      - x: "*[1]"
+      else:
+      - test:
+          if: "*[2][self::m:mrow and *[2][self::m:mo and .='→']]"
+          then:
+          - T: "norma"
+          - x: "*[2]"      # caly mrow indeksu p→q emitowany (nawigowalny); mowa "od p do q" nizej
+          else:
+          - test:
+            - if: "*[2][.='F']"
+              then:
+              - T: "norma"
+              - x: "*[2]"      # F -> "Frobeniusa" (regula mi kontekstowa); emisja = nawigowalny
+            - else_if: "*[2][.='*' or .='∗']"
+              then:
+              - T: "norma"
+              - x: "*[2]"      # * -> "gwiazdkowa" (regula mo kontekstowa); emisja = nawigowalny
+            - else:
+              - T: "norma"      # phrase(the 'norm' can be a measure of distance)
+              - x: "*[2]"
+      - test:
+          if: "$Verbosity!='Terse'"
+          then:
+          - T: "z"      # phrase(systems 'of' linear equations)
+      - x: "*[1]"
+
+- name: word-open-subscripted-norm
+  tag: mo
+  match: ".='∥' and following-sibling::*[self::m:mo[.='∥'] or ((self::m:indexed-by or self::m:msub or self::m:msubsup) and *[1][self::m:mo and .='∥']) or ((self::m:power or self::m:msup) and *[1][(self::m:indexed-by or self::m:msub or self::m:msubsup) and *[1][self::m:mo and .='∥']])][1][not(self::m:mo)]"
+  variables:
+  - ClosingNorm: "following-sibling::*[self::m:mo[.='∥'] or ((self::m:indexed-by or self::m:msub or self::m:msubsup) and *[1][self::m:mo and .='∥']) or ((self::m:power or self::m:msup) and *[1][(self::m:indexed-by or self::m:msub or self::m:msubsup) and *[1][self::m:mo and .='∥']])][1]"
+  replace:
+  - test:
+      if: "$Verbosity='Verbose'"
+      then:
+      - T: ""      # phrase('the' norm can be a measure of distance)
+  - test:
+      if: "($ClosingNorm[self::m:power or self::m:msup] and $ClosingNorm/*[1]/*[2][.='∞']) or (not($ClosingNorm[self::m:power or self::m:msup]) and $ClosingNorm/*[2][.='∞'])"
+      then:
+      - T: "norma nieskończoności"      # phrase(the infinity norm can be a measure of distance)
+      - test:
+          if: "$Verbosity!='Terse'"
+          then:
+          - T: "z"      # phrase(the norm 'of' x)
+      else:
+      - test:
+          if: "$ClosingNorm[self::m:power or self::m:msup] and $ClosingNorm/*[1]/*[2][self::m:mrow and *[2][self::m:mo and .='→']]"
+          then:
+          - T: "norma od"
+          - x: "$ClosingNorm/*[1]/*[2]/*[1]"
+          - T: "do"
+          - test:
+              if: "$ClosingNorm/*[1]/*[2]/*[3][.='∞']"
+              then:
+              - T: "nieskończoności"
+              else:
+              - x: "$ClosingNorm/*[1]/*[2]/*[3]"
+          else:
+          - test:
+              if: "not($ClosingNorm[self::m:power or self::m:msup]) and $ClosingNorm/*[2][self::m:mrow and *[2][self::m:mo and .='→']]"
+              then:
+              - T: "norma od"
+              - x: "$ClosingNorm/*[2]/*[1]"
+              - T: "do"
+              - test:
+                  if: "$ClosingNorm/*[2]/*[3][.='∞']"
+                  then:
+                  - T: "nieskończoności"
+                  else:
+                  - x: "$ClosingNorm/*[2]/*[3]"
+              else:
+              - test:
+                  if: "$ClosingNorm[self::m:power or self::m:msup]"
+                  then:
+                  - test:
+                    - if: "$ClosingNorm/*[1]/*[2][.='F']"
+                      then:
+                      - T: "norma Frobeniusa"
+                    - else_if: "$ClosingNorm/*[1]/*[2][.='*' or .='∗']"
+                      then:
+                      - T: "norma gwiazdkowa"
+                    - else:
+                      - T: "norma"      # phrase(the 'norm' can be a measure of distance)
+                      - x: "$ClosingNorm/*[1]/*[2]"
+                  else:
+                  - test:
+                    - if: "$ClosingNorm/*[2][.='F']"
+                      then:
+                      - T: "norma Frobeniusa"
+                    - else_if: "$ClosingNorm/*[2][.='*' or .='∗']"
+                      then:
+                      - T: "norma gwiazdkowa"
+                    - else:
+                      - T: "norma"      # phrase(the 'norm' can be a measure of distance)
+                      - x: "$ClosingNorm/*[2]"
+      - test:
+          if: "$Verbosity!='Terse'"
+          then:
+          - T: "z"      # phrase(the norm 'of' x)
+
+- name: word-close-subscripted-powered-norm
+  tag: [power, msubsup, msup]
+  match: "(self::m:msubsup[*[1][self::m:mo and .='∥']] or (self::m:power | self::m:msup)[*[1][(self::m:indexed-by or self::m:msub or self::m:msubsup) and *[1][self::m:mo and .='∥']]]) and preceding-sibling::*[self::m:mo and .='∥']"
+  replace:
+  - test:
+      if: "self::m:msubsup"
+      then:
+      - test:
+        - if: "*[3][self::m:mn][.='2']"
+          then: [T: "do kwadratu"]      # phrase(x 'squared' equals 49)
+        - else_if: "*[3][self::m:mn][.='3']"
+          then: [T: "do sześcianu"]      # phrase(x 'cubed' equals 125)
+        - else:
+          - T: "do potęgi"      # phrase(x raised 'to the power' 4)
+          - x: "*[3]"
+      else:
+      - test:
+        - if: "*[2][self::m:mn][.='2']"
+          then: [T: "do kwadratu"]      # phrase(x 'squared' equals 49)
+        - else_if: "*[2][self::m:mn][.='3']"
+          then: [T: "do sześcianu"]      # phrase(x 'cubed' equals 125)
+        - else:
+          - T: "do potęgi"      # phrase(x raised 'to the power' 4)
+          - x: "*[2]"
+
+- name: word-close-subscripted-norm
+  tag: [indexed-by, msub]
+  match: "*[1][self::m:mo and .='∥'] and preceding-sibling::*[self::m:mo and .='∥']"
+  replace:
+  - T: ""
+
+- name: word-open-norm
+  tag: mo
+  match: ".='∥' and following-sibling::*[self::m:mo and .='∥']"
+  replace:
+  - test:
+      if: "$Verbosity='Verbose'"
+      then:
+      - T: ""      # phrase('the' norm can be a measure of distance)
+  - T: "norma"      # phrase(the 'norm' can be a measure of distance)
+  - test:
+      if: "$Verbosity!='Terse'"
+      then:
+      - T: "z"      # phrase(the norm 'of' x)
+
+- name: word-close-norm
+  tag: mo
+  match: ".='∥' and preceding-sibling::*[self::m:mo and .='∥']"
+  replace:
+  - T: ""
+
+- name: word-leading-subscripted-norm
+  tag: mrow
+  match: "count(*)>3 and *[1][self::m:mo and .='∥'] and *[position()>2][(self::m:indexed-by or self::m:msub) and *[1][self::m:mo and .='∥']]"
+  variables:
+  - ClosingNorm: "*[(self::m:indexed-by or self::m:msub) and *[1][self::m:mo and .='∥']][1]"
+  replace:
+  - test:
+      if: "$Verbosity='Verbose'"
+      then:
+      - T: ""      # phrase('the' norm can be a measure of distance)
+  - test:
+      if: "$ClosingNorm/*[2][.='∞']"
+      then:
+      - T: "norma nieskończoności"      # phrase(the infinity norm can be a measure of distance)
+      - test:
+          if: "$Verbosity!='Terse'"
+          then:
+          - T: "z"      # phrase(the norm 'of' x)
+      else:
+      - test:
+          if: "$ClosingNorm/*[2][self::m:mrow and *[2][self::m:mo and .='→']]"
+          then:
+          - T: "norma od"
+          - x: "$ClosingNorm/*[2]/*[1]"
+          - T: "do"
+          - test:
+              if: "$ClosingNorm/*[2]/*[3][.='∞']"
+              then:
+              - T: "nieskończoności"
+              else:
+              - x: "$ClosingNorm/*[2]/*[3]"
+          else:
+          - test:
+            - if: "$ClosingNorm/*[2][.='F']"
+              then:
+              - T: "norma Frobeniusa"
+            - else_if: "$ClosingNorm/*[2][.='*' or .='∗']"
+              then:
+              - T: "norma gwiazdkowa"
+            - else:
+              - T: "norma"      # phrase(the 'norm' can be a measure of distance)
+              - x: "$ClosingNorm/*[2]"
+      - test:
+          if: "$Verbosity!='Terse'"
+          then:
+          - T: "z"      # phrase(the norm 'of' x)
+  - x: "$ClosingNorm/preceding-sibling::*[not(self::m:mo and .='∥')]"
+  - x: "$ClosingNorm/following-sibling::*"
+
+- name: word-subscripted-norm
+  tag: mrow
+  match: "count(*)>2 and *[1][self::m:mo and .='∥'] and *[last()][(self::m:indexed-by or self::m:msub) and *[1][self::m:mo and .='∥']]"
+  replace:
+  - test:
+      if: "$Verbosity='Verbose'"
+      then:
+      - T: ""      # phrase('the' norm can be a measure of distance)
+  - test:
+      if: "*[last()]/*[2][.='∞']"
+      then:
+      - T: "norma nieskończoności"      # phrase(the infinity norm can be a measure of distance)
+      - test:
+          if: "$Verbosity!='Terse'"
+          then:
+          - T: "z"      # phrase(the norm 'of' x)
+      else:
+      - test:
+          if: "*[last()]/*[2][self::m:mrow and *[2][self::m:mo and .='→']]"
+          then:
+          - T: "norma od"
+          - x: "*[last()]/*[2]/*[1]"
+          - T: "do"
+          - test:
+              if: "*[last()]/*[2]/*[3][.='∞']"
+              then:
+              - T: "nieskończoności"
+              else:
+              - x: "*[last()]/*[2]/*[3]"
+          else:
+          - test:
+            - if: "*[last()]/*[2][.='F']"
+              then:
+              - T: "norma Frobeniusa"
+            - else_if: "*[last()]/*[2][.='*' or .='∗']"
+              then:
+              - T: "norma gwiazdkowa"
+            - else:
+              - T: "norma"      # phrase(the 'norm' can be a measure of distance)
+              - x: "*[last()]/*[2]"
+      - test:
+          if: "$Verbosity!='Terse'"
+          then:
+          - T: "z"      # phrase(the norm 'of' x)
+  - x: "*[position()>1 and position()<last()]"
+
+- name: word-leading-norm
+  tag: mrow
+  match: "count(*)>3 and *[1][self::m:mo and .='∥'] and *[position()>2][self::m:mo and .='∥']"
+  variables:
+  - ClosingNorm: "*[self::m:mo and .='∥' and preceding-sibling::*][1]"
+  replace:
+  - test:
+      if: "$Verbosity='Verbose'"
+      then:
+      - T: ""      # phrase('the' norm can be a measure of distance)
+  - T: "norma"      # phrase(the 'norm' can be a measure of distance)
+  - test:
+      if: "$Verbosity!='Terse'"
+      then:
+      - T: "z"      # phrase(the norm 'of' x)
+  - x: "$ClosingNorm/preceding-sibling::*[not(self::m:mo and .='∥')]"
+  - x: "$ClosingNorm/following-sibling::*"

--- a/Rules/Languages/pl/SimpleSpeak_Rules.yaml
+++ b/Rules/Languages/pl/SimpleSpeak_Rules.yaml
@@ -1,0 +1,404 @@
+---
+- name: pause
+  tag: "!*"
+  match: "not(self::m:math) and not($MatchingPause) and @data-intent-property[contains(., ':pause')]"
+  replace:
+   - with:
+      variables: [MatchingPause: "true()"]
+      replace:
+      - test:
+        - if: "contains(@data-intent-property, ':pause-long')"
+          then: [pause: long]
+        - else_if: "contains(@data-intent-property, ':pause-short')"
+          then: [pause: short]
+          else: [pause: medium]
+      - x: "."
+
+- name: intent-literal-silent
+  tag: [mi, mo, mn]
+  match: "contains(@data-intent-property, ':silent:')"
+  # say nothing
+  replace: []
+
+# handling of negative numbers that come from 'intent' is hard -- we do something that is close to right here 
+- name: intent-literal-negative-number
+  tag: mn
+  match: "starts-with(text(), '-')"
+  replace:
+  - T: "minus"        # phrase(x 'minus' y)
+  - x: "translate(text(), '-_', '')"
+
+- name: default
+  tag: square-root
+  match: "."
+  replace:
+  - T: "pierwiastek kwadratowy"      # phrase(the 'square root' of x)
+  - test:
+      if: "$Verbosity!='Terse'"
+      then: [T: "z"]   # phrase(the square root 'of' x)
+      else: [pause: short]
+  - x: "*[1]"
+  - pause: short
+  - test:
+      if: "not(IsNode(*[1], 'leaf')) and $Impairment = 'Blindness'"
+      then: [T: "koniec pierwiastka", pause: medium]  # phrase(start the square root of x 'end of root')
+
+- name: default
+  tag: root
+  match: "."
+  replace:
+  - test:
+      if: "*[2][self::m:mn and not(contains(., '.'))]"
+      then_test:
+      - if: "*[2][.='2']"
+        then: [T: "pierwiastek kwadratowy"]        # phrase(the 'square root' of x)
+      - else_if: "*[2][.='3']"
+        then: [T: "pierwiastek sześcienny"]        # phrase(the 'cube root' of x)
+      - else: [x: "ToOrdinal(*[2])", T: "pierwiastek"]      # phrase(the square 'root' of 25)
+      else:
+      - test:
+          if: "*[2][self::m:mi][string-length(.)=1]"
+          then:
+          - x: "*[2]"
+          else: [x: "*[2]"]
+      - T: "pierwiastek"        # phrase(the square 'root' of)
+  - test:
+      if: "$Verbosity!='Terse'"
+      then: [T: "z"]        # phrase(the square root 'of' x)
+  - x: "*[1]"
+  - pause: short
+  - test:
+      if: "not(IsNode(*[1], 'leaf')) and $Impairment = 'Blindness'"
+      then: [T: "koniec pierwiastka", pause: medium]  # phrase(start the square root of x 'end of root')
+
+# Fraction rules
+# Mixed numbers mostly "just work" because the invisible char reads as "and" and other parts read properly on their own
+- name: common-fraction
+  tag: fraction
+  match:
+  - "*[1][self::m:mn][not(contains(., '.')) and text()<20]   and"
+  - "*[2][self::m:mn][not(contains(., '.')) and 2<= text() and text()<=10]"
+  variables: [IsPlural: "*[1]!=1"]
+  replace:
+  - test:
+      if: "*[1][.='1']"
+      then:
+      - T: "jedna"      # phrase(one half)
+      else:
+      - test:
+          if: "*[1][.='2']"
+          then:
+          - T: "dwie"      # phrase(two thirds)
+          else:
+          - x: "*[1]"
+  - x: "ToOrdinal(*[2], true(), $IsPlural)"   # extra args specify fractional ordinal and whether it is plural
+
+- name: common-fraction-mixed-number
+  tag: fraction
+  match:
+  - "preceding-sibling::*[1][self::m:mo][.='⁤'] and" # preceding element is invisible plus
+  - "*[1][self::m:mn][not(contains(., '.'))]   and"
+  - "*[2][self::m:mn][not(contains(., '.'))]"
+  variables: [IsPlural: "*[1]!=1"]
+  replace:
+  - test:
+      if: "*[1][.='1']"
+      then:
+      - T: "jedna"      # phrase(one half)
+      else:
+      - test:
+          if: "*[1][.='2']"
+          then:
+          - T: "dwie"      # phrase(two thirds)
+          else:
+          - x: "*[1]"
+  - x: "ToOrdinal(*[2], true(), $IsPlural)"   # extra args specify fractional ordinal and whether it is plural
+
+
+# Units (e.g., meters per second, m^2/s^2, (3m^2)/s)
+- name: per-fraction
+  tag: fraction
+  match:
+  - "BaseNode(*[1])[contains(@data-intent-property, ':unit') or"
+  - "               ( self::m:mrow and count(*)=3 and"  # maybe a bit paranoid checking the structure...
+  - "                 *[1][self::m:mn] and *[2][.='\u2062'] and BaseNode(*[3])[contains(@data-intent-property, ':unit')] ) ] and"
+  - "BaseNode(*[2])[contains(@data-intent-property, ':unit')] "
+  replace:
+  - x: "*[1]"
+  - T: "na"      # phrase('5 meters 'per' second)
+  - x: "*[2]"
+
+- name: simple
+  # don't include nested fractions. E.g, fraction a plus b over c + 1 end fraction" is ambiguous
+  # by simplistic SimpleSpeak's rules "b over c" is a fraction, but if we say nested fractions
+  # are never simple, then any 'over' applies only to enclosing "fraction...end fraction" pair.
+  tag: fraction
+  match:
+  - "(IsNode(*[1],'leaf') and IsNode(*[2],'leaf')) and"
+  - "not(ancestor::*[name() != 'mrow'][1]/self::m:fraction)" # FIX: can't test for mrow -- what should be used???
+  replace:
+  - x: "*[1]"
+  - T: "przez"      # phrase(the fraction 3 'over' 4)
+  - x: "*[2]"
+  - pause: short
+
+- name: default
+  tag: fraction
+  match: "."
+  replace:
+  - test:
+      if: "$Impairment = 'Blindness'"
+      then: [T: "ułamek"]      # phrase(the 'fraction' 3 over 4)
+  - pause: short
+  - x: "*[1]"
+  - test:
+      if: "not(IsNode(*[1],'leaf'))"
+      then: [pause: short]
+  - T: "przez"      # phrase(the fraction 3 'over' 4)
+  - test:
+      if: "not(IsNode(*[2],'leaf'))"
+      then: [pause: short]
+  - x: "*[2]"
+  - pause: short
+  - test:
+      if: "$Impairment = 'Blindness'"
+      then: [T: "koniec ułamka"]      # phrase(start 7 over 8 'end of fraction')
+  - pause: medium
+
+# rules for functions raised to a power
+# these could have been written on 'mrow' but putting them on msup seems more specific
+# to see if it is a function, we look right to see if the following sibling is apply-function
+- name: inverse-function
+  tag: inverse-function
+  match: "."
+  replace:
+  - T: "odwrotność"      # phrase(the 'inverse' of f)
+  - x: "*[1]"
+
+- name: closing-subscripted-norm-squared-or-cubed
+  tag: power
+  match: "*[1][self::m:indexed-by and *[1][self::m:mo and .='∥']] and preceding-sibling::*[self::m:mo and .='∥'] and *[2][self::m:mn][.='2' or .='3']"
+  replace:
+  - bookmark: "*[2]/@id"
+  - test:
+      if: "*[2][.=2]"
+      then: [T: "do kwadratu"]      # phrase(5 'squared' equals 25)
+      else: [T: "do sześcianu"]      # phrase(5 'cubed' equals 125)
+
+- name: closing-subscripted-norm-power
+  tag: power
+  match: "*[1][self::m:indexed-by and *[1][self::m:mo and .='∥']] and preceding-sibling::*[self::m:mo and .='∥']"
+  replace:
+  - T: "do potęgi"
+  - bookmark: "*[2]/@id"
+  - test:
+      if: "*[2][self::m:mn][not(contains(., '.'))]"
+      then: [x: "ToOrdinal(*[2])"]
+      else: [x: "*[2]"]
+  - pause: short
+
+- name: function-squared-or-cubed
+  tag: power
+  match:
+  - "*[2][self::m:mn][.='2' or .='3'] and"
+  - "following-sibling::*[1][self::m:mo][.='⁡']" #invisible function apply
+  replace:
+  - x: "*[1]"
+  - bookmark: "*[2]/@id"
+  - test:
+      if: "*[2][.=2]"
+      then: [T: "do kwadratu"]      # phrase(5 'squared' equals 25)
+      else: [T: "do sześcianu"]      # phrase(5 'cubed' equals 125)
+- name: function-power
+  tag: power
+  match:
+  - "following-sibling::*[1][self::m:mo][.='⁡']" #invisible function apply
+  replace:
+  - x: "*[1]"
+  - T: "do potęgi"
+  - bookmark: "*[2]/@id"
+  - test:
+      if: "*[2][self::m:mn][not(contains(., '.'))]"
+      then: [x: "ToOrdinal(*[2])"]
+      else: [x: "*[2]"]
+  - pause: short
+
+# non-function rules for power
+- name: squared-or-cubed
+  tag: power
+  match: "*[2][self::m:mn][.='2' or .='3']"
+  replace:
+  - x: "*[1]"
+  - bookmark: "*[2]/@id"
+  - test:
+      if: "*[2][.=2]"
+      then: [T: "do kwadratu"]      # phrase(5 'squared' equals 25)
+      else: [T: "do sześcianu"]      # phrase(5 'cubed' equals 125)
+
+- name: simple-integer
+  tag: power
+  match: "*[2][self::m:mn][not(contains(., '.'))]"
+  replace:
+  - x: "*[1]"
+  - T: "do potęgi"      # phrase(15 raised 'to the' second power equals 225)
+  - test:
+      if: "*[2][.>0]"
+      then: [x: "ToOrdinal(*[2])"]
+      else: [x: "*[2]"]
+- name: simple-negative-integer
+  tag: power
+  match:
+  - "*[2][self::m:minus and count(*)=1 and"
+  - "     *[1][self::m:mn][not(contains(., '.'))]]"
+  replace:
+  - x: "*[1]"
+  - T: "do potęgi"      # phrase(15 raised 'to the' second power equals 225)
+  - x: "*[2]"
+- name: simple-var
+  tag: power
+  match: "*[2][self::m:mi][string-length(.)=1]"
+  replace:
+  - x: "*[1]"
+  - T: "do potęgi"      # phrase(15 raised 'to the' second power equals 225)
+  - x: "*[2]"
+
+- name: simple
+  tag: power
+  match: "IsNode(*[2], 'leaf')"
+  replace:
+  - x: "*[1]"
+  - T: "do potęgi"      # phrase(15 raised 'to the' second power equals 225)
+  - x: "*[2]"
+
+- name: nested
+  # it won't end in "power" if the exponent is simple enough
+  # FIX: not that important, but this misses the case where the nested exp is a negative integer (change test if this is fixed)
+  # ending nested exponents with "...power power" sounds bad
+  tag: power
+  match:
+  - "*[2]["
+  - "     (self::m:power and not(IsNode(*[2], 'leaf'))) or" # non-simple nested superscript
+  - "     self::m:mrow[*[last()][self::m:power[not(IsNode(*[2], 'leaf'))]]]" # same as above but at the end of an mrow # FIX: need to figure out linear replacement
+  - "    ]"
+  replace:
+  - x: "*[1]"
+  - T: "do potęgi"      # phrase(15 'raised to the' second power equals 225)
+  - x: "*[2]"
+  - pause: short
+  - test:
+      if: "$Impairment = 'Blindness'"
+      then:
+      - T: "koniec wykładnika"      # phrase(start 2 raised to the exponent 4 'end of exponent')
+      - pause: short
+      else:
+      - pause: medium
+
+- name: default
+  tag: power
+  match: "."
+  replace:
+  - x: "*[1]"
+  - T: "do potęgi"      # phrase(15 'raised to the' second power equals 225)
+  - x: "*[2]"
+  - pause: short
+
+#
+# Some rules on mrows
+#
+- name: set
+  tag: set
+  match: "."
+  replace:
+  - test:
+    - if: "count(*)=0"
+      then:
+      - test:
+          if: "$Verbosity!='Terse'"
+          then: [T: ""]      # phrase('the' empty set)
+      - T: "zbiór pusty"      # phrase(when a set contains no value it is called an 'empty set' and this is valid)
+    - else_if: "count(*[1]/*)=3 and *[1]/*[2][self::m:mo][.=':' or .='|' or .='∣']"
+      then:
+      - test:
+          if: "$Verbosity!='Terse'"
+          then: [T: ""]      # phrase('the' set of all integers)
+      - T: "zbiór wszystkich"      # phrase(the 'set of all' positive integers less than 10)
+      - x: "*[1]/*[1]"
+      - T: "takich że"      # phrase(x 'such that' x is less than y)
+      - x: "*[1]/*[3]"
+      else:
+      - test:
+          if: "$Verbosity!='Terse'"
+          then: [T: ""]      # phrase('the' set of integers)
+      - T: "zbiór"      # phrase(here is a 'set' of numbers)
+      - x: "*[1]"
+
+- name: subscripted-function-application
+  tag: mo
+  match:
+  - "(.='⁢' or .='⁡') and"
+  - "not(ancestor-or-self::*[contains(@data-intent-property, ':literal:')]) and"
+  - "preceding-sibling::*[1][(self::m:indexed-by or self::m:msub or self::m:msubsup) and *[1][self::m:mi]] and"
+  - "(following-sibling::*[1][IsBracketed(., '(', ')') or IsBracketed(., '[', ']')] or"
+  - " .='⁡' and following-sibling::*[1][IsNode(., 'simple')])"
+  replace:
+  - T: "z"      # phrase(function 'of' one variable)
+
+- name: large-operator-subscripted-function-application
+  tag: mo
+  match:
+  - ".='⁢' and"
+  - "not(ancestor-or-self::*[contains(@data-intent-property, ':literal:')]) and"
+  - "(preceding-sibling::*[1][.//m:mo[.='∑' or .='∏' or .='∐'] and"
+  - "  .//*[(self::m:indexed-by or self::m:msub or self::m:msubsup) and *[1][self::m:mi]]] or"
+  - " parent::*[self::m:mrow and preceding-sibling::*[1][.//m:mo[.='∑' or .='∏' or .='∐'] and"
+  - "   .//*[(self::m:indexed-by or self::m:msub or self::m:msubsup) and *[1][self::m:mi]]]]) and"
+  - "following-sibling::*[1][IsBracketed(., '(', ')') or IsBracketed(., '[', ']')]"
+  replace:
+  - T: "z"      # phrase(function 'of' one variable)
+
+- name: times
+  tag: mo
+  match:
+  # say "times" when invisible times is followed by parens or a superscript that has a base with parens or "|"s
+  # added: say times is the superscript is not simple
+  # if we aren't sure if it is times or not, don't say anything
+  - ".='⁢' and"
+  - "not(@data-function-guess) and ("
+  - "not(ancestor-or-self::*[contains(@data-intent-property, ':literal:')]) and "
+  - "  following-sibling::*[1]["
+  - "    IsBracketed(., '(', ')') or IsBracketed(., '[', ']') or IsBracketed(., '|', '|') or "
+  - "    self::m:matrix or self::m:determinant or self::m:binomial or" # followed by parens
+  - "    self::m:square-root or self::m:msqrt or self::m:root or self::m:mroot or"
+  - "    (self::m:msub or self::m:msubsup or"
+  - "    ((self::m:msup or self::m:power) and not(IsNode(*[1], 'leaf') and *[2][self::m:mn and (.=2 or '.=3')]))) and " # followed by msup, etc.
+  - "     (*[1][self::m:mrow[IsBracketed(., '(', ')') or IsBracketed(., '[', ']') or IsBracketed(., '|', '|')] or "
+  - "           self::m:matrix or self::m:determinant] or" # base has parens
+  - "      not(IsNode(*[2], 'simple')) or "
+  - "      (self::m:msubsup and not(IsNode(*[3], 'simple')))"
+  - "     )"
+  - "  ]"  # other possibility is the preceding element has parens (but not the following)
+  - " or "
+  - "  preceding-sibling::*[1]["
+  - "    self::m:binomial or IsBracketed(., '(', ')') or IsBracketed(., '[', ']') or IsBracketed(., '|', '|')]" # followed by parens or a binomial coefficient
+  - " )"
+  replace:
+  - T: "razy"      # phrase(7 'times' 5 equals 35)
+
+- name: no-say-parens
+  tag: mrow
+  match:
+  - "parent::*[not(self::m:msup) and not(self::m:msub) and not(self::m:msubsup) and not(self::m:power) and"
+  - "          not(self::m:math) ] and "       # rule out [x] standing alone
+  - "( IsBracketed(., '(', ')') or IsBracketed(., '[', ']') ) and "
+  - "( IsNode(*[2], 'simple')  ) and"
+  - "not(preceding-sibling::*[1][.='\u2062' and @data-function-guess]) and"
+  - "not(ancestor-or-self::*[contains(@data-intent-property, ':literal:')])"
+  # missing clause: 'a positive fraction that is spoken as an ordinal
+  #   (either by the Ordinal preference or by the default rules_'
+  replace:
+  - x: "*[2]"
+
+- include: "SharedRules/geometry.yaml"
+- include: "SharedRules/linear-algebra.yaml"
+- include: "SharedRules/general.yaml"
+- include: "SharedRules/default.yaml"

--- a/Rules/Languages/pl/definitions.yaml
+++ b/Rules/Languages/pl/definitions.yaml
@@ -1,0 +1,618 @@
+---
+- include: "../../definitions.yaml"
+
+# If an "intent" is used, the 'terse:medium:verbose' speech for the intent name is given here.
+# Polish entries below are source-level speech strings used by MathCAT.
+- IntentMappings: {
+    "binomial": "infix=symbol newtona; po; koniec symbolu newtona",
+
+    "inverse":"function=odwrotność || postfix=odwrotność", 
+
+    "domain": "function=dziedzina",
+    "codomain": "function=przeciwdziedzina",
+
+    "image":"function=obraz", 
+    "mixed-fraction":"infix=i",
+    "quotient":"function=część całkowita; podzielone przez",
+    "evaluated-at":"infix=obliczone w",
+    "remainder":"function=reszta; podzielone przez",
+
+    "max":"function=maksimum",
+    "min":"function=minimum",
+
+    "power":"infix=do potęgi",
+    "root":"function=pierwiastek",
+
+    "greatest-common-divisor": "function=nwd: największy wspólny dzielnik: największy wspólny dzielnik",
+    "least-common-multiple":"function=nww: najmniejsza wspólna wielokrotność: najmniejsza wspólna wielokrotność",
+
+    "absolute-value": "function=; wartość bezwzględna: wartość bezwzględna: wartość bezwzględna; koniec wartości bezwzględnej",
+    "complex-conjugate":"function=sprzężenie zespolone",
+    "complex-arg":"function=arg",
+    "real-part": "function=część rzeczywista",
+    "imaginary-part": "function=część urojona: część urojona: część urojona",
+
+    "polar-coordinate":"function=współrzędna biegunowa; przecinek",
+    "spherical-coordinate":"function=współrzędna sferyczna; przecinek; przecinek",
+    "cartesian-coordinate":"function=współrzędna kartezjańska; przecinek",
+    "coordinate":"function=współrzędna; przecinek",
+    "floor":"function=podłoga",
+    "ceiling":"function=sufit",
+    "round":"function=zaokrąglenie",
+    "fractional-part":"function=część ułamkowa",
+
+
+    ### Calculus
+    "limit": "prefix=granica gdy",
+    "tends-to":"infix=dąży do",
+    "tends-to-from-above":"infix=dąży do z prawej",
+    "tends-to-from-below":"infix=dąży do z lewej",
+
+
+    ### Sets
+    "set": "function=; zbiór: zbiór",
+    "set-difference":"function=różnica zbiorów; i || infix=minus", # NOTE: not tested
+    "complement":"function=dopełnienie",
+    "cardinality":"function=moc zbioru",
+    "list":"function=lista",
+    "tuple": "function=; krotka: krotka",
+
+
+    ### Sequence and Series
+    "sum":"function=; suma po: suma; ",
+    "product":"function=iloczyn || function=iloczyn po || function=iloczyn od; do",
+
+
+    ### Elementary classical functions
+    "sine":"function=sin: sinus",
+    "cosine":"function=cos: cosinus",
+    "tangent":"function=tan: tangens",
+    "secant":"function=sec: sekans",
+    "cosecant":"function=cosec: kosekans",
+    "cotangent":"function=cot: cotangens",
+
+    "arcsine":"function=arcus sinus",
+    "arccosine":"function=arcus cosinus",
+    "arctangent":"function=arcus tangens",
+    "arcsecant":"function=arcus sekans",
+    "arccosecant":"function=arcus kosekans",
+    "arccotangent":"function=arcus cotangens",
+
+    "hyperbolic-sine":"function=sinus hiperboliczny",
+    "hyperbolic-cosine":"function=cosinus hiperboliczny",
+    "hyperbolic-tangent":"function=tangens hiperboliczny",
+    "hyperbolic-secant":"function=sekans hiperboliczny",
+    "hyperbolic-cosecant":"function=kosekans hiperboliczny",
+    "hyperbolic-cotangent":"function=cotangens hiperboliczny",
+
+    "arc-hyperbolic-sine":"function=arcus sinus hiperboliczny",
+    "arc-hyperbolic-cosine":"function=arcus cosinus hiperboliczny",
+    "arc-hyperbolic-tangent":"function=arcus tangens hiperboliczny",
+    "arc-hyperbolic-secant":"function=arcus sekans hiperboliczny",
+    "arc-hyperbolic-cosecant":"function=arcus kosekans hiperboliczny",
+    "arc-hyperbolic-cotangent":"function=arcus cotangens hiperboliczny",
+
+    "exponential":"function=funkcja wykładnicza",
+    "natural-logarithm": "function=L N: logarytm naturalny: logarytm naturalny",
+    "logarithm":"function=logarytm", ##Check arity 2 
+
+
+    ### Statistics and Probability
+    "mean":"function=średnia", 
+    "standard-deviation":"function=odchylenie standardowe",
+    "variance":"function=wariancja",
+    "median":"function=mediana",
+    "mode":"function=dominanta",
+
+    "conditional-probability":"function=prawdopodobieństwo; pod warunkiem", # NOTE: Check test
+
+
+    ### Linear Algebra
+    "vector": "function=; wektor || prefix=wektor", # prefix not tested, also prefix not on webpage
+    "matrix":"function=macierz", # NOTE: Failing test, recheck
+    "array":"function=tablica",
+    "determinant":"function=wyznacznik",
+    "adjugate":"function=macierz dopełnień algebraicznych",
+    "magnitude":"function=długość",
+    "norm": "function=; norma: norma: norma; koniec normy",
+    "span":"function=powłoka liniowa",
+
+    "unit-vector":"prefix=wektor jednostkowy",
+
+    "identity-matrix":"nofix=macierz jednostkowa", # NOTE: no function specified
+    "transpose":"function=transpozycja || postfix=transponowane",
+    "dimensional-product":"infix=na", # INFIX
+
+
+    ### Constants and Sets
+    "set-of-integers":"nofix=ℤ: zbiór liczb całkowitych",
+    "set-of-reals":"nofix=ℝ: zbiór liczb rzeczywistych",
+    "set-of-rationals":"nofix=ℚ: zbiór liczb wymiernych",
+    "set-of-natural-numbers":"nofix=ℕ: zbiór liczb naturalnych",
+    "set-of-complex-numbers":"nofix=ℂ: zbiór liczb zespolonych",
+    "set-of-primes":"nofix=ℙ: zbiór liczb pierwszych",
+
+    
+    ### Geometry
+    "line-segment":"prefix=odcinek",
+    "directed-line-segment":"prefix=odcinek skierowany", 
+    "line":"prefix=linia",
+    "ray":"prefix=półprosta",
+    "arc":"prefix=łuk",
+
+    "length":"function=długość",
+    "area":"function=pole",
+
+    "point":"prefix=punkt",  ## NOTE: Has ??? for property in site. Should it be prefix? Or something else.
+
+    ### Separators
+    "time-separator":"infix=",
+
+    ### General Concepts 
+    "fenced-group":"function=grupa w nawiasach",
+    "ordered-pair": "function=; para; i",
+    "indexed-by": "infix=; indeks dolny; koniec indeksu dolnego",
+    
+    "highlight":"postfix=podświetlone",
+    "least-common-denominator":"function=najmniejszy wspólny mianownik",
+    "rate":"infix=na",
+    "translation":"function=przesunięcie o; przecinek",
+    "constraint":"infix=; przy warunku; ", 
+    
+    "binomial-coefficient":"infix=po",
+    "pochhammer":"function=symbol Pochhammera",
+    "permutation-cycle":"function=cykl permutacji",
+    "embellished-name":"infix=z oznaczeniem",
+
+    ### Grouping
+    "annotation":"infix=; czyli ;",
+    "braced-group":"function=grupa w nawiasach klamrowych; koniec grupy",
+
+
+    ### Other
+    ## Default fixity function
+    "curl": "function=rotacja",
+    "divergence": "function=dywergencja",
+    "gradient": "function=gradient",
+    "laplacian": "function=laplasjan",
+
+    ## Default fixity prefix
+    "angle": "prefix=kąt",
+    "angle-measure": "prefix=miara kąta",
+    "change": "prefix=zmiana",
+    "for-all": "prefix=dla każdego",
+    "measured-angle": "prefix=kąt mierzony",
+    "not": "prefix=nie",
+    "number-of": "prefix=liczba",
+    "partial-derivative": "prefix=cząstkowe",
+    "right-angle": "prefix=kąt prosty",
+    "square-root-of": "prefix=pierwiastek kwadratowy z",
+    "there-does-not-exist": "prefix=nie istnieje",
+    "there-exists": "prefix=istnieje",
+
+
+    ## Default fixity infix
+    "and": "infix=i",
+    "applied-to": "infix=zastosowane do",
+    "approximately": "infix=w przybliżeniu",
+    "congruent": "infix=przystające do",
+    "cartesian-product": "infix=iloczyn kartezjański",
+    "composed-with": "infix=złożone z",
+    "cross-product": "infix=krzyż: iloczyn wektorowy: iloczyn wektorowy",
+    "defined-as": "infix=zdefiniowane jako",
+    "divided-by": "infix=podzielone przez",
+    "divides": "infix=dzieli",
+    "does-not-belong-to": "infix=nie należy do",
+    "does-not-divide": "infix=nie dzieli",
+    "dot-product": "infix=iloczyn skalarny",
+    "downwards-diagonal-ellipsis": "infix=ukośny wielokropek w dół",
+    "direct-product": "infix=iloczyn prosty",
+    "element-of": "infix=należy do",
+    "ellipsis": "infix=wielokropek",
+    "equals": "infix=równa się",
+    "equivalent-to": "infix=równoważne",
+    "evaluates-to": "infix=ma wartość",
+    "given": "infix=pod warunkiem",
+    "greater-than": "infix=większe niż",
+    "greater-than-or-equal-to": "infix=większe lub równe",
+    "identically-equals": "infix=tożsamościowo równe",
+    "if-and-only-if": "infix=wtedy i tylko wtedy gdy",
+    "implies": "infix=implikuje",
+    "inner-product": "infix=iloczyn wewnętrzny",
+    "intersection": "infix=część wspólna",
+    "less-than": "infix=mniejsze niż",
+    "less-than-or-equal-to": "infix=mniejsze lub równe",
+    "list-separator": "infix=przecinek",
+    "maps-to": "infix=przekształca na",
+    "member-of": "infix=element zbioru",
+    "minus-or-plus": "infix=minus lub plus",
+    "not-subset": "infix=nie jest podzbiorem",
+    "not-superset": "infix=nie jest nadzbiorem",
+    "not-equal-to": "infix=nie równa się",
+    "not-member-of": "infix=nie jest elementem zbioru",
+    "not-parallel-to": "infix=nierównoległe do",
+    "obtained-from": "infix=otrzymane z",
+    "or": "infix=lub",
+    "outer-product": "infix=iloczyn zewnętrzny",
+    "parallel-to": "infix=równoległe do",
+    "perpendicular": "infix=prostopadłe do",
+    "plus": "infix=plus || prefix=plus",
+    "minus": "infix=minus || prefix=minus",
+    "plus-or-minus": "infix=plus minus",
+    "precedes": "infix=poprzedza",
+    "proportional": "infix=proporcjonalne do",
+    "range-separator": "infix=do",
+    "ratio": "infix=stosunek",
+    "similar": "infix=podobne do",
+    "subset": "infix=podzbiór",
+    "subset-or-equal": "infix=podzbiór lub równy",
+    "succeeds": "infix=następuje po",
+    "such-that": "infix=taki że",
+    "superset": "infix=nadzbiór",
+    "superset-or-equal": "infix=nadzbiór lub równy",
+    "tilde": "infix=tylda",
+    "times": "infix=razy",
+    "union": "infix=suma zbiorów",
+    "upwards-diagonal-ellipsis": "infix=ukośny wielokropek w górę",
+    "vertical-ellipsis": "infix=wielokropek pionowy",
+    "xor": "infix=albo",
+
+    ## Default fixity postfix
+    "factorial": "postfix=silnia",
+    "percent": "postfix=procent",
+
+    ## Default fixity nofix
+    "diameter":"nofix=d: średnica",
+    "distance":"nofix=d; D: odległość",
+    "probability":"nofix=P: prawdopodobieństwo",
+    "radius":"nofix=r: promień",
+    "volume":"nofix=V: objętość || function=objętość",
+    "exponential-e":"nofix=e",
+    "imaginary-i":"nofix=i",
+    "differential-d":"nofix=d",
+    "golden-ratio":"nofix=złota proporcja",
+    
+
+    ## Other : Not tested, don't appear in https://w3c.github.io/mathml-docs/intent-core-concepts/
+    "modified-variable": "silent=",
+    "say-super": "infix=indeks górny: indeks górny: indeks górny",   # used with 'mo' for superscripts (e.g, "<")
+    "skip-super": "silent=",   # used with 'mo' for superscripts (e.g, "*")
+    # "large-op": "infix=przez|| other=od,do",
+    "lim-sup": "prefix=lim sup gdy: granica górna gdy: granica górna gdy",
+    "lim-inf": "prefix=lim inf gdy: granica dolna gdy: granica dolna gdy",
+    "limit-sup": "prefix=lim sup gdy: granica górna gdy: granica górna gdy",
+    "limit-inf": "prefix=lim inf gdy: granica dolna gdy: granica dolna gdy",
+    "logarithm-with-base": "prefix=log podstawa: logarytm o podstawie: logarytm o podstawie",
+    "trace": "function=; ślad: ślad: ślad; koniec śladu",
+    "dimension": "function=; wymiar: wymiar: wymiar; koniec wymiaru",
+    "homomorphism": "function=; homomorfizm: homomorfizm: homomorfizm; koniec homomorfizmu",
+    "kernel": "function=; jądro: jądro: jądro; koniec jądra",
+    
+    "chemistry-concentration": "function=; stężenie: stężenie: stężenie; koniec stężenia",
+  }
+
+  # Names of functions that in terse mode don't say "of" (or it's equivalent in other languages)
+- TerseFunctionNames: {
+    "divergence", "gradient", "curl"
+  }
+
+- NavigationParts: {
+    # These are the parts of a formula that can be navigated to.
+    # Nazwy w DOPELNIACZU, bo trafiaja do konstrukcji "do <czesc>" / "z <czesc>"
+    # (np. "do licznika", "z mianownika"). Patrz regula into-or-out-of-default w navigate.yaml.
+    "large-op": "podstawy; dolnej granicy; górnej granicy",
+    "mfrac": "licznika; mianownika",
+    "fraction": "licznika; mianownika",
+    "msqrt": "pierwiastka",
+    "square-root": "pierwiastka",
+    "mroot": "pierwiastka; stopnia pierwiastka",
+    "root": "pierwiastka; stopnia pierwiastka",
+    "msub": "podstawy; indeksu dolnego",
+    "sub": "podstawy; indeksu dolnego",
+    "logarithm-with-base": "podstawy",
+    "indexed-by": "podstawy; indeksu dolnego",
+    "msup": "podstawy; wykładnika",
+    "say-super": "podstawy; wykładnika",
+    "skip-super": "podstawy; wykładnika",
+    "power": "podstawy; wykładnika",
+    "msubsup": "podstawy; indeksu dolnego; wykładnika",
+    "munder": "podstawy; dolnej granicy",
+    "mover": "podstawy; górnej granicy",
+    "munderover": "podstawy; dolnej granicy; górnej granicy",
+
+    # words for moving into and out of one of the parts (e.g., "move right 'out of' numerator, 'in' denominator")
+    # it's a hack to put them here, but at least they are grouped with the other navigation parts
+    "in": "do",
+    "out": "z",
+  }
+
+- KnownWords: {
+    "sin", "cos", "tan", "cot", "sec", "cosec", "log", "lim", "arg", "mod", "det", "min", "max"
+  }
+
+- SIPrefixes: {
+    "Q": "kwetta", "R": "ronna", "Y": "jotta", "Z": "zetta", "E": "eksa", "P": "peta", "T": "tera", "G": "giga", "M": "mega", "k": "kilo", "h": "hekto", "da": "deka",
+    "d": "decy", "c": "centy", "m": "mili", "µ": "mikro", "n": "nano", "p": "piko", "f": "femto", "a": "atto", "z": "zepto", "y": "jokto", "r": "ronto", "q": "kwekto"
+  }
+
+# this is a list of all units that accept SIPrefixes
+# from www.bipm.org/documents/20126/41483022/SI-Brochure-9-EN.pdf
+#   Prefixes may be used with any of the 29 SI units with special names
+#   The SI prefixes can be used with several of accepted units, but not, for example, with the non-SI units of time.
+- SIUnits: {
+    # base units
+    "A": "amper",
+    "cd": "kandela",
+    "K": "kelwin", "K": "kelwin", # U+212A
+    "g": "gram",
+    "m": "metr",
+    "mol": "mol",
+    "s": "sekunda", "sec": "sekunda",
+
+    # derived units
+    "Bq": "bekerel",
+    "C": "kulomb",
+    "°C": "stopień Celsjusza", "℃": "stopień Celsjusza", # should only take negative powers
+    "F": "farad",
+    "Gy": "grej",
+    "H": "henr",
+    "Hz": "herce",
+    "J": "dżul",
+    "kat": "katal",
+    "lm": "lumen",
+    "lx": "luks",
+    "N": "niuton",
+    "Ω": "om", "Ω": "om",       # Greek Cap letter, U+2126 OHM SIGN
+    "Pa": "paskal",
+    "S": "siemens",
+    "Sv": "siwert",
+    "T": "tesla",
+    "V": "wolt",
+    "W": "wat",
+    "Wb": "weber",
+
+    # accepted (plus a few variants) that take SI prefixes
+    "l": "litr", "L": "litr", "ℓ": "litr",
+    "t": "tona",
+    "Da": "dalton",
+    "Np": "neper",               # should only take negative powers
+    "u": "jednostka masy atomowej",
+    "eV": "elektronowolt",
+    "rad": "radian",
+    "sr": "steradian",
+  
+    # others that take a prefix
+    "a": "rok",
+    "as": "sekunda łuku",
+
+    # technically wrong, but used in practice with SI Units
+    "b": "bit",
+    "B": "bajt",
+    "Bd": "bod",
+  }
+
+
+- UnitsWithoutPrefixes: {
+    # time
+    "″": "sekunda", "\"": "sekunda",
+    "′": "minuta", "'": "minuta","min": "minuta",
+    "h": "godzina", "hr": "godzina", "Hr": "godzina",
+    "d": "dzień", "dy": "dzień",
+    "w": "tydzień", "wk": "tydzień",
+    "y": "rok", "yr": "rok",    
+
+    # angles
+    "°": "stopień", "deg": "stopień", # should only take negative powers
+    "arcmin": "minuta łuku",
+    "amin": "minuta łuku",
+    "am": "minuta łuku",
+    "MOA": "minuta łuku",
+    "arcsec": "sekunda łuku",
+    "asec": "sekunda łuku",
+
+    # distance
+    "au": "jednostka astronomiczna", "AU": "jednostka astronomiczna",
+    "ltyr": "rok świetlny", "ly": "rok świetlny",
+    "pc": "parsek",
+    "Å": "angstrem", "Å": "angstrem",           # U+00C5 and U+212B
+    "fm": "fermi",
+
+    # others
+    "ha": "hektar",
+    # "B": "bel",    # "B" more commonly means bytes
+    "dB": "decybel", # already logarithmic, so not used with SI prefixes
+
+    "amu": "jednostka masy atomowej",
+    "atm": "atmosfera",
+    "bar": "bar",
+    "cal": "kaloria",
+    "Ci": "kiur",
+    "grad": "grad",
+    "M": "molowy",
+    "R": "rentgen",
+    "rpm": "obrót na minutę",
+    "℧": "M h o",
+    "dyn": "dyna",
+    "erg": "erg",
+
+    # powers of 2 used with bits and bytes
+    "Kib": "kibibit", "Mib": "mebibit", "Gib": "gibibit", "Tib": "tebibit", "Pib": "pebibit", "Eib": "eksbibit", "Zib": "zebibit", "Yib": "jobibit",
+    "KiB": "kibibajt", "MiB": "mebibajt", "GiB": "gibibajt", "TiB": "tebibajt", "PiB": "pebibajt", "EiB": "eksbibajt", "ZiB": "zebibajt", "YiB": "jobibajt",
+  }
+
+  # this will only be used if the language is English, so it can be empty for other countries
+- EnglishUnits: {
+    # length
+    "in": "cal",
+    "ft": "stopa",
+    "mi": "mila",
+    "rd": "pręt",
+    "li": "ogniwo",
+    "ch": "łańcuch",
+
+    # area
+    "sq in": "cal kwadratowy", "sq. in": "cal kwadratowy", "sq. in.": "cal kwadratowy",
+    "sq ft": "stopa kwadratowa", "sq. ft": "stopa kwadratowa", "sq. ft.": "stopa kwadratowa",
+    "sq yd": "jard kwadratowy", "sq. yd": "jard kwadratowy", "sq. yd.": "jard kwadratowy",
+    "sq mi": "mila kwadratowa", "sq. mi": "mila kwadratowa", "sq. mi.": "mila kwadratowa",
+    "ac": "akr",
+    "FBM": "stopa deskowa",
+
+    # volume
+    "cu in": "cal sześcienny", "cu. in": "cal sześcienny", "cu. in.": "cal sześcienny",
+    "cu ft": "stopa sześcienna", "cu. ft": "stopa sześcienna", "cu. ft.": "stopa sześcienna",
+    "cu yd": "jard sześcienny", "cu. yd": "jard sześcienny", "cu. yd.": "jard sześcienny",
+    "bbl": "baryłka", "BBL": "baryłka",
+    "pk": "pek",
+    "bu": "buszel",
+    "tsp": "łyżeczka",
+    "tbl": "łyżka stołowa",
+
+    # liquid
+    "fl dr": "drachma płynu",
+    "fl oz": "uncja płynu",
+    "gi": "gill",
+    "cp": "kubek", "cup": "kubek",
+    "pt": "pinta",
+    "qt": "kwarta",
+    "gal": "galon",
+
+    # weight
+    "gr": "gran",
+    "dr": "drachma",
+    "oz": "uncja", "℥": "uncja",
+    "lb": "funt",
+    "cwt": "cetnar",
+    "dwt": "pennyweight",
+    "oz t": "uncja trojańska",
+    "lb t": "funt trojański",
+
+    # energy
+    "hp": "konie mechaniczne",
+    "BTU": "btu",
+    "°F": "stopień Fahrenheita", "℉": "stopień Fahrenheita",
+
+    # other
+    "mph": "mila na godzinę",
+    "mpg": "mila na galon",
+  }
+
+- CurrencySymbols: {
+    "$": "dolar", "¢": "cent", "€": "euro", "£": "funt", "₡": "colon", "₤": "lir", "₨": "rupia",
+    "₩": "won", "₪": "szekel", "₱": "peso", "₹": "rupia", "₺": "lir", "₿": "bitcoin",
+    # could add more currencies...
+  }
+
+- PluralForms: {
+  # FIX: this needs to be flushed out
+    "cal": "cale", "cal kwadratowy": "cale kwadratowe", "cal sześcienny": "cale sześcienne",
+    "stopa": "stopy", "stopa kwadratowa": "stopy kwadratowe", "stopa sześcienna": "stopy sześcienne",
+    "stopa deskowa": "stopy deskowe",
+    "stopień": "stopnie",
+    "stopień Celsjusza": "stopnie Celsjusza",
+    "stopień Fahrenheita": "stopnie Fahrenheita",
+    "degree celsius": "stopnie Celsjusza",
+    "degree fahrenheit": "stopnie Fahrenheita",
+    "henr": "henry",
+    "wolt": "wolty",
+    "wat": "waty",
+    "hertz": "herce",
+    "luks": "luksy",
+    "siemens": "siemens",
+    "obrót na minutę": "obroty na minutę",
+    "mila na godzinę": "mile na godzinę",
+    "mila na galon": "mile na galon",
+    "colon": "colony", "lir": "liry", "won": "wony", "bitcoin": "bitcoiny"
+  }
+
+# Lines starting with "#" are a comment
+# Each definition in this file is of the form
+# - name: { "...", "..." "..." }
+# For numbers, 
+# - name: [] "...", "..." "..." ]
+
+
+# ----------------  Cardinal and Ordinal Numbers  --------------------------
+# The following definitions are used to convert numbers to words
+# The are mainly used for ordinals, of which there are two cases:
+# 1. Regular ordinals: first, second, third, ...
+# 2. Ordinals used in the denominator of fractions (e.g, one half, one third)
+#    When used in the denominator of fractions, a plural version might be
+#    used (e.g., two halves, two thirds)
+# Although a lot of languages are regular after a few entries, for generality,
+# the following lists should be filled out even though they are the same
+# or easily derived from others in many languages (e.g, an 's' is added for plurals).
+# The larger ordinal numbers (e.g, millionth) is used when there are only
+# '0's after that decimal place (e.g., 23000000).:w
+
+# All definitions start 0, 10, 100, etc.
+
+# The definitions for the "ones" should extend until a regular pattern begins
+#   The minimum length is 10.
+
+# For English, a regular pattern starts at twenty
+- NumbersOnes: [
+        "zero", "jeden", "dwa", "trzy", "cztery", "pięć", "sześć", "siedem", "osiem", "dziewięć",
+        "dziesięć", "jedenaście", "dwanaście", "trzynaście", "czternaście", "piętnaście", "szesnaście", "siedemnaście", "osiemnaście", "dziewiętnaście"
+    ]
+
+- NumbersOrdinalOnes: [
+        "zerowej", "pierwszej", "drugiej", "trzeciej", "czwartej", "piątej", "szóstej", "siódmej", "ósmej", "dziewiątej",
+        "dziesiątej", "jedenastej", "dwunastej", "trzynastej", "czternastej", "piętnastej", "szesnastej", "siedemnastej", "osiemnastej", "dziewiętnastej"
+    ]
+
+- NumbersOrdinalPluralOnes: [
+        "zerowych", "pierwszych", "drugich", "trzecich", "czwartych", "piątych", "szóstych", "siódmych", "ósmych", "dziewiątych",
+        "dziesiątych", "jedenastych", "dwunastych", "trzynastych", "czternastych", "piętnastych", "szesnastych", "siedemnastych", "osiemnastych", "dziewiętnastych"
+    ]
+
+    # stop when regularity begins
+- NumbersOrdinalFractionalOnes: [
+        "zero", "pierwsza", "druga", "trzecia", "czwarta", "piąta", "szósta", "siódma", "ósma", "dziewiąta", "dziesiąta"
+    ]
+
+    # stop when regularity begins
+- NumbersOrdinalFractionalPluralOnes: [
+        "zera", "pierwsze", "drugie", "trzecie", "czwarte", "piąte", "szóste", "siódme", "ósme", "dziewiąte", "dziesiąte"
+    ]
+
+
+    # What to use for multiples of 10
+- NumbersTens: [
+        "", "dziesięć", "dwadzieścia", "trzydzieści", "czterdzieści", "pięćdziesiąt", "sześćdziesiąt", "siedemdziesiąt", "osiemdziesiąt", "dziewięćdziesiąt"
+    ]
+
+- NumbersOrdinalTens: [
+        "", "dziesiątej", "dwudziestej", "trzydziestej", "czterdziestej", "pięćdziesiątej", "sześćdziesiątej", "siedemdziesiątej", "osiemdziesiątej", "dziewięćdziesiątej"
+    ]
+
+- NumbersOrdinalPluralTens: [
+        "", "dziesiątych", "dwudziestych", "trzydziestych", "czterdziestych", "pięćdziesiątych", "sześćdziesiątych", "siedemdziesiątych", "osiemdziesiątych", "dziewięćdziesiątych"
+    ]
+
+
+- NumbersHundreds: [
+        "", "sto", "dwieście", "trzysta", "czterysta", "pięćset", "sześćset", "siedemset", "osiemset", "dziewięćset"
+    ]
+
+- NumbersOrdinalHundreds: [
+        "", "setnej", "dwusetnej", "trzysetnej", "czterysetnej", "pięćsetnej", "sześćsetnej", "siedemsetnej", "osiemsetnej", "dziewięćsetnej"
+    ]
+
+- NumbersOrdinalPluralHundreds: [
+        "", "setnych", "dwusetnych", "trzysetnych", "czterysetnych", "pięćsetnych", "sześćsetnych", "siedemsetnych", "osiemsetnych", "dziewięćsetnych"
+    ]
+      
+
+    # At this point, hopefully the language is regular. If not, code needs to be written
+- NumbersLarge: [
+        "", "tysiąc", "milion", "miliard", "bilion", "biliard", "trylion", "tryliard", "kwadrylion", "kwadryliard"
+    ]
+      
+- NumbersOrdinalLarge: [
+        "", "tysięcznej", "milionowej", "miliardowej", "bilionowej", "biliardowej", "trylionowej", "tryliardowej", "kwadrylionowej", "kwadryliardowej"
+    ]
+      
+- NumbersOrdinalPluralLarge: [
+        "", "tysięcznych", "milionowych", "miliardowych", "bilionowych", "biliardowych", "trylionowych", "tryliardowych", "kwadrylionowych", "kwadryliardowych"
+    ]

--- a/Rules/Languages/pl/intent.yaml
+++ b/Rules/Languages/pl/intent.yaml
@@ -1,0 +1,178 @@
+---
+# Per-jezyk override warstwy INTENT dla polskiego (Opcja 2 - bez ruszania rdzenia silnika).
+# Pandoc generuje norme ‖...‖ (U+2225) z OBOMA ogranicznikami jako form="postfix", przez co
+# IsBracketed nie paruje pary i norma nie staje sie intentem -> jej pod-wezly (∥, indeks, tresc)
+# sa NIENAWIGOWALNE (NVDA: "blad wyrazenia matematycznego"). Te reguly grupuja te norme w
+# semantyczny wezel PRZED wspolnym intentem. Sa WASKIE (wymagaja ∥ na poczatku), wiec nie ruszaja
+# zwyklej relacji rownoleglosci a ∥ b.
+
+# --- Norma BEZ indeksu: ‖tresc‖ -> mrow[ ∥, tresc..., ∥, ...reszta... ] ---
+-
+  name: norm-plain-iso-pandoc
+  tag: mrow
+  match:
+    - "count(*)=3 and"
+    - "*[1][self::m:mo and .='∥'] and"
+    - "*[3][self::m:mo and .='∥']"
+  replace:
+  - intent:
+      name: "norm"
+      attrs: "data-intent-property='concat(data-intent-property, \":function:\")'"
+      children:
+      - x: "*[2]"
+
+-
+  name: norm-plain-leading-pandoc
+  tag: mrow
+  match:
+    - "count(*)>3 and"
+    - "*[1][self::m:mo and .='∥'] and"
+    - "*[3][self::m:mo and .='∥'] and"
+    - "not(*[2][self::m:mo and .='∥'])"
+  replace:
+  - intent:
+      xpath-name: "name(.)"
+      attrs: "id='*[3]/@id'"
+      children:
+      - intent:
+          name: "norm"
+          attrs: "data-intent-property='concat(data-intent-property, \":function:\")'"
+          children:
+          - x: "*[2]"
+      - x: "*[position()>3]"
+
+-
+  name: norm-subscripted-iso-pandoc
+  tag: mrow
+  match:
+    - "count(*)=3 and"
+    - "*[1][self::m:mo and .='∥'] and"
+    - "*[3][(self::m:msub or self::m:indexed-by) and *[1][self::m:mo and .='∥']]"
+  replace:
+  - intent:
+      name: "subscripted-norm"
+      attrs: "data-intent-property='concat(data-intent-property, \":function:\")'"
+      children:
+      - x: "*[2]"
+      - x: "*[3]/*[2]"
+
+-
+  name: norm-leading-subscripted-pandoc
+  tag: mrow
+  match:
+    - "count(*)>3 and"
+    - "*[1][self::m:mo and .='∥'] and"
+    - "*[3][(self::m:msub or self::m:indexed-by) and *[1][self::m:mo and .='∥']] and"
+    - "not(*[position()>1 and position()<3][self::m:mo and .='∥'])"
+  replace:
+  - intent:
+      xpath-name: "name(.)"
+      attrs: "id='*[3]/@id'"   # owijajacy mrow: id zwolnione przez rozbicie msub
+      children:
+      - intent:
+          name: "subscripted-norm"
+          attrs: "data-intent-property='concat(data-intent-property, \":function:\")'"
+          children:
+          - x: "*[2]"
+          - x: "*[3]/*[2]"
+      - x: "*[position()>3]"
+
+# --- Norma z indeksem I POTEGA: ‖tresc‖_indeks^potega ---
+# canonicalize: mrow[ ∥, tresc..., power[ (indexed-by|msub)[∥, indeks], potega ], ...reszta... ]
+# Budujemy: power[ subscripted-norm[tresc, indeks], potega ].
+-
+  name: norm-subscripted-powered-iso-pandoc
+  tag: mrow
+  match:
+    - "count(*)=3 and"
+    - "*[1][self::m:mo and .='∥'] and"
+    - "*[3][(self::m:power or self::m:msubsup) and *[1][(self::m:indexed-by or self::m:msub) and *[1][self::m:mo and .='∥']]]"
+  replace:
+  - intent:
+      name: "power"
+      attrs: "data-intent-property='concat(data-intent-property, \":postfix:\")'"
+      children:
+      - intent:
+          name: "subscripted-norm"
+          attrs: "data-intent-property='concat(data-intent-property, \":function:\")'"
+          children:
+          - x: "*[2]"
+          - x: "*[3]/*[1]/*[2]"   # indeks (z indexed-by/msub wewnatrz power)
+      - x: "*[3]/*[2]"            # potega
+
+-
+  name: norm-leading-subscripted-powered-pandoc
+  tag: mrow
+  match:
+    - "count(*)>3 and"
+    - "*[1][self::m:mo and .='∥'] and"
+    - "*[3][(self::m:power or self::m:msubsup) and *[1][(self::m:indexed-by or self::m:msub) and *[1][self::m:mo and .='∥']]] and"
+    - "not(*[position()>1 and position()<3][self::m:mo and .='∥'])"
+  replace:
+  - intent:
+      xpath-name: "name(.)"
+      attrs: "id='*[3]/@id'"
+      children:
+      - intent:
+          name: "power"
+          attrs: "data-intent-property='concat(data-intent-property, \":postfix:\")'"
+          children:
+          - intent:
+              name: "subscripted-norm"
+              attrs: "data-intent-property='concat(data-intent-property, \":function:\")'"
+              children:
+              - x: "*[2]"
+              - x: "*[3]/*[1]/*[2]"
+          - x: "*[3]/*[2]"
+      - x: "*[position()>3]"
+
+# --- Norma z indeksem I POTEGA (wariant: zamykajacy ∥ to baza msubsup) ---
+# canonicalize czasem zostawia: mrow[ ∥, tresc..., msubsup[ ∥, indeks, potega ], ...reszta... ]
+# Budujemy: power[ subscripted-norm[tresc, indeks], potega ].
+-
+  name: norm-subscripted-powered-msubsup-iso-pandoc
+  tag: mrow
+  match:
+    - "count(*)=3 and"
+    - "*[1][self::m:mo and .='∥'] and"
+    - "*[3][self::m:msubsup and *[1][self::m:mo and .='∥']]"
+  replace:
+  - intent:
+      name: "power"
+      attrs: "data-intent-property='concat(data-intent-property, \":postfix:\")'"
+      children:
+      - intent:
+          name: "subscripted-norm"
+          attrs: "data-intent-property='concat(data-intent-property, \":function:\")'"
+          children:
+          - x: "*[2]"
+          - x: "*[3]/*[2]"   # indeks
+      - x: "*[3]/*[3]"       # potega
+
+-
+  name: norm-leading-subscripted-powered-msubsup-pandoc
+  tag: mrow
+  match:
+    - "count(*)>3 and"
+    - "*[1][self::m:mo and .='∥'] and"
+    - "*[3][self::m:msubsup and *[1][self::m:mo and .='∥']] and"
+    - "not(*[position()>1 and position()<3][self::m:mo and .='∥'])"
+  replace:
+  - intent:
+      xpath-name: "name(.)"
+      attrs: "id='*[3]/@id'"
+      children:
+      - intent:
+          name: "power"
+          attrs: "data-intent-property='concat(data-intent-property, \":postfix:\")'"
+          children:
+          - intent:
+              name: "subscripted-norm"
+              attrs: "data-intent-property='concat(data-intent-property, \":function:\")'"
+              children:
+              - x: "*[2]"
+              - x: "*[3]/*[2]"
+          - x: "*[3]/*[3]"
+      - x: "*[position()>3]"
+
+- include: "../../intent.yaml"

--- a/Rules/Languages/pl/navigate.yaml
+++ b/Rules/Languages/pl/navigate.yaml
@@ -1,0 +1,1701 @@
+---
+# Documentation:
+#
+# The general form for many rules is:
+# 1. Say the command if this is first rule to fire (MatchCounter) and depending upon "NavVerbosity"s value
+#    This will increment MatchCounter so that the command won't be spoken again
+# 2. Say info about moving into/out of 2D structures
+# 3. Set some variables and possibly recurse.
+#    If stopping, "NavNode" should be set.
+#
+# The meaning of NavVerbosity:
+# * Verbose -- always echo the command and end points (e.g., "can't move right")
+# * Medium -- only echo the command for obscure commands like the placemarker commands; also say end points
+# * Terse -- no echo of commands or end points
+# 
+# For the second item, a common set of rules is used. These rules require the variable "Move2D"
+# to be set along with "Child2D", where "Move2D" is either 'in' or 'out'.
+#
+# In addition, the navigation rules make use of two functions:
+#
+# int DistanceFromLeaf(node, leftSide, treat2DElementsAsTokens)
+#   Returns the distance (number of children) until a leaf is reached by traversing the leftmost/rightmost child
+#   If 'treat2DElementsAsTokens' is true, then 2D notations such as fractions are treated like leaves 
+#   A leaf has distance == 0
+#
+# EdgeNode(node, "left"/"right", stopNodeName)
+#   Returns the stopNode if at left/right edge of named ancestor node. 'stopNodeName' can also be "2D"
+#   If the stopNode isn't found, the original node is returned
+#  Note: if stopNodeName=="math", then punctuation is taken into account since it isn't really part of the math
+#
+# A few other variables are of importance to Navigation
+# NavMode -- Enhanced, Simple, Character
+# ReadZoomLevel -- -1 for Enhanced, otherwise the distance from leaf the rules should maintain
+# PlaceMarkerIndex
+
+# Note: the rules for saying a command and announcing what is said when moving in/out of a 2d exprs are hacks
+# They depend upon special variables "SayCommand" and "Move2D" being set and if they are, the rules are activated.
+# If/when functions can be defined in a rules file, it is likely these would be much better done via those functions
+#   as they would likely be much more efficient and also cleaner.
+
+# Rules for announcing the command
+- name: say-command
+  tag: "!*"
+  match: "$SayCommand != ''"   # value should be '', 'true', or 'false'
+  variables: [Prefix: "''"]
+  replace:
+  - test:
+    - if: "$MatchCounter = 0 and $SayCommand = 'true'"
+      then_test:
+      - if: "self::m:math and starts-with($NavCommand, 'ZoomOut')"
+        then: [t: "maksymalnie oddalono", pause: "medium"]
+      - else_if: "IsNode(., 'leaf') and starts-with($NavCommand, 'ZoomIn')"
+        then: [t: "maksymalnie oddalono", pause: "medium"]
+        else:
+        - test:
+          - if: "starts-with($NavCommand, 'Zoom')"
+            then: [set_variables: [Prefix: "'przybliż'"]]          # phrase('zoom' in to see more details)     
+          - else_if: "starts-with($NavCommand, 'Move')"
+            then: [set_variables: [Prefix: "'przejdź'"]]          # phrase('move' to next entry in table)     
+          - else_if: "starts-with($NavCommand, 'Read')"
+            then: [set_variables: [Prefix: "'odczytaj'"]]          # phrase('read' to next entry in table)     
+          - else_if: "starts-with($NavCommand, 'Describe')"
+            then: [set_variables: [Prefix: "'opisz'"]]      # phrase('describe' to next entry in table)
+        - test:
+            if: "$Prefix != ''"
+            then:
+            - x: "$Prefix"
+            - test:
+              - if: "substring($NavCommand, string-length($Prefix)+1) = 'In'"
+                then: [T: "do"]                                  # phrase(zoom 'in' to see more details)
+              - else_if: "substring($NavCommand, string-length($Prefix)+1) = 'InAll'"
+                # HACK: '\uF8FE' is used internally for the concatenation char by 'ct' -- this gets "ed" concatenated to "zoom"
+                then: [t: "maksymalnie do środka"]                     # phrase(zoom 'out all the way' to see more details)
+              - else_if: "substring($NavCommand, string-length($Prefix)+1) = 'Out'"
+                then: [t: "na zewnątrz"]                                 # phrase(zoom 'out' to see more details)
+              - else_if: "substring($NavCommand, string-length($Prefix)+1) = 'OutAll'"
+                # HACK: '\uF8FE' is used internally for the concatenation char by 'ct' -- this gets "ed" concatenated to "zoom"
+                then: [t: "maksymalnie na zewnątrz"]                     # phrase(zoom 'out all the way' to see more details)
+              - else_if: "substring($NavCommand, string-length($Prefix)+1) = 'Next'"
+                then: [t: "w prawo"]                               # phrase(move to the 'right')
+              - else_if: "substring($NavCommand, string-length($Prefix)+1) = 'Previous'"
+                then: [t: "w lewo"]                                # phrase(move to the 'left')
+              - else_if: "substring($NavCommand, string-length($Prefix)+1) = 'Current'"
+                then: [t: "bieżący"]                                 # phrase(who is the 'current' president)
+              - else_if: "substring($NavCommand, string-length($Prefix)+1) = 'LineStart'"
+                then: [t: "do początku linii"]                                 # phrase(move 'to start of line')
+              - else_if: "substring($NavCommand, string-length($Prefix)+1) = 'LineEnd'"
+                then: [t: "do końca linii"]                                 # phrase(move 'to end of line')
+            - pause: "medium"
+  - set_variables: [MatchCounter: "$MatchCounter + 1"]
+
+- name: into-or-out-of-silent
+  tag: "*"
+  # saying "out of row n" is not very useful, so skip it
+  match: "$Move2D != '' and (not(@data-from-mathml) or @data-from-mathml = name(.)) and
+          (name(.)='mrow' or name(.) = 'mtr' or name(.) = 'mlabeledtr' or @data-from-mathml = 'mtable')"
+  replace: []
+
+- name: into-or-out-of-mtr
+  tag: [mtr, mlabeledtr]
+  match: "$Move2D = 'in'"
+  replace:
+  - T: "kolumna"
+  - x: "count($Child2D/preceding-sibling::*)+1"
+  - pause: "medium"
+
+- name: into-or-out-of-mmultiscripts
+  tag: "*"
+  match: "$Move2D != '' and (@data-from-mathml='mmultiscripts' or self::m:mmultiscripts)"
+  replace:
+  - test:
+      if: "name($Child2D)!='none'"
+      then:
+      - with:
+          variables:
+          - NumPrecedingSiblings: "count($Child2D/preceding-sibling::*)"
+          replace:
+          - test:
+            - if: "$Move2D = 'in'"
+              then: [t: "do"]                            # phrase(move 'in' to a part)
+            - else_if: "$Move2D = 'out of'"
+              then: [t: "z"]                             # phrase(move 'out of' a part)
+            - else_if: "$Move2D = 'end of'"
+              then: [t: "na koniec"]                     # phrase(move to the 'end of' a part)
+            - else_if: "$Move2D = 'start of'"
+              then: [t: "na początek"]                   # phrase(move to the 'start of' a part)
+              else: [x: "$Move2D"]
+          - test:
+            - if: "$NumPrecedingSiblings=0"
+              then: [T: "podstawy"]                 # phrase(the 'base' of the power)
+            - else_if: "$Child2D/preceding-sibling::*[self::m:mprescripts]" # are we before mprescripts and hence are postscripts
+              then:
+              - test:   # in postscripts -- base shifts by one
+                  if: "$NumPrecedingSiblings mod 2 = 0" 
+                  then: [t: "lewego indeksu dolnego"]       # phrase(x with 'subscript' 2)
+                  else: [t: "lewego indeksu górnego"]     # phrase(x with 'superscript' 2)
+              else:
+              - test:
+                  if: "$NumPrecedingSiblings mod 2 = 0"
+                  then: [T: "indeksu górnego"]    # phrase(x with 'pre-superscript' 2)
+                  else: [T: "indeksu dolnego"]      # phrase(x with 'pre-subscript' 2)
+          - pause: "medium"
+
+# Rules for speaking what happens when moving into or out of a notation
+- name: into-or-out-of-default
+  tag: "*"
+  # saying "out of row n" is not very useful, so skip it
+  # match: "$Move2D != '' and @data-from-mathml and @data-from-mathml != name(.) and count(*)>1 and @data-from-mathml != 'mtable'"
+  match: "$Move2D != '' and not(self::m:math or @data-from-mathml = 'mtable' or  @data-from-mathml = 'mtd') "
+  replace:
+  - with:
+      variables:
+      - PartNumber: "count($Child2D/preceding-sibling::*)"
+      - PartName: "GetNavigationPartName(name(.), $PartNumber)"
+      replace:
+      - test:
+        - if: "$Move2D = 'in'"
+          then: [t: "do"]                            # phrase(move 'in' to a part)
+        - else_if: "$Move2D = 'out of' and starts-with($PartName, 'st')"
+          then: [t: "ze"]                            # "ze stopnia" (eufonia przed 'st')
+        - else_if: "$Move2D = 'out of'"
+          then: [t: "z"]                             # phrase(move 'out of' a part)
+        - else_if: "$Move2D = 'end of'"
+          then: [t: "na koniec"]                     # phrase(move to the 'end of' a part)
+        - else_if: "$Move2D = 'start of'"
+          then: [t: "na początek"]                   # phrase(move to the 'start of' a part)
+          else: [x: "$Move2D"]
+      - test:
+        - if: "$PartName != ''"
+          then: [x: "$PartName"]
+          else:
+          - t: "części"         # phrase(the 'part' of the expression)
+          - x: "count($Child2D/preceding-sibling::*) + 1"
+      - pause: "medium"
+
+- name: default-move
+  # nothing to do (not 2D) -- need to catch $Move2D though so rules based on NavCommand don't trigger
+  tag: "*"
+  match: "$Move2D != ''"
+  replace: []
+
+# ********* Go back to last position ***************
+# This is first since start/end position shouldn't matter
+- name: move-last-location
+
+
+  tag: "*"
+  match: "$NavCommand = 'MoveLastLocation'"
+  replace:
+  - test:
+      if: "$NavVerbosity != 'Terse'"
+      then:
+      - test:
+        - if: "$PreviousNavCommand = 'ZoomIn'"
+          then: [t: "cofnij przybliżenie"]                       # phrase('undo zoom in')
+        - else_if: "$PreviousNavCommand = 'ZoomOut'"
+          then: [t: "cofnij oddalenie"]                      # phrase('undo zoom out')
+        - else_if: "$PreviousNavCommand = 'ZoomInAll'"
+          then: [t: "cofnij maksymalne przybliżenie"]        # phrase('undo zooming in all the way')
+        - else_if: "$PreviousNavCommand = 'ZoomOutAll'"
+          then: [t: "cofnij maksymalne oddalenie"]       # phrase('undo zooming out all the way')
+        - else_if: "$PreviousNavCommand = 'MovePrevious' or $PreviousNavCommand = 'MovePreviousZoom'"
+          then: [t: "cofnij ruch w lewo"]                     # phrase('undo move left')
+        - else_if: "$PreviousNavCommand = 'MoveNext' or $PreviousNavCommand = 'MoveNextZoom'"
+          then: [t: "cofnij ruch w prawo"]                    # phrase('undo move right')
+        - else_if: "$PreviousNavCommand = 'None'"
+          then: [t: "brak poprzedniego polecenia"]                # phrase('no previous command')
+      - pause: "medium"
+  - set_variables: [NavNode: "@id"]
+
+# many times, for typographic reasons, people include punctuation at the end of a math expr
+# these rules detect that and skip speaking it (should be similar regular rule)
+- name: skip-punct-at-end-zoom-in
+  tag: mrow
+  match:
+  - "($NavCommand = 'ZoomIn' or $NavCommand = 'ZoomInAll' or $NavCommand = 'MoveNextZoom' or $NavCommand = 'MovePreviousZoom') and"
+  - " parent::m:math and count(*)=2 and"
+  - " *[2][translate(.,'.,;:?', '')='']"
+  replace:
+  - x: "*[1]"
+
+# ********* ZoomIn  ***************
+- name: zoom-in-leaf
+
+  tag: "*"
+  match: "($NavCommand = 'ZoomIn' or $NavCommand = 'ZoomInAll') and IsNode(., 'leaf')"
+  replace:
+  - test:
+      if: "$MatchCounter = 0 and $NavVerbosity != 'Terse'"
+      then: [t: "maksymalnie przybliżono", pause: "long"]    # phrase('zoomed in all of the way')
+  - test:
+      if: "$ReadZoomLevel!=-1"
+      then:
+      - set_variables: [ReadZoomLevel: "0"]
+  - set_variables: [NavNode: "@id"]
+
+# special case of zooming into a table -- move to the first row (if only one row, first column)
+- name: zoom-in-table
+  tag: "*"
+  match: "$NavCommand = 'ZoomIn' and (name(.) = 'mtable' or (count(*)=1 and *[1][@data-from-mathml='mtable']))"
+  replace:
+  - with:
+      variables: [SayCommand: "string($NavVerbosity = 'Verbose')"]
+      replace: [x: "."]
+  - test:
+      if: "count(*)=1"
+      then: 
+      - set_variables: [NavNode: "*[1]/*[1]/@id"]
+      else:
+      - set_variables: [NavNode: "*[1]/@id"]
+
+- name: zoom-in-mrow-in-math
+  # zooming in only once is meaningless because 'math' has only a single child and it was spoken at the math level -- dig inside and do it again 
+  tag: math
+  match: "$NavCommand = 'ZoomIn' or $NavCommand = 'MoveNextZoom' or $NavCommand = 'MovePreviousZoom'"
+  replace:
+  - test:
+      if: "$NavCommand = 'MovePreviousZoom'"
+      then: [x: "*[last()]"]
+      else: [x: "*[1]"]
+
+- # For msqrt and menclose, if the single child isn't an mrow, don't zoom in
+  name: zoom-in-again
+  # If there is only one child, this isn't an interesting move -- zoom in again
+  tag: "*"
+  match:
+  - "($NavCommand = 'ZoomIn' or "
+  - "  ($NavCommand = 'MoveNextZoom' or $NavCommand = 'MovePreviousZoom') and $NavMode='Enhanced') and "
+  - "count(*)=1 and
+     (*[1][self::m:mrow or @data-from-mathml='mrow'] and
+      not(@data-from-mathml='msqrt' or self::m:msqrt or @data-from-mathml='menclose' or self::m:menclose))"
+  replace:
+  - with:
+      variables: [SayCommand: "string($NavVerbosity = 'Verbose')"]
+      replace: [x: "."]
+  - test:
+      if: "name(*[1]) != 'mrow'"
+      then:
+      - with:
+          variables: [Move2D: "'in'", Child2D: "IfThenElse(count(*)=0, $Move2D, $Move2D)"]   # phrase('in' the denominator)
+          replace: [x: "IfThenElse($NavCommand = 'MovePreviousZoom', 1, $Child2D)"]
+  - test:
+      if: "$NavCommand = 'MovePreviousZoom'"
+      then: [x: "*[last()]"]
+      else: [x: "*[1]"]
+
+- name: zoom-in-enhanced
+  tag: "*"
+  match: "$NavCommand = 'ZoomIn' and $NavMode='Enhanced'"
+  replace:
+  - with:
+      variables: [SayCommand: "string($NavVerbosity = 'Verbose')"]
+      replace: [x: "."]
+  - test:
+    - if: "self::m:mtr or self::m:mlabeledtr"
+      then:
+      - with:
+          variables: [Move2D: "'in'", Child2D: "*[1]/*[1]"]   # phrase('in' the denominator)
+          replace: [x: "."]
+      - set_variables: [NavNode: "*[1]/*[1]/@id"] # skip mtd
+    - else_if: "*[1][self::m:mrow and (IsBracketed(., '(', ')', false) or IsBracketed(., '[', ']', false))]" # auto zoom
+      then:
+      - with:
+          variables: [Move2D: "'in'", Child2D: "*[1]"]   # phrase('in' the denominator)
+          replace: [x: "."]
+      - set_variables: [NavNode: "*[1]/*[2]/@id"]        # skip parens/brackets
+      else:
+      - with:
+          variables: [Move2D: "'in'", Child2D: "*[1]"]        # phrase('in' the denominator)
+          replace: [x: "."]
+      - set_variables: [NavNode: "*[1]/@id"]
+
+
+- name: zoom-in-simple
+  tag: "*"
+  match: "$NavCommand = 'ZoomIn' and $NavMode='Simple'"
+  replace:
+  - with:
+      variables: [SayCommand: "string($NavVerbosity = 'Verbose')"]
+      replace: [x: "."]
+  - test:
+      if: "DEBUG($MatchCounter) > 1 and IsNode(., '2D') "
+      then: [set_variables: [NavNode: "@id"]]   # time to stop, not going "in" to next thing, so before "Move2D"
+      else:
+      - with:
+          variables: [Move2D: "'in'", Child2D: "*[1]"]        # phrase('in' the denominator)
+          replace: [x: "."]
+      - x: "*[1]"
+
+  # At this point, we are zooming in on a non-2D element, non-leaf in Character mode
+- name: zoom-in-2D-character
+  tag: "*"
+  match: "$NavCommand = 'ZoomIn' and (IsNode(., '2D') or not(IsNode(., 'mathml')))"
+  replace:
+  - with:
+      variables: [SayCommand: "string($NavVerbosity = 'Verbose')"]
+      replace: [x: "."]
+  - with:
+      variables: [Move2D: "'in'", Child2D: "*[1]"]          # phrase('in' the denominator)
+      replace: [x: "."]
+  - test:
+      if: "$NavMode = 'Simple'"
+      then:
+      - set_variables: [NavNode: "*[1]/@id"]
+      else:
+      - with:
+          variables: [NavCommand: "'MoveNextZoom'"]
+          replace: [x: "*[1]"]
+
+  # At this point, we are zooming in on a non-2D element, non-leaf in Character mode
+- name: zoom-in-default
+  tag: "*"
+  match: "$NavCommand = 'ZoomIn'"
+  replace:
+  - with:
+      variables: [SayCommand: "string($NavVerbosity = 'Verbose')"]
+      replace: [x: "."]
+  - x: "*[1]"
+
+
+- name: zoom-in-all-default
+  tag: "*"
+  match: "$NavCommand = 'ZoomInAll'"
+  replace:
+  - with:
+      variables: [SayCommand: "string($NavVerbosity = 'Verbose')"]
+      replace: [x: "."]
+  - with:
+      variables: [Move2D: "'in'", Child2D: "*[1]"]              # phrase('in' the denominator)
+      replace: [x: "."]
+  - x: "*[1]"
+
+- name: zoom-out
+  tag: math
+  match: "$NavCommand = 'ZoomOut' or $NavCommand = 'ZoomOutAll'"
+  replace:
+  - with:
+      variables: [SayCommand: "string($NavVerbosity = 'Verbose')"]
+      replace: [x: "."]
+  - set_variables: [NavNode: "*[1]/@id"] # no-op for $NavCommand = 'ZoomOut'
+
+- name: skip-punct-at-end-zoom-out
+  tag: mrow
+  match:
+  - "($NavCommand = 'ZoomOut' or $NavCommand = 'ZoomOutAll') and"
+  - " parent::m:math and count(*)=2 and"
+  - " *[2][translate(.,'.,;:?', '')='']"
+  replace:
+  - x: ".."
+
+- name: zoom-out-top
+  tag: "*"
+  match:
+  - "($NavCommand = 'ZoomOut' or $NavCommand = 'ZoomOutAll') and"
+  - "parent::m:math "
+  replace:
+  - x: ".." # let math rule deal with it
+
+- name: zoom-out-all-default
+  tag: "*"
+  match: "$NavCommand = 'ZoomOutAll'"
+  replace:
+  - with:
+      variables: [SayCommand: "string($NavVerbosity = 'Verbose')"]
+      replace: [x: "."]
+  - with:
+      variables: [Move2D: "'out of'", Child2D: "."]
+      replace: [x: ".."]
+  - x: ".."
+
+# deal with internal zooming: MoveNextZoom and MovePreviousZoom
+
+# start with Enhanced mode
+- name: move-zoom-enhanced
+  tag: "*"
+  match:
+  - "($NavCommand = 'MoveNextZoom' or $NavCommand = 'MovePreviousZoom') and "
+  - "$NavMode = 'Enhanced'"
+  replace:
+  - with:
+      variables: [Move2D: "'in'", Child2D: "*[1]"]            # phrase('in' the denominator)
+      replace: [x: "."]
+  - test:
+    - if: "count(*)> 1 or IsNode(., 'leaf') or
+           @data-from-mathml='msqrt' or self::m:msqrt or @data-from-mathml='menclose' or self::m:menclose"
+      then: [set_variables: [NavNode: "@id"]]
+      else: [x: "*[1]"]
+
+- name: move-next-zoom-not-enhanced
+  # $ReadZoomLevel must be >= 0
+  tag: "*"
+  match: "$NavCommand = 'MoveNextZoom'"
+  replace:
+  #don't bother with MatchCounter since we only get here if > 1
+  - test:
+      if: "IsNode(., 'leaf') or $ReadZoomLevel >= DistanceFromLeaf(., false, $NavMode!='Character')"
+      then:
+      # - with:
+      #     variables: [Move2D: "'in'", Child2D: "following-sibling::*[1]"]    # phrase('in' the denominator)
+      #     replace: [x: ".."]
+      - set_variables: [NavNode: "@id"]
+      else:
+      - with:
+          variables: [Move2D: "'in'", Child2D: "*[1]"]                        # phrase('in' the denominator)
+          replace: [x: "."]
+      - x: "*[1]"
+
+- name: move-previous-zoom-not-enhanced
+  # $ReadZoomLevel must be >= 0
+  tag: "*"
+  match: "$NavCommand = 'MovePreviousZoom'"
+  replace:
+  #don't bother with MatchCounter since we only get here if > 1
+  - test:
+      if: "$ReadZoomLevel >= DistanceFromLeaf(., true, $NavMode!='Character')"
+      then:
+      # - with:
+      #     variables: [Move2D: "'in'", Child2D: "preceding-sibling::*[1]"]     # phrase('in' the denominator)
+      #     replace: [x: ".."]
+      - set_variables: [NavNode: "@id"]
+      else:
+      - with:
+          variables: [Move2D: "'in'", Child2D: "*[last()]"]                     # phrase('in' the denominator)
+          replace: [x: "."]
+      - x: "*[last()]"
+
+# ********* ZoomOut  ***************
+- name: zoom-out-default
+
+
+  tag: mtd
+  match: "$Move2D = '' and ($NavCommand = 'ZoomOut')"
+  replace:
+  - with:
+      variables: [SayCommand: "string($NavVerbosity = 'Verbose')"]
+      replace: [x: "."]
+  # we need to speak it here
+  # - T: "wiersz"                                                  # phrase(the first 'row' of the matrix)
+  #   # if we let the speech rules speak the row, it is given just the MathML for the row, so the row # will always be '1'
+  # - x: "count(../preceding-sibling::*)+1"
+  # - pause: medium
+  - set_variables: [NavNode: "../@id"]
+
+- name: zoom-out
+  # a row around a single element -- these might duplicate the position/offset, so we jump an extra level here  
+  tag: "*"
+  match: "$NavCommand = 'ZoomOut'"
+  replace:
+  - with:
+      variables: [SayCommand: "string($NavVerbosity = 'Verbose')"]
+      replace: [x: "."]
+  - test:
+      if: "$NavMode='Enhanced' and parent::*[self::m:mrow and (IsBracketed(., '(', ')', false) or IsBracketed(., '[', ']', false))]"
+      then: [x: ".."] # auto-zoom: move out a level and retry
+      else:
+      - with:
+          variables: [Move2D: "'out of'", Child2D: "."]
+          replace: [x: ".."]
+      - test:
+          if: "parent::m:mtd"
+          then: [x: ".."]
+          else:
+          - test:
+              if: "$ReadZoomLevel!=-1"
+              then: [set_variables: [ReadZoomLevel: "DistanceFromLeaf(.., true, $NavMode!='Character')"]]
+          - set_variables: [NavNode: "../@id"]
+
+# ********* MoveStart/End  ***************
+- name: math-move-to-start-or-end
+  tag: math
+  match: "$NavCommand = 'MoveStart' or $NavCommand = 'MoveLineStart' or $NavCommand = 'MoveEnd' or $NavCommand = 'MoveLineEnd'"
+  replace:
+  - with:
+      variables: [MatchCounter: "$MatchCounter + 1"]
+      replace:
+      - test:
+          if: "$NavVerbosity = 'Verbose'"
+          then:
+          - test:
+            - if: "$NavCommand = 'MoveStart'"
+              then: [t: "przejdź na początek wyrażenia matematycznego"]                  # phrase('move to start of math')
+            - else_if: "$NavCommand = 'MoveLineStart'"
+              then: [t: "przejdź na początek linii"]                  # phrase('move to start of line')
+            - else_if: "$NavCommand = 'MoveEnd'"
+              then: [t: "przejdź na koniec wyrażenia matematycznego"]                    # phrase('move to end of math')
+              else: [t: "przejdź na koniec linii"] # "$NavCommand = 'MoveLineEnd'"  # phrase('move to end of line')
+          - pause: "medium"
+      - test:
+          if: "$NavCommand = 'MoveStart' or $NavCommand = 'MoveLineStart'"
+          then:
+          # move inside of the mrow inside of 'math' or inside the fraction, etc  (hence two levels down)
+          # Note: an apparent bug in the xpath code doesn't let me use IfThenElse for the 2 if: then: below
+          - with:
+              variables: [NavCommand: "'MoveNextZoom'"]
+              replace:
+              - test:
+                  if: "*[1]/*[1]"    # could be a <math><mi>x</mi></math>, so no grandchild
+                  then: [x: "*[1]/*[1]"]
+                  else: [x: "*[1]"]
+          else:
+          - with:
+              variables: [NavCommand: "'MovePreviousZoom'"]
+              replace:
+              - test:
+                  if: "*[last()]/*[last()]"  # could be a <math><mi>x</mi></math>, so no grandchild
+                  then: [x: "*[last()]/*[last()]"]
+                  else: [x: "*[last()]"]
+
+# We stop when the parent is 2d (e.g., frac), but not if in leaf base of msub/msup/msubsup/mmultiscripts because that's really on the same line
+- name: move-to-start-or-end-2d
+  tag: "*"
+  match:
+  - "($NavCommand = 'MoveLineStart' or $NavCommand = 'MoveLineEnd') and IsNode(.., '2D') and"
+  - "not( IsNode(., 'leaf') and"
+  - "     parent::*[1][self::m:msub or self::m:msup or self::m:msubsup or self::m:mmultiscripts or"
+  - "                 @data-from-mathml and"
+  - "                  (@data-from-mathml='msub' or @data-from-mathml='msup' or"
+  - "                   @data-from-mathml='msubsup' or @data-from-mathml='mmultiscripts')"
+  - "                 ] )"
+  replace:
+  - test:
+      if: "$NavVerbosity = 'Verbose'"
+      then:
+      - test:
+          if: "$NavCommand = 'MoveLineStart'"
+          then: [t: "przejdź na początek linii"]                                # phrase('move to start of line')
+          else: [t: "przejdź na koniec linii"] # "$NavCommand = 'MoveLineEnd'"  # phrase('move to end of line')
+      - pause: "medium"
+  - test:
+      if: "self::m:mrow or @data-from-mathml = 'mrow'"
+      then_test:
+        if: "$NavCommand = 'MoveLineStart'"
+        then:
+        - with:
+            variables: [NavCommand: "'MoveNextZoom'"]
+            replace: [x: "*[1]"]
+        else:
+        - with:
+            variables: [NavCommand: "'MovePreviousZoom'"]
+            replace: [x: "*[last()]"]
+      else: [set_variables: [NavNode: "@id"]]
+
+- name: move-to-start-or-end-default
+  tag: "*"
+  match: "$NavCommand = 'MoveStart' or $NavCommand = 'MoveLineStart' or $NavCommand = 'MoveEnd' or $NavCommand = 'MoveLineEnd'"
+  replace:
+  - with:
+      variables: [MatchCounter: "$MatchCounter + 1"]
+      replace: [x: ".."]
+
+# Table-related movement
+# Typically, we need to zoom out to the mtd level, then we move the appropriate direction
+- name: not-in-table
+
+
+  tag: math
+  match:
+  - "$NavCommand='MoveCellPrevious' or $NavCommand='MoveCellNext' or"
+  - "$NavCommand='MoveCellUp' or $NavCommand='MoveCellDown' or"
+  - "$NavCommand='MoveColumnStart' or $NavCommand='MoveColumnEnd' or"
+  - "$NavCommand='ReadCellCurrent'"
+  replace:
+  - t: "poza tabelą"                               # phrase('not in table')
+  - pause: long
+  - set_variables: [SpeakExpression: "'false'"]
+
+- name: move-cell-previous
+  tag: mtd
+  match: "$NavCommand='MoveCellPrevious'"
+  replace:
+  - test:
+      if: "preceding-sibling::*"
+      then:
+      - test:
+          if: "$NavVerbosity = 'Verbose'"
+          then:
+          - t: "przejdź w lewo"                        # phrase('move left')
+          - pause: short
+      - test:
+          if: "$NavVerbosity != 'Terse'"
+          then:
+          - T: "kolumna"                           # phrase(the first 'column' of the table)
+          - x: "count(preceding-sibling::*)"
+          - pause: medium
+      - test:
+          if: "$NavMode='Character'"
+          then:
+          - with:
+              variables: [NavCommand: "'MovePreviousZoom'"]
+              replace: [x: "preceding-sibling::*[1]"]
+          else:
+          - set_variables: [NavNode: "preceding-sibling::*[1]/*[1]/@id"]
+      else:
+      - t: "brak poprzedniej kolumny"                 # phrase('no previous column' in the table)
+      - set_variables: [SpeakExpression: "'false'"]
+
+- name: move-cell-next
+  tag: mtd
+  match: "$NavCommand='MoveCellNext'"
+  replace:
+  - test:
+      if: "following-sibling::*"
+      then:
+      - test:
+          if: "$NavVerbosity = 'Verbose'"
+          then:
+          - t: "przejdź w prawo"                     # phrase('move right')
+          - pause: short
+      - test:
+          if: "$NavVerbosity != 'Terse'"
+          then:
+          - T: "kolumna"                         # phrase(the first 'column' in the table)
+          - x: "count(preceding-sibling::*)+2"
+          - pause: medium
+      - test:
+          if: "$NavMode='Character'"
+          then:
+          - with:
+              variables: [NavCommand: "'MoveNextZoom'"]
+              replace: [x: "following-sibling::*[1]"]
+          else:
+          - set_variables: [NavNode: "following-sibling::*[1]/*[1]/@id"]
+      else:
+      - t: "brak następnej kolumny"                  # phrase('no next column' in the table)
+      - set_variables: [SpeakExpression: "'false'"]
+
+- name: move-cell-up
+  tag: mtd
+  match: "$NavCommand='MoveCellUp'"
+  replace:
+  - test:
+      if: "../preceding-sibling::*"
+      then:
+      - with:
+          variables: [Column: "count(preceding-sibling::*)+1"] # store this because otherwise the value is used in the wrong context below
+          replace:
+          - test:
+              if: "$NavVerbosity = 'Verbose'"
+              then:
+              - t: "przejdź w górę"                             # phrase('move up' to previous row in the table)
+              - pause: short
+          - test:
+              if: "$NavVerbosity != 'Terse'"
+              then:
+              - T: "wiersz"                                 # phrase(the previous 'row' in the table)
+              - x: "count(../preceding-sibling::*)"
+              - pause: short
+              - T: "kolumna"                              # phrase(the previous 'column' in the table)
+              - x: "count(preceding-sibling::*)+1"
+              - pause: medium
+          - test:
+              if: "$NavMode='Character'"
+              then:
+              - with:
+                  variables: [NavCommand: "'MoveNextZoom'"]
+                  replace: [x: "../preceding-sibling::*[1]/*[$Column]"]
+              else:
+              - set_variables: [NavNode: "../preceding-sibling::*[1]/*[$Column]/*[1]/@id"]
+      else:
+      - t: "brak poprzedniego wiersza"                            # phrase('no previous row' in the table)
+      - set_variables: [SpeakExpression: "'false'"]
+
+- name: move-cell-down
+  tag: mtd
+  match: "$NavCommand='MoveCellDown'"
+  replace:
+  - test:
+      if: "../following-sibling::*"
+      then:
+      - with:
+          variables: [Column: "count(preceding-sibling::*)+1"] # store this because otherwise the value is used in the wrong context below
+          replace:
+          - test:
+              if: "$NavVerbosity = 'Verbose'"
+              then:
+              - t: "przejdź w dół"                          # phrase('move down to the next row in the table)
+              - pause: short
+          - test:
+              if: "$NavVerbosity != 'Terse'"
+              then:
+              - T: "wiersz"                                # phrase(the next 'row' in the table)
+              - x: "count(../preceding-sibling::*)+2"
+              - pause: short
+              - T: "kolumna"                             # phrase(the next 'column' in the table)
+              - x: "count(preceding-sibling::*)+1"
+              - pause: medium
+          - test:
+              if: "$NavMode='Character'"
+              then:
+              - with:
+                  variables: [NavCommand: "'MoveNextZoom'"]
+                  replace: [x: "../following-sibling::*[1]/*[$Column]"]
+              else:
+              - set_variables: [NavNode: "../following-sibling::*[1]/*[$Column]/*[1]/@id"]
+      else:
+      - t: "brak następnego wiersza"                                # phrase('no next row' in the table)
+      - set_variables: [SpeakExpression: "'false'"]
+
+- name: move-cell-up
+  tag: [mtr, mlabeledtr]
+  match: "$NavCommand='MoveCellUp'"
+  replace:
+  - test:
+      if: "$NavVerbosity = 'Verbose'"
+      then:
+      - t: "przejdź do poprzedniego wiersza"                              # phrase('move to previous row' to the previous row in the table)
+      - pause: medium
+  - test:
+      if: "preceding-sibling::*"
+      then:
+      - test:
+          if: "$NavMode='Character'"
+          then:
+          - with:
+              variables: [NavCommand: "'MoveNextZoom'"]
+              replace: [x: "preceding-sibling::*[1]"]
+          else:
+          - set_variables: [NavNode: "preceding-sibling::*[1]/@id"]
+      else:
+      - t: "brak poprzedniego wiersza"                          # phrase('no previous row' in the table)
+      - set_variables: [SpeakExpression: "'false'"]
+
+- name: move-cell-down
+  tag: [mtr, mlabeledtr]
+  match: "$NavCommand='MoveCellDown'"
+  replace:
+  - test:
+      if: "$NavVerbosity = 'Verbose'"
+      then:
+      - t: "przejdź do następnego wiersza"                          # phrase('move to next row' to the next row in the table)
+      - pause: medium
+  - test:
+      if: "following-sibling::*"
+      then:
+      - test:
+          if: "$NavMode='Character'"
+          then:
+          - with:
+              variables: [NavCommand: "'MoveNextZoom'"]
+              replace: [x: "following-sibling::*[1]"]
+          else:
+          - set_variables: [NavNode: "following-sibling::*[1]/@id"]
+      else:
+      - t: "brak następnego wiersza"                          # phrase('no next row' in the table)
+      - set_variables: [SpeakExpression: "'false'"]
+
+- name: move-cell-previous
+  # if a row is selected, there is no previous/next column, so this is trivial
+  tag: [mtr, mlabeledtr]
+  match: "$NavCommand='MoveCellPrevious'"
+  replace:
+  - test:
+      if: "$NavVerbosity = 'Verbose'"
+      then:
+      - t: "przejdź do poprzedniej kolumny"                              # phrase('move to previous column' to the previous row in the table)
+      - pause: medium
+  - t: "brak poprzedniej kolumny"                          # phrase('no previous column' in the table)
+  - set_variables: [SpeakExpression: "'false'"]
+
+- name: move-cell-next
+  # if a row is selected, there is no previous/next column, so this is trivial
+  tag: [mtr, mlabeledtr]
+  match: "$NavCommand='MoveCellNext'"
+  replace:
+  - test:
+      if: "$NavVerbosity = 'Verbose'"
+      then:
+      - t: "przejdź do następnej kolumny"                              # phrase('move up' to the previous row in the table)
+      - pause: medium
+  - t: "brak następnej kolumny"                          # phrase('no next row' in the table)
+  - set_variables: [SpeakExpression: "'false'"]
+
+- name: default-read-cell
+  tag: "*"
+  match: "$NavCommand='ReadCellCurrent'"
+  replace:
+  - with:
+      variables: [MTD: "ancestor::m:mtd"]
+      replace:
+      - test:
+          if: "$MTD"
+          then:
+          - test:
+              if: "$NavVerbosity = 'Verbose'"
+              then:
+              - t: "czytaj bieżący element"                         # phrase('read current entry' in the table)
+              - pause: medium
+          - test:
+              if: "$NavVerbosity != 'Terse'"
+              then:
+              - T: "wiersz"                                        # phrase(the previous 'row' in the table)
+              - x: "count($MTD[1]/../preceding-sibling::*)+1"
+              - pause: short
+              - T: "kolumna"                                     # phrase(the previous 'column' in the table)
+              - x: "count($MTD[1]/preceding-sibling::*)+1"
+              - pause: short
+          - set_variables: [NavNode: "$MTD[1]/*[1]/@id"]
+          else:
+          - t: "poza tabelą"                                   # phrase('not in table' or matrix)
+          - pause: long
+          - set_variables: [SpeakExpression: "'false'"]
+
+# mtd ? ( $NavCommand='MoveColumnStart' )
+# => MoveColStart {
+#       ruleRef = name(^^match);
+#       column = index(match);
+#       ::StartPosition = ^^match[0][index(match)][0].dfs;
+#       ::EndPosition = ^^match[0][index(match)][0].offset;
+#   };
+
+# mtd ? ( $NavCommand='MoveColumnEnd' )
+# => MoveColEnd {
+#       ruleRef = name(^^match);
+#       column = index(match);
+#       ::StartPosition = ^^match[count(^^match)-1][index(match)][0].dfs;
+#       ::EndPosition = ^^match[count(^^match)-1][index(match)][0].offset;
+#   };
+
+
+
+# # Rules for columnar math (mstack and mlongdiv) -- each row is an msrow or mscarries except for the start of mlongdiv
+# # FIX:  not dealing with different number of digits on different lines
+# # FIX:  not dealing with + (etc) on same line if they are on the right side (Dutch, others)
+# # FIX:  not dealing with intervening msline (say it and move on??)
+# # FIX:  not dealing with carries well
+# # FIX:  not dealing with navigation of first three children of mlongdiv
+# char ? ( has_parent(match, 2) && name(^match)=="mn" && name(^^match)=="msrow" &&
+#         ($NavCommand="MovePrevious" || $NavCommand='MoveCellPrevious') && has_previous(match) )
+# => MoveCell {
+#       ruleRef = name(^^match);
+#       wordRef = "previous";
+#       ::StartPosition = previous(match).dfs;
+#       ::EndPosition = previous(match).offset;
+#   };
+
+# # no previous child -- in first column -- don't move
+# char ? ( has_parent(match, 2) && name(^match)=="mn" && name(^^match)=="msrow" &&
+#         ($NavCommand="MovePrevious" || $NavCommand='MoveCellPrevious' ) )
+# => MoveCell {
+#       ruleRef = name(^^match);
+#       wordRef = "previous";
+#       childIndex = -1;                   # key to know what to say for each notation
+#       ::SpeakAfterMove = false;
+#   };
+
+# char ? ( has_parent(match, 2) && name(^match)=="mn" && name(^^match)=="msrow" &&
+#         ($NavCommand="MoveNext" || $NavCommand='MoveCellNext') && has_next(match) )
+# => MoveCell {
+#       ruleRef = name(^^match);
+#       wordRef = "next";
+#       ::StartPosition = next(match).dfs;
+#       ::EndPosition = next(match).offset;
+#   };
+
+# # no next child -- in first column -- don't move
+# char ? ( has_parent(match, 2) && name(^match)=="mn" && name(^^match)=="msrow" &&
+#         ($NavCommand="MoveNext" || $NavCommand='MoveCellNext' ) )
+# => MoveCell {
+#       ruleRef = name(^^match);
+#       wordRef = "next";
+#       childIndex = -1;                   # key to know what to say for each notation
+#       ::SpeakAfterMove = false;
+#   };
+
+# char ? ( has_parent(match, 2) && name(^match)=="mn" && name(^^match)=="msrow" &&
+#         $NavCommand='MoveCellUp' && has_previous(^^match) )
+# => MoveCell {
+#       ruleRef = name(^^match);
+#       wordRef = "up";
+#       ::StartPosition = ^^^match[index(^^match)-1][-1][index(match)-count(^match)].dfs;
+#       ::EndPosition = ^^^match[index(^^match)-1][-1][index(match)-count(^match)].offset;
+#   };
+
+# # no previous child -- in first column -- don't move
+# char ? ( has_parent(match, 2) && name(^match)=="mn" && name(^^match)=="msrow" &&
+#         $NavCommand='MoveCellUp' )
+# => MoveCell {
+#       ruleRef = name(^^match);
+#       wordRef = "up";
+#       childIndex = -1;                   # key to know what to say for each notation
+#       ::SpeakAfterMove = false;
+#   };
+
+# char ? ( has_parent(match, 2) && name(^match)=="mn" && name(^^match)=="msrow" &&
+#         $NavCommand='MoveCellDown' && has_next(^^match) )
+# => MoveCell {
+#       ruleRef = name(^^match);
+#       wordRef = "down";
+#       ::StartPosition = ^^^match[index(^^match)+1][-1][index(match)-count(^match)].dfs;
+#       ::EndPosition = ^^^match[index(^^match)+1][-1][index(match)-count(^match)].offset;
+#   };
+
+# # no previous child -- in first column -- don't move
+# char ? ( has_parent(match, 2) && name(^match)=="mn" && name(^^match)=="msrow" &&
+#         $NavCommand='MoveCellDown' )
+# => MoveCell {
+#       ruleRef = name(^^match);
+#       wordRef = "down";
+#       childIndex = -1;                   # key to know what to say for each notation
+#       ::SpeakAfterMove = false;
+#   };
+
+# char ? ( has_parent(match, 2) && name(^match)=="mn" && name(^^match)=="msrow" &&
+#           $NavCommand='MoveColumnStart' )
+# => MoveColStart {
+#       ruleRef = name(^^match);
+#       column = index(match);
+#       ::StartPosition = ^^^match[0][-1][index(match)-count(^match)].dfs;
+#       ::EndPosition = ^^^match[0][-1][index(match)-count(^match)].offset;
+#   };
+
+# char ? ( has_parent(match, 2) && name(^match)=="mn" && name(^^match)=="msrow" &&
+#           $NavCommand='MoveColumnEnd' )
+# => MoveColEnd {
+#       ruleRef = name(^^match);
+#       column = index(match);
+#       ::StartPosition = ^^^match[count(^^^match)-1][-1][index(match)-count(^match)].dfs;
+#       ::EndPosition = ^^^match[count(^^^match)-1][-1][index(match)-count(^match)].offset;
+#   };
+
+# any ? ( (name(match)=="mn" || name(match)=="none") &&
+#         has_parent(match) && name(^match)=="mscarries" &&
+#         ($NavCommand="MovePrevious" || $NavCommand='MoveCellPrevious') && has_previous(match) )
+# => MoveCell {
+#       ruleRef = name(^match);
+#       wordRef = "previous";
+#       ::StartPosition = previous(match).dfs;
+#       ::EndPosition = previous(match).offset;
+#   };
+
+# # no previous child -- in first column -- don't move
+# any ? ( (name(match)=="mn" || name(match)=="none") &&
+#         has_parent(match) && name(^match)=="mscarries" &&
+#         ($NavCommand="MovePrevious" || $NavCommand='MoveCellPrevious') )
+# => MoveCell {
+#       ruleRef = name(^match);
+#       wordRef = "previous";
+#       childIndex = -1;                   # key to know what to say for each notation
+#       ::SpeakAfterMove = false;
+#   };
+
+# any ? ( (name(match)=="mn" || name(match)=="none") &&
+#         has_parent(match) && name(^match)=="mscarries" &&
+#         ($NavCommand="MoveNext" || $NavCommand='MoveCellNext') && has_next(match) )
+# => MoveCell {
+#       ruleRef = name(^match);
+#       wordRef = "next";
+#       ::StartPosition = next(match).dfs;
+#       ::EndPosition = next(match).offset;
+#   };
+
+# # no next child -- in last column -- don't move
+# any ? ( (name(match)=="mn" || name(match)=="none") &&
+#         has_parent(match) && name(^match)=="mscarries" &&
+#         ($NavCommand="MoveNext" || $NavCommand='MoveCellNext') )
+# => MoveCell {
+#       ruleRef = name(^match);
+#       wordRef = "next";
+#       childIndex = -1;                   # key to know what to say for each notation
+#       ::SpeakAfterMove = false;
+#   };
+
+# any ? ( (name(match)=="mn" || name(match)=="none") &&
+#         has_parent(match) && name(^match)=="mscarries" &&
+#         $NavCommand='MoveCellUp' && has_previous(^match) )
+# => MoveCell {
+#       ruleRef = name(^match);
+#       wordRef = "up";
+#       ::StartPosition = ^^match[index(^match)-1][index(match)-count(^match)].dfs;
+#       ::EndPosition = ^^match[index(^match)-1][index(match)-count(^match)].offset;
+#   };
+
+# # no previous child -- in first row -- don't move
+# any ? ( (name(match)=="mn" || name(match)=="none") &&
+#         has_parent(match) && name(^match)=="mscarries" &&
+#         $NavCommand='MoveCellUp' )
+# => MoveCell {
+#       ruleRef = name(^match);
+#       wordRef = "up";
+#       childIndex = -1;                   # key to know what to say for each notation
+#       ::SpeakAfterMove = false;
+#   };
+
+# any ? ( (name(match)=="mn" || name(match)=="none") &&
+#         has_parent(match) && name(^match)=="mscarries" &&
+#         $NavCommand='MoveCellDown' && has_next(^match) )
+# => MoveCell {
+#       ruleRef = name(^match);
+#       wordRef = "down";
+#       ::StartPosition = ^^match[index(^match)+1][-1][index(match)-count(^match)].dfs;
+#       ::EndPosition = ^^match[index(^match)+1][-1][index(match)-count(^match)].offset;
+#   };
+
+# # no next child -- in last row -- don't move
+# any ? ( (name(match)=="mn" || name(match)=="none") &&
+#         has_parent(match) && name(^match)=="mscarries" &&
+#         $NavCommand='MoveCellDown' )
+# => MoveCell {
+#       ruleRef = name(^match);
+#       wordRef = "down";
+#       childIndex = -1;                   # key to know what to say for each notation
+#       ::SpeakAfterMove = false;
+#   };
+
+# mn ? ( has_parent(match, 2) && name(^match)=="mn" && name(^^match)=="msrow" &&
+#           $NavCommand='MoveColumnStart' )
+# => MoveColStart {
+#       ruleRef = name(^^match);
+#       column = index(match);
+#       ::StartPosition = ^^^match[0][-1][index(match)-count(^match)].dfs;
+#       ::EndPosition = ^^^match[0][-1][index(match)-count(^match)].offset;
+#   };
+
+# mn ? ( has_parent(match, 2) && name(^match)=="mn" && name(^^match)=="msrow" &&
+#           $NavCommand='MoveColumnEnd' )
+# => MoveColEnd {
+#       ruleRef = name(^^match);
+#       column = index(match);
+#       ::StartPosition = ^^^match[count(^^^match)-1][-1][index(match)-count(^match)].dfs;
+#       ::EndPosition = ^^^match[count(^^^match)-1][-1][index(match)-count(^match)].offset;
+#   };
+
+
+
+- name: default-cell-move
+
+  tag: "*"
+  match:
+  - "$NavCommand='MoveCellPrevious' or $NavCommand='MoveCellNext' or"
+  - "$NavCommand='MoveCellUp' or $NavCommand='MoveCellDown' or"
+  - "$NavCommand='MoveColumnStart' or $NavCommand='MoveColumnEnd' or"
+  - "$NavCommand='ReadCellCurrent'"
+  replace:
+  - test:
+      if: "ancestor::m:mtd"
+      then:
+      - x: "ancestor::m:mtd[1]" # try again on an mtd node
+      else:
+      - t: "poza tabelą"                                               # phrase('not in table' or matrix)
+      - pause: long
+      - set_variables: [SpeakExpression: "'false'"]
+
+# ========  Move/Read/Describe Next rules =================
+
+# skip 'none'
+- name: move-next-none
+  tag: [none, mprescripts]
+  match: 
+  - "($NavCommand = 'MoveNext' or $NavCommand = 'ReadNext' or $NavCommand = 'DescribeNext' or $NavCommand = 'DescribePrevious' or $NavCommand = 'MoveNextZoom') and"
+  - "parent::*[1][name(.)='mmultiscripts'] and following-sibling::*"
+  replace:
+  - with:
+      variables: [Following: "following-sibling::*[1]"]
+      replace:
+      # two 'none's in a row -- move over and try again; one 'none', zoom in on next 
+      - test:
+          if: "$Following[name(.)='none']"
+          then: [x: "$Following"]
+          else:
+          - with:
+              variables: [Move2D: "'in'", Child2D: "$Following"]        # phrase('in' the denominator)
+              replace: [x: ".."]
+          - with:
+              variables: [NavCommand: "'MoveNextZoom'"]
+              replace: [x: "$Following"]
+
+# skip 'none'
+- name: move-previous-none
+  tag: [none, mprescripts]
+  match: 
+  - "($NavCommand = 'MovePrevious' or $NavCommand = 'ReadPrevious' or $NavCommand = 'DescribePrevious' or $NavCommand = 'MovePreviousZoom') and"
+  - "parent::*[1][name(.)='mmultiscripts'] and preceding-sibling::*"
+  replace:
+  - with:
+      variables: [Preceding: "preceding-sibling::*[1]"]
+      replace:
+      # two 'none's in a row -- move over and try again; one 'none', zoom in on preceding 
+      - test:
+          if: "$Preceding[name(.)='none']"
+          then: [x: "$Preceding"]
+          else:
+          - with:
+              variables: [Move2D: "'in'", Child2D: "$Preceding"]          # phrase('in' the denominator)
+              replace: [x: ".."]
+          - with:
+              variables: [NavCommand: "'MovePreviousZoom'"]
+              replace: [x: "$Preceding"]
+
+
+
+# skip invisible chars except for Enhanced mode when "times" should be read
+- name: move-next-invisible
+  tag: "*"
+  match:
+  - "($NavCommand = 'MoveNext' or $NavCommand = 'ReadNext' or $NavCommand = 'DescribeNext') and"
+  - "following-sibling::*[1][name(.)='mo' and translate(., '\u2061\u2062\u2063\u2064', '')='']"
+  replace:
+  - with:
+      variables: [SayCommand: "string($NavVerbosity = 'Verbose')"]
+      replace: [x: "."]
+  - test:
+      if: "following-sibling::*[1][.='\u2062' or .='\u2064'] and
+           ($NavMode='Enhanced' or ($NavMode='Simple' and following-sibling::*[2][not(IsNode(., 'mathml'))]))"   # invisible times and plus
+      then: [set_variables: [NavNode: "following-sibling::*[1]/@id"]]
+      else: [x: "following-sibling::*[1]"]
+
+- name: move-next-no-auto-zoom-at-edge
+  # at edge of 2D and in a mode where moving right isn't an option
+  tag: "*"
+  variables: [EdgeNode: "EdgeNode(., 'right', '2D')"]
+  match: "$NavCommand = 'MoveNext' and $NavMode!='Character' and not($AutoZoomOut) and $EdgeNode/@id!=@id"
+  replace:
+  - test:
+      if: "$MatchCounter = 0 and $NavVerbosity = 'Verbose'"
+      then:
+      - t: "nie można przejść w prawo"                              # phrase('cannot move right')
+      - pause: medium
+  - with:
+      variables:
+      - Move2D: "'end of'"
+      - Child2D: "$EdgeNode/*[last()]"
+      - MatchCounter: $MatchCounter + 1
+      replace: [x: "$EdgeNode"]
+  - pause: long
+  - set_variables: [SpeakExpression: "'false'"]
+
+- name: move-next-no-auto-zoom-at-edge-math
+  # at edge of math -- no where to go (must be after we rule out being at the edge of 2D) because we want to speak that
+  tag: "*"
+  match:
+  - "($NavCommand = 'MoveNext' or $NavCommand = 'ReadNext' or $NavCommand = 'DescribeNext') and"
+  - "(self::m:math or name(EdgeNode(., 'right', 'math'))='math')" # at edge of math
+  replace:
+  - test:
+      if: "$MatchCounter = 0 and $NavVerbosity = 'Verbose'"
+      then:
+      - t: "nie można"                                          # phrase('cannot' move right in expression)
+      - test:
+        - if: "$NavCommand = 'MoveNext'"
+          then: [t: "przejść"]                                  # phrase('move' to next entry in table)     
+        - else_if: "$NavCommand = 'ReadNext'"
+          then: [t: "odczytać"]                                  # phrase('read' next entry in table)     
+          else: [t: "opisać"]                              # phrase('describe' next entry in table)     
+      - t: "w prawo"                              # phrase(move 'right')
+      - pause: short
+  - T: "koniec matematyki"                              # phrase(move 'end of math')
+  - pause: long
+  - set_variables: [SpeakExpression: "'false'"]
+
+- name: move-next-auto-zoom-up-one-level
+  # Last child or in auto-zoom'd in-- move up a level and try again 
+  # Note: we've already checked the for the case where we are at an edge and should not AutoZoomOut
+  tag: "*"
+  match:
+  - "($NavCommand = 'MoveNext' or $NavCommand = 'ReadNext' or $NavCommand = 'DescribeNext') and"
+  - "( not(following-sibling::*) or"
+  - "  ( $NavMode='Enhanced' and "
+  - "    count(following-sibling::*)=1 and (IsBracketed(.., '(', ')') or IsBracketed(.., '[', ']'))"
+  - "  )"
+  - ")"
+  replace:
+  - with:
+      variables: [SayCommand: "string($NavVerbosity = 'Verbose')"]
+      replace: [x: "."]
+  - test:
+      if: "following-sibling::*"
+      then:
+      - with:
+          variables: [Move2D: "'in'", Child2D: "."]             # phrase('in' the denominator)
+          replace: [x: ".."]
+      else:
+      - with:
+          variables: [Move2D: "'out of'", Child2D: "."]
+          replace: [x: ".."]
+  - x: ".."
+
+# At this point, if XXXNext, then we know there is must be a right sibling
+- name: move-next-default
+  tag: mtd
+  match: "$Move2D = '' and ($NavCommand = 'MoveNext' or $NavCommand = 'ReadNext' or $NavCommand = 'DescribeNext')"
+  replace:
+  - with:
+      variables: [SayCommand: "string($NavVerbosity = 'Verbose')"]
+      replace: [x: "."]
+  - test:
+      if: "following-sibling::*"
+      then:
+      - test:
+          if: "$NavVerbosity = 'Verbose'"
+          then:
+          - T: "kolumna"                                       # phrase(the previous 'column' in the table)
+          - x: "count(preceding-sibling::*)+2"
+          - pause: short
+      - test:
+          if: "$NavMode = 'Character'"
+          then:
+          - with:
+              variables: [NavCommand: "'MoveNextZoom'"]
+              replace: [x: "following-sibling::*[1]"]
+          else: [set_variables: [NavNode: "following-sibling::*[1]/*[1]/@id"]]
+      else:
+      - x: ".." # try again at the row level
+
+- name: move-next-default
+  tag: [mtr, mlabeledtr]
+  match: "$Move2D = '' and
+          ($NavCommand = 'MoveNext' or $NavCommand = 'ReadNext' or $NavCommand = 'DescribeNext') and
+          following-sibling::*"
+  replace:
+  - with:
+      variables: [SayCommand: "string($NavVerbosity = 'Verbose')"]
+      replace: [x: "."]
+  - test:
+      if: "$NavMode = 'Character'"
+      then:
+      - with:
+          variables: [NavCommand: "'MoveNextZoom'"]
+          replace: [x: "following-sibling::*[1]"]
+      else:
+      - set_variables: [NavNode: "following-sibling::*[1]/@id"]
+
+- name: move-next-auto-zoom-parens
+  # auto-zoom into next child if next child is parenthesized expr
+  tag: "*"
+  match:
+  - "($NavCommand = 'MoveNext' or $NavCommand = 'ReadNext' or $NavCommand = 'DescribeNext') and"
+  - "$NavMode='Enhanced' and"
+  - "parent::m:mrow and following-sibling::* and"
+  - "following-sibling::*[1][self::m:mrow and count(*)=3 and " #exclude empty parens
+  - "                        (IsBracketed(., '(', ')') or IsBracketed(., '[', ']'))"
+  - "                       ]"
+  replace:
+  - with:
+      variables: [SayCommand: "string($NavVerbosity = 'Verbose')"]
+      replace: [x: "."]
+  - set_variables: [NavNode: "following-sibling::*[1]/*[2]/@id"]
+
+# normal cases for MoveNext
+- name: move-next-locked-zoom-level
+  # locked zoom level
+  tag: "*"
+  match:
+  - "($NavCommand = 'MoveNext' or $NavCommand = 'ReadNext' or $NavCommand = 'DescribeNext') and"
+  - "$ReadZoomLevel>=0"
+  replace:
+  - with:
+      variables: [SayCommand: "string($NavVerbosity = 'Verbose')"]
+      replace: [x: "."]
+  - test:
+      # if in base (nothing before), we must be moving to a script, so "in" will be said
+      if: "preceding-sibling::* and following-sibling::*[1][name(.)='none']"
+      then:
+      - with:
+          variables: [Move2D: "'out of'", Child2D: "."]
+          replace: [x: ".."]
+      - x: "following-sibling::*[1]"
+      else:
+      - with:
+          variables: [Move2D: "'in'", Child2D: "following-sibling::*[1]"]       # phrase('in' the denominator)
+          replace: [x: ".."]
+      - with:
+          variables: [NavCommand: "'MoveNextZoom'"]
+          replace: [x: "following-sibling::*[1]"]
+
+- name: move-next-default
+  tag: "*"
+  match: "$NavCommand = 'MoveNext' or $NavCommand = 'ReadNext' or $NavCommand = 'DescribeNext'"
+  replace:
+  - with:
+      variables: [SayCommand: "string($NavVerbosity = 'Verbose')"]
+      replace: [x: "."]
+  - test:
+      if: "following-sibling::*[1][@data-from-mathml='none' or @data-from-mathml='mprescripts']"
+      then: [x: "following-sibling::*[1]"]
+      else:
+      - test:
+          if: "IsNode(.., '2D') or not(IsNode(.., 'mathml'))"
+          then:
+          - with:
+              variables: [Move2D: "'in'", Child2D: "following-sibling::*[1]"]           # phrase('in' the denominator)
+              replace: [x: ".."]
+      - set_variables: [NavNode: "following-sibling::*[1]/@id"]
+
+# ========  Move/Read/Describe Previous rules =================
+
+# skip invisible chars except for Enhanced mode when "times" should be read
+- name: move-previous-invisible
+  tag: "*"
+  match:
+  - "($NavCommand = 'MovePrevious' or $NavCommand = 'ReadPrevious' or $NavCommand = 'DescribePrevious') and"
+  - "preceding-sibling::*[1][name(.)='mo' and translate(., '\u2061\u2062\u2063\u2064', '')='']"
+  replace:
+  - with:
+      variables: [SayCommand: "string($NavVerbosity = 'Verbose')"]
+      replace: [x: "."]
+  - test:
+      if: "preceding-sibling::*[1][.='\u2062' or .='\u2064'] and $NavMode='Enhanced'"   # invisible times and plus
+      then: [set_variables: [NavNode: "preceding-sibling::*[1]/@id"]]
+      else: [x: "preceding-sibling::*[1]"]
+
+# two rules for when can't move left
+- name: move-previous-no-auto-zoom-at-edge
+  # at edge of 2D and in a mode where moving left isn't an option
+  tag: "*"
+  variables: [EdgeNode: "EdgeNode(., 'left', '2D')"]
+  match: "$NavCommand = 'MovePrevious' and $NavMode!='Character' and not($AutoZoomOut) and $EdgeNode/@id!=@id"
+  replace:
+  - test:
+      if: "$MatchCounter = 0 and $NavVerbosity = 'Verbose' and $NavCommand = 'MovePrevious'"
+      then:
+      - t: "nie można przejść w lewo"                                   # phrase('cannot move left' in expression)
+      - pause: medium
+  - with:
+      variables:
+      - Move2D: "'end of'"
+      - Child2D: "$EdgeNode/*[1]"
+      - MatchCounter: $MatchCounter + 1
+      replace: [x: "$EdgeNode"]
+  - pause: long
+
+- name: move-previous-no-auto-zoom-at-edge-of-math
+  # at edge of math -- no where to go (must be after we rule out being at the edge of 2D) because we want to speak that
+  tag: "*"
+  match:
+  - "($NavCommand = 'MovePrevious' or $NavCommand = 'ReadPrevious' or $NavCommand = 'DescribePrevious') and"
+  - "(self::m:math or name(EdgeNode(., 'left', 'math'))='math')"
+  replace:
+  - t: "początek wyrażenia matematycznego"                                              # phrase('start of math')
+  - pause: long
+  - set_variables: [SpeakExpression: "'false'"]
+
+- name: move-previous-at-end
+  tag: "*"
+  match:
+  - "($NavCommand = 'MovePrevious' or $NavCommand = 'ReadPrevious' or $NavCommand = 'DescribePrevious') and"
+  - "name(EdgeNode(., 'left', 'math'))='math'" # at edge of math
+  replace:
+  - test:
+      if: "$MatchCounter = 0 and $NavVerbosity = 'Verbose'"
+      then:
+      - t: "nie można przejść w lewo"                      # phrase('cannot move left')
+      - pause: short
+  - with:
+      variables: [Move2D: "'start of'", Child2D: "."]
+      replace: [x: "."]
+  - pause: long
+  - set_variables: [SpeakExpression: "'false'"]
+
+- name: move-previous-auto-zoom-up-one-level
+  # Last child or in auto-zoom'd in-- move up a level and try again 
+  # Note: we've already checked the for the case where we are at an edge and should not AutoZoomOut
+  tag: "*"
+  match:
+  - "($NavCommand = 'MovePrevious' or $NavCommand = 'ReadPrevious' or $NavCommand = 'DescribePrevious') and"
+  - "( not(preceding-sibling::*) or"
+  - "  ( $NavMode='Enhanced' and "
+  - "    count(preceding-sibling::*)=1 and (IsBracketed(.., '(', ')') or IsBracketed(.., '[', ']'))"
+  - "  )"
+  - ")"
+  replace:
+  - with:
+      variables: [SayCommand: "string($NavVerbosity = 'Verbose')"]
+      replace: [x: "."]
+  - test:
+      if: "preceding-sibling::*"
+      then:
+      - with:
+          variables: [Move2D: "'in'", Child2D: "."]             # phrase('in' the denominator)
+          replace: [x: ".."]
+      else:
+      - with:
+          variables: [Move2D: "'out of'", Child2D: "."]
+          replace: [x: ".."]
+  - x: ".."
+
+- name: move-previous-auto-zoom-parens
+  # auto-zoom into previous child if previous child is parenthesized expr
+  # Note: there is an asymmetry here from MoveNext because the base of a scripted might have parens for grouping, but not true for the script
+  tag: "*"
+  match:
+  - "($NavCommand = 'MovePrevious' or $NavCommand = 'ReadPrevious' or $NavCommand = 'DescribePrevious') and"
+  - "$NavMode='Enhanced' and"
+  - "preceding-sibling::* and"
+  - "(parent::m:mrow or parent::m:msub or parent::m:msup or"
+  - " (count(preceding-sibling::*)=1 and (parent::m:msubsup or parent::m:mmultiscripts))"  # make sure moving into base
+  - ") and"
+  - "preceding-sibling::*[1][self::m:mrow and count(*)=3 and " #exclude empty parens
+  - "       (IsBracketed(., '(', ')') or IsBracketed(., '[', ']'))"
+  - "   ]"
+  replace:
+  - with:
+      variables: [SayCommand: "string($NavVerbosity = 'Verbose')"]
+      replace: [x: "."]
+  - test:
+      if: "not(parent::m:mrow)"
+      then:
+      - with:
+          variables: [Move2D: "'in'", Child2D: "preceding-sibling::*[1]"]         # phrase('in' the denominator)
+          replace: [x: ".."]
+  - set_variables: [NavNode: "preceding-sibling::*[1]/*[2]/@id"]
+
+# normal cases for MovePrevious
+
+- name: move-previous-default
+  tag: mtd
+  match: "$Move2D = '' and
+          ($NavCommand = 'MovePrevious' or $NavCommand = 'ReadPrevious' or $NavCommand = 'DescribePrevious') and
+          preceding-sibling::*"
+  replace:
+  - with:
+      variables: [SayCommand: "string($NavVerbosity = 'Verbose')"]
+      replace: [x: "."]
+  - test:
+      if: "$NavVerbosity = 'Verbose'"
+      then:
+      - T: "kolumna"                               # phrase(the first 'column' in the table)
+      - x: "count(preceding-sibling::*)"
+      - pause: short
+  - test:
+      if: "$NavMode = 'Character'"
+      then:
+      - with:
+          variables: [NavCommand: "'MovePreviousZoom'"]
+          replace: [x: "preceding-sibling::*[1]"]
+      else: [set_variables: [NavNode: "preceding-sibling::*[1]/*[last()]/@id"]]
+
+- name: move-previous-default
+  tag: [mtr, mlabeledtr]
+  match: "$Move2D = '' and ($NavCommand = 'MovePrevious' or $NavCommand = 'ReadPrevious' or $NavCommand = 'DescribePrevious')"
+  replace:
+  - with:
+      variables: [SayCommand: "string($NavVerbosity = 'Verbose')"]
+      replace: [x: "."]
+  - test:
+      if: "preceding-sibling::*"
+      then:
+      - test:
+          if: "$NavMode = 'Character'"
+          then:
+          - with:
+              variables: [NavCommand: "'MovePreviousZoom'"]
+              replace: [x: "preceding-sibling::*[1]"]
+          else:
+          - set_variables: [NavNode: "preceding-sibling::*[1]/@id"]
+      else: [x: ".."] # try again for after
+
+- name: move-previous-locked-zoom-level
+  # locked zoom level
+  tag: "*"
+  match:
+  - "($NavCommand = 'MovePrevious' or $NavCommand = 'ReadPrevious' or $NavCommand = 'DescribePrevious') and"
+  - "$ReadZoomLevel>=0"
+  replace:
+  - with:
+      variables: [SayCommand: "string($NavVerbosity = 'Verbose')"]
+      replace: [x: "."]
+  - test:
+      # if moving into base (nothing before), we must be moving to the base, so "in" will be said
+      if: "count(preceding-sibling::*) > 2 and preceding-sibling::*[1][name(.)='none']"
+      then:
+      - with:
+          variables: [Move2D: "'out of'", Child2D: "."]
+          replace: [x: ".."]
+      - x: "preceding-sibling::*[1]"          # skip over 'none'
+      else:
+      - with:
+          variables: [Move2D: "'in'", Child2D: "preceding-sibling::*[1]"]               # phrase('in' the denominator)
+          replace: [x: ".."]
+      - with:
+          variables: [NavCommand: "'MovePreviousZoom'"]
+          replace: [x: "preceding-sibling::*[1]"]
+
+- name: move-previous-default
+  tag: "*"
+  match: "$NavCommand = 'MovePrevious' or $NavCommand = 'ReadPrevious' or $NavCommand = 'DescribePrevious'"
+  replace:
+  - with:
+      variables: [SayCommand: "string($NavVerbosity = 'Verbose')"]
+      replace: [x: "."]
+  - test:
+      if: "preceding-sibling::*[1][@data-from-mathml='none' or @data-from-mathml='mprescripts']"
+      then: [x: "preceding-sibling::*[1]"]
+      else:
+      - test:
+          if: "IsNode(.., '2D') or not(IsNode(.., 'mathml'))"
+          then:
+          - with:
+              variables: [Move2D: "'in'", Child2D: "preceding-sibling::*[1]"]           # phrase('in' the denominator)
+              replace: [x: ".."]
+      - set_variables: [NavNode: "preceding-sibling::*[1]/@id"]
+
+# ********* ReadZoomLevel toggle ***************
+# These set ::NavMode
+
+- name: toggle-mode-up
+  tag: "*"
+  match: "$NavCommand = 'ToggleZoomLockUp'"
+  replace:
+  - test:
+    - if: "$NavMode = 'Enhanced'"
+      then:
+      - t: "znak"                                                # phrase(a mathematical 'character')
+      - set_variables: [NavMode: "'Character'", ReadZoomLevel: "1"]
+    - else_if: "$NavMode = 'Character'"
+      then:
+      - t: "prosty"                                                   # phrase(a 'simple' way to do something)
+      - set_variables: [NavMode: "'Simple'", ReadZoomLevel: "1"]
+    - else:
+      - t: "rozszerzony"                                                 # phrase(an 'enhanced' way to do something)
+      - set_variables: [NavMode: "'Enhanced'", ReadZoomLevel: "-1"]
+  - t: "tryb"                                                         # phrase(a simple 'mode' of use)
+  - pause: long
+  - test:
+    - if: "$NavMode != 'Enhanced'" # potentially need to zoom to the sibling
+      then:
+      - with:
+          variables: [MatchCounter: "$MatchCounter + 1", NavCommand: "'MoveNextZoom'"]
+          replace: [x: "."]
+
+- name: toggle-mode-down
+  tag: "*"
+  match: "$NavCommand = 'ToggleZoomLockDown'"
+  replace:
+  - test:
+    - if: "$NavMode = 'Enhanced'"
+      then:
+      - t: "prosty"                                                 # phrase(an 'simple' way to do something)
+      - set_variables: [NavMode: "'Simple'", ReadZoomLevel: "1"]
+    - else_if: "$NavMode = 'Character'"
+      then:
+      - t: "rozszerzony"                                               # phrase(an 'enhanced' way to do something)
+      - set_variables: [NavMode: "'Enhanced'", ReadZoomLevel: "-1"]
+    - else:
+      - t: "znak"                                              # phrase(a mathematical 'character')
+      - set_variables: [NavMode: "'Character'", ReadZoomLevel: "1"]
+  - t: "tryb"                                                       # phrase(a simple 'mode' of use)
+  - pause: long
+  - test:
+    - if: "$NavMode != 'Enhanced'" # potentially need to zoom to the sibling
+      then:
+      - with:
+          variables: [MatchCounter: "$MatchCounter + 1", NavCommand: "'MoveNextZoom'"]
+          replace: [x: "."]
+
+- name: toggle-speech-describe
+  tag: "*"
+  match: "$NavCommand = 'ToggleSpeakMode'"
+  replace:
+  - test:
+      if: "$Overview = 'true'"
+      then:
+      - t: "czytaj wyrażenie po ruchu"                # phrase('speak expression after move')
+      - pause: long
+      - set_variables: [Overview: "'false'"]
+      else:
+      - T: "przegląd wyrażenia po ruchu"          # phrase('overview of expression after move')
+      - pause: long
+      - set_variables: [Overview: "'true'"]
+
+- name: current
+  tag: "*"
+  match: "$NavCommand = 'ReadCurrent' or $NavCommand = 'DescribeCurrent'"
+  replace:
+  - test:
+      if: "$NavVerbosity = 'Verbose'"
+      then:
+      - test:
+        - if: "$NavCommand = 'ReadCurrent'"
+          then: [t: "czytaj"]                                  # phrase('read' next entry in table) 
+          else: [t: "opisz"]                              # phrase('describe' next entry in table)     
+      - t: "bieżący"                                         # phrase('current' entry in table)
+      - pause: long
+  - set_variables: [NavNode: "@id"]
+
+# this needs to be near the end because we only test for 'Describe', "Read", etc., and we don't want to get 'DescribeNext', etc.
+- name: placemarker
+
+  tag: "*"
+  match:
+  - "starts-with($NavCommand, 'Read') or "
+  - "starts-with($NavCommand, 'Describe') or "
+  - "starts-with($NavCommand, 'MoveTo')"
+  replace:
+  - test:
+      if: "$NavVerbosity != 'Terse'"
+      then:
+      - test:
+        - if: "starts-with($NavCommand, 'Read')"
+          then: [t: "czytaj"]                                  # phrase('read' next entry in table)     
+        - else_if: "starts-with($NavCommand, 'Describe')"
+          then: [t: "opisz"]                              # phrase('describe' next entry in table)     
+        - else_if: "starts-with($NavCommand, 'MoveTo')"
+          then: [t: "przejdź do"]                              # phrase('move to' the next entry in table) 
+          else: [T: "zbiór"]                                   # phrase('set' the value of the next entry in table) 
+      - t: "symbol zastępczy"                                     # phrase('placeholder' for the value)
+      - x: "$PlaceMarkerIndex"
+      - pause: long
+  - set_variables: [NavNode: "$PlaceMarker"]
+
+- name: set-placemarker
+  tag: "*"
+  match: "starts-with($NavCommand, 'SetPlacemarker')"
+  replace:
+  - test:
+      if: "$NavVerbosity != 'Terse'"
+      then:
+      - t: "ustaw symbol zastępczy"                                 # phrase('set placeholder' to the value) 
+      - x: "$PlaceMarkerIndex"
+      - pause: long
+  - set_variables: [NavNode: "@id"]
+
+# ********* WhereAmI  ***************
+
+# FIX: WhereAmI needs support from the Rust code to loop around and do speech at each iteration.
+#      Alternatively, it could insert a special token that Rust code does a "replace" on with the speech (e.g. SPEECH_AT{id})
+#      or a new command "speak" which takes a node id
+- name: where-am-i-start
+  tag: "*"
+  match: "($NavCommand = 'WhereAmI' or $NavCommand = 'WhereAmIAll') and $MatchCounter = 0"
+  replace:
+  - translate: "@id"
+  - pause: long
+  - with:
+      variables: [MatchCounter: "$MatchCounter + 1"]
+      replace: [x: ".."]
+
+- name: where-am-i-stop
+  tag: "*"
+  match:
+  - "($NavCommand = 'WhereAmI' or $NavCommand = 'WhereAmIAll') and $MatchCounter > 0 and"
+  # stopping conditions
+  - "(self::m:math or "
+  - " parent::*[self::m:math and (count(*)=1 or (count(*)=2 and *[2][.=',' or .='.' or .=';' or .='?']) ) ] "
+  - ")"
+  replace:
+  - test:
+      if: "$NavCommand = 'WhereAmI'"
+      then:
+      - t: "wewnątrz niczego więcej"                         # phrase('inside of nothing more') 
+      - pause: long
+      - set_variables: [SpeakExpression: "'false'"]
+      else:
+      - t: "wewnątrz"                                         # phrase('inside' a big expression) 
+      - pause: medium
+  - set_variables: [NavNode: "@id"]
+
+- name: where-am-i-middle
+  tag: "*"
+  match: "$NavCommand = 'WhereAmI' or $NavCommand = 'WhereAmIAll'"
+  replace:
+  - t: "wewnątrz"                                           # phrase('inside' a big expression)
+  - pause: medium
+  - test:
+    - if: "$NavMode='Enhanced' and parent::*[self::m:mrow and (IsBracketed(., '(', ')', false) or IsBracketed(., '[', ']', false))]"
+      then: [x: ".."] # auto-zoom up
+    - else_if: "$NavCommand = 'WhereAmI'"
+      then: [set_variables: [NavNode: "@id"]]
+      else:
+      - translate: "@id"
+      - pause: long
+      - x: '..'

--- a/Rules/Languages/pl/overview.yaml
+++ b/Rules/Languages/pl/overview.yaml
@@ -1,0 +1,119 @@
+---
+# Provide an overview/outline/description of the math
+# MathPlayer just tried to shorten things like "mfrac" by just saying "fraction"
+#   For mrow, it say up to 5 operands and just say "and n more things" for the rest
+# This results in strings of varying length. Given human memory is about 7 words long,
+#   it would be better to aim for 7 words (maybe aim for a range of 6-10 words).
+# Idea:
+#   Start by generating a terse form of the speech
+#   At every step when the strings are being joined
+#     a) if the #words <= 7, return the joined string
+#     b) otherwise, set verbosity to 'overview' and regenerate the expression and use that
+# There is a balance that you want to maximize the info given, so 10 words is likely better then 3.
+#   That might mean that at the top level, we may want to allow the first few children to expand
+
+
+- name: overview-default
+  tag: [mfrac, fraction]
+  match: "."
+  replace:
+  - test:
+      if: "IsNode(*[1], 'simple') and IsNode(*[2], 'simple')"
+      then:
+      - x: "*[1]"
+      - t: "przez"
+      - x: "*[2]"
+      else:
+      - t: "ułamek"
+
+- name: overview-default
+  tag: [msqrt, "square-root"]
+  match: "."
+  replace:
+  - t: "pierwiastek kwadratowy"
+  - test:
+      if: "IsNode(*[1], 'simple')"
+      then:
+      - test:
+          if: "$Verbosity!='Terse'"
+          then: [t: "z"]
+      - x: "*[1]"
+
+- name: overview-default
+  tag: [mroot, root]
+  match: "."
+  replace:
+  - test:
+      if: "*[2][self::m:mn]"
+      then_test:
+      - if: "*[2][.='2']"
+        then: [t: "pierwiastek kwadratowy"]
+      - else_if: "*[2][.='3']"
+        then: [t: "pierwiastek sześcienny"]
+      - else_if: "*[2][not(contains(., '.'))]"
+        then: [x: "ToOrdinal(*[2])", t: "pierwiastek"]
+      else:
+      - test:
+          if: "*[2][self::m:mi][string-length(.)=1]"
+          then:
+          - x: "*[2]"
+          else: {x: "*[2]"}
+      - t: "pierwiastek"
+  - test:
+      if: "IsNode(*[1], 'simple')"
+      then:
+      - test:
+          if: "$Verbosity!='Terse'"
+          then: [t: "z"]
+      - x: "*[1]"
+
+- name: matrix-override
+  tag: mrow
+  match:
+  - "*[2][self::m:mtable] and"
+  - "(IsBracketed(., '(', ')') or IsBracketed(., '[', ']') or IsBracketed(., '|', '|'))"
+  replace:
+  - t: ""
+  - x: count(*[2]/*)
+  - t: "na"
+  - x: count(*[2]/*[self::m:mtr][1]/*)
+  - test:
+      if: "*[1][.='|']" # just need to check the first bracket since we know it must be (, [, or |
+      then: [t: "wyznacznik"]
+      else: [t: "macierz"]
+
+- name: overview-default
+  tag: mtable
+  match: "."
+  replace:
+  - t: ""
+  - x: count(*[2]/*)
+  - t: "na"
+  - x: count(*[2]/*[self::m:mtr][1]/*)
+  - t: "tabela"
+
+- name: short-mrow
+  tag: mrow
+  match: "count(*)<6"
+  replace:
+  - insert:
+      nodes: "*"
+      replace: [pause: auto]
+
+- name: long-mrow
+  tag: mrow
+  match: "."
+  replace:
+  - x: "*[1]"
+  - pause: auto
+  - x: "*[2]"
+  - pause: auto
+  - x: "*[3]"
+  - pause: auto
+  - x: "*[4]"
+  - pause: auto
+  - x: "*[5]"
+  - pause: auto
+  - t: "i tak dalej"
+
+- include: "SimpleSpeak_Rules.yaml"

--- a/Rules/Languages/pl/unicode-full.yaml
+++ b/Rules/Languages/pl/unicode-full.yaml
@@ -1,0 +1,3647 @@
+---
+
+
+ - "¢": [t: "centy"]                               # 0xa2
+ - "£": [t: "funty"]                              # 0xa3
+ - "¤": [t: "znak waluty"]                       # 0xa4
+ - "¥": [t: "jen"]                                 # 0xa5
+ - "¦": [t: "przerwana kreska"]                          # 0xa6
+ - "§": [t: "paragraf"]                             # 0xa7
+ - "¨": [t: "diereza"]                          # 0xa8
+ - "©": [t: "znak praw autorskich"]                           # 0xa9
+ - "ª": [t: "żeński wskaźnik liczebnika porządkowego"]          # 0xaa
+ - "¬": [T: "nie"]                                 # 0xac
+ - "«": [t: "lewy podwójny cudzysłów ostrokątny"] # 0xab
+ - "¯":                                            # 0xaf
+     - test:
+        if: "ancestor::m:modified-variable and preceding-sibling::*[1][self::m:mi]"
+        then: [t: "kreska"]
+        else: [t: "linia"]
+ - "²": [t: "dwa"]                                 # 0xb2
+ - "³": [t: "trzy"]                               # 0xb3
+ - "´": [t: "akut"]                               # 0xb4
+ - "µ": [t: "mikro"]                               # 0xb5
+ - "¹": [t: "jeden"]                                 # 0xb9
+ - "º": [t: "męski wskaźnik liczebnika porządkowego"]                                 # 0xb9
+ - "·":
+    - test:
+        if: "$SpeechStyle != 'ClearSpeak' or $ClearSpeak_MultSymbolDot = 'Auto'"
+        then: [T: "razy"]
+        else: [T: "kropka"]
+ - "×":                                          # 0xd7
+    - test:
+        if: "$SpeechStyle != 'ClearSpeak' or $ClearSpeak_MultSymbolX = 'Auto'"
+        then: [T: "razy"]
+        else_test:
+            if: $ClearSpeak_MultSymbolX = 'By'
+            then: [T: "na"]
+            else: [t: "krzyż"]
+ - "÷": [T: "podzielone przez"]                          # 0xf7
+ - "¡": [t: "odwrócony wykrzyknik"]           # 0xa1
+ - "¶": [t: "znak akapitu"]                      # 0xb6
+ - "¿": [t: "odwrócony znak zapytania"]              # 0xbf
+
+ - "ʰ": [t: "modyfikator mały h"]                    # 0x2b0
+ - "ʱ": [t: "modyfikator mały h z haczykiem"]    # 0x2b1
+ - "ʲ": [t: "modyfikator mały j"]                    # 0x2b2
+ - "ʳ": [t: "modyfikator mały R"]                    # 0x2b3
+ - "ʴ": [t: "modyfikator mały odwrócony R"]             # 0x2b4
+ - "ʵ": [t: "modyfikator mały odwrócony R z haczykiem"] # 0x2b5
+ - "ʶ":                                            # 0x2b6
+    - t: "modyfikator mały odwrócony"
+    - spell: "translate('R', 'R', 'R')"
+
+ - "ʷ": [t: "modyfikator mały w"]                    # 0x2b7
+ - "ʸ": [t: "modyfikator mały y"]                    # 0x2b8
+ - "ʹ": [t: "modyfikator prim"]                      # 0x2b9
+ - "ʺ": [t: "modyfikator podwójny prim"]               # 0x2ba
+ - "ʻ": [t: "modyfikator odwrócony przecinek"]               # 0x2bb
+ - "ʼ": [t: "modyfikator apostrof"]                 # 0x2bc
+ - "ʽ": [t: "modyfikator odwrócony przecinek"]             # 0x2bd
+ - "ʾ": [t: "modyfikator prawa połowa pierścień"]            # 0x2be
+ - "ʿ": [t: "modyfikator lewa połowa pierścień"]             # 0x2bf
+ - "ˀ": [t: "modyfikator zwarcie krtaniowe"]               # 0x2c0
+ - "ˁ": [t: "modyfikator odwrócone zwarcie krtaniowe"]      # 0x2c1
+ - "˂": [t: "modyfikator lewy grot strzałki"]             # 0x2c2
+ - "˃": [t: "modyfikator prawy grot strzałki"]            # 0x2c3
+ - "˄": [t: "modyfikator górny grot strzałki"]               # 0x2c4
+ - "˅": [t: "modyfikator dolny grot strzałki"]             # 0x2c5
+ - "ˆ": [t: "modyfikator akcent daszkowy"]          # 0x2c6
+ - "ˇ": [t: "haczek"]                               # 0x2c7
+ - "ˈ": [t: "modyfikator pionowej kreski"]              # 0x2c8
+ - "ˉ": [t: "modyfikator makron"]                     # 0x2c9
+ - "ˊ": [t: "modyfikator akut akcent"]               # 0x2ca
+ - "ˋ": [t: "modyfikator grawis akcent"]               # 0x2cb
+ - "ˌ": [t: "modyfikator dolnej pionowej kreski"]          # 0x2cc
+ - "ˍ": [t: "modyfikator dolny makron"]                 # 0x2cd
+ - "ˎ": [t: "modyfikator dolny akcent grawis"]           # 0x2ce
+ - "ˏ": [t: "modyfikator dolny akcent akut"]           # 0x2cf
+ - "ː": [t: "modyfikator trójkątny dwukropek"]           # 0x2d0
+ - "ˑ": [t: "modyfikator połowa trójkątny dwukropek"]      # 0x2d1
+ - "˒": [t: "modyfikator wyśrodkowany prawa połowa pierścień"]   # 0x2d2
+ - "˓": [t: "modyfikator wyśrodkowany lewa połowa pierścień"]    # 0x2d3
+ - "˔": [t: "modyfikator górnej pinezki"]              # 0x2d4
+ - "˕": [t: "modyfikator dolnej pinezki"]              # 0x2d5
+ - "˖": [t: "modyfikator znaku plus"]                  # 0x2d6
+ - "˗": [t: "modyfikator znaku minus"]                 # 0x2d7
+ - "˘": [t: "znak krótkości"]                     # 0x2d8
+ - "˙": [T: "kropka"]                                 # 0x2d9
+ - "˚": [t: "pierścień nad"]                          # 0x2da
+ - "˛": [t: "ogonek"]                              # 0x2db
+ - "˜": [t: "mały tylda"]                         # 0x2dc
+ - "˝": [t: "podwójny akut akcent"]                 # 0x2dd
+ - "˞": [t: "modyfikator rotycznego haczyka"]        # 0x2de
+ - "˟": [t: "modyfikator krzyż akcent"]               # 0x2df
+ - "ˠ": [t: "modyfikator mały gamma"]                # 0x2e0
+ - "ˡ": [t: "modyfikator mały L"]                    # 0x2e1
+ - "ˢ": [t: "modyfikator mały s"]                    # 0x2e2
+ - "ˣ": [t: "modyfikator mały X"]                    # 0x2e3
+ - "ˤ": [t: "modyfikator mały odwrócone zwarcie krtaniowe"] # 0x2e4
+ - "˥": [t: "modyfikator kreski bardzo wysokiego tonu"]        # 0x2e5
+ - "˦": [t: "modyfikator kreski wysokiego tonu"]              # 0x2e6
+ - "˧": [t: "modyfikator środkowy tonowy kreska"]               # 0x2e7
+ - "˨": [t: "modyfikator kreski niskiego tonu"]               # 0x2e8
+ - "˩": [t: "modyfikator kreski bardzo niskiego tonu"]         # 0x2e9
+ - "˪": [t: "modyfikator znak tonu yin odchodzącego"]    # 0x2ea
+ - "˫": [t: "modyfikator znak tonu yang odchodzącego"]   # 0x2eb
+ - "ˬ": [t: "modyfikator dźwięczność"]                    # 0x2ec
+ - "˭": [t: "modyfikator nieaspirowany"]                # 0x2ed
+ - "ˮ": [t: "modyfikator podwójny apostrof"]          # 0x2ee
+ - "˯": [t: "modyfikator dolny grot strzałki"]         # 0x2ef
+ - "˰": [t: "modyfikator dolny górny grot strzałki"]           # 0x2f0
+ - "˱": [t: "modyfikator dolny lewy grot strzałki"]         # 0x2f1
+ - "˲": [t: "modyfikator dolny prawy grot strzałki"]        # 0x2f2
+ - "˳": [t: "modyfikator dolny pierścień"]                   # 0x2f3
+ - "˴": [t: "modyfikator środkowy grawis akcent"]        # 0x2f4
+ - "˵": [t: "modyfikator środkowy podwójny grawis akcent"] # 0x2f5
+ - "˶": [t: "modyfikator środkowy podwójny akut akcent"] # 0x2f6
+ - "˷": [t: "modyfikator dolna tylda"]                  # 0x2f7
+ - "˸": [t: "modyfikator podniesiony dwukropek"]               # 0x2f8
+ - "˹": [t: "modyfikator początek wysoki ton"]            # 0x2f9
+ - "˺": [t: "modyfikator koniec wysoki ton"]              # 0x2fa
+ - "˻": [t: "modyfikator początek niski ton"]             # 0x2fb
+ - "˼": [t: "modyfikator koniec niski ton"]               # 0x2fc
+ - "˽": [t: "modyfikator półka"]                      # 0x2fd
+ - "˾": [t: "modyfikator otwórz półka"]                 # 0x2fe
+ - "˿": [t: "modyfikator dolny strzałka w lewo"]             # 0x2ff
+ - "̀": [t: "ozdobnik akcentu grawis"]          # 0x300
+ - "́": [t: "ozdobnik akcentu ostrego"]          # 0x301
+ - "̂": [t: "ozdobnik daszka"]     # 0x302
+ - "̃": [t: "ozdobnik tyldy"]                 # 0x303
+ - "̄": [t: "ozdobnik makronu"]                # 0x304
+ - "̅": [t: "ozdobnik kreski górnej"]               # 0x305
+ - "̆": [t: "ozdobnik znaku krótkości"]       # 0x306
+ - "̇": [t: "ozdobnik kropki nad"]             # 0x307
+ - "̈": [t: "ozdobnik diaerezy"]             # 0x308
+ - "̉": [t: "hak nad ozdobnik"]            # 0x309
+ - "̊": [t: "pierścień nad ozdobnik"]            # 0x30a
+ - "̋": [t: "ozdobnik podwójnego akutu"]   # 0x30b
+ - "̌": [t: "haczek"]                 # 0x30c
+ - "̍": [t: "ozdobnik pionowej kreski nad"]   # 0x30d
+ - "̎": [t: "ozdobnik podwójnej pionowej kreski nad"] # 0x30e
+ - "̏": [t: "ozdobnik podwójnego grawisu"]   # 0x30f
+ - "̐": [t: "ozdobnik ćandrabindu"]           # 0x310
+ - "̑": [t: "odwrócony ozdobnik znaku krótkości"] # 0x311
+ - "̒": [t: "odwrócony przecinek nad ozdobnik"]    # 0x312
+ - "̓": [t: "przecinek nad ozdobnik"]           # 0x313
+ - "̔": [t: "odwrócony przecinek nad ozdobnik"]  # 0x314
+ - "̕": [t: "przecinek nad prawy ozdobnik"]     # 0x315
+ - "̖": [t: "ozdobnik akcentu grawis pod"]    # 0x316
+ - "̗": [t: "ozdobnik akcentu ostrego pod"]    # 0x317
+ - "̘": [t: "ozdobnik lewej pinezki pod spodem"] # 0x318
+ - "̙": [t: "ozdobnik prawej pinezki pod spodem"] # 0x319
+ - "̚": [t: "lewy kąt nad ozdobnik"]      # 0x31a
+ - "̛": [t: "ozdobnik rożka"]                 # 0x31b
+ - "̜": [t: "lewa połowa pierścień pod ozdobnik"]  # 0x31c
+ - "̝": [t: "ozdobnik górnej pinezki pod spodem"] # 0x31d
+ - "̞": [t: "ozdobnik dolnej pinezki pod spodem"] # 0x31e
+ - "̟": [t: "ozdobnik znaku plus pod spodem"]       # 0x31f
+ - "̠": [t: "ozdobnik znaku minus pod spodem"]      # 0x320
+ - "̡": [t: "palatalizowany haczyk pod spodem"] # 0x321
+ - "̢": [t: "retrofleksyjny haczyk pod spodem"] # 0x322
+ - "̣": [t: "ozdobnik kropki pod"]             # 0x323
+ - "̤": [t: "ozdobnik dierezy pod spodem"]  # 0x324
+ - "̥": [t: "pierścień pod ozdobnik"]            # 0x325
+ - "̦": [t: "przecinek pod ozdobnik"]           # 0x326
+ - "̧": [t: "ozdobnik cedilli"]               # 0x327
+ - "̨": [t: "ogonek ozdobnik"]                # 0x328
+ - "̩": [t: "ozdobnik pionowej kreski pod spodem"]   # 0x329
+ - "̪": [t: "mostek pod ozdobnik"]          # 0x32a
+ - "̫": [t: "odwrócony podwójny łuk pod spodem"] # 0x32b
+ - "̬": [t: "haczek pod ozdobnik"]           # 0x32c
+ - "̭": [t: "ozdobnik daszka pod"] # 0x32d
+ - "̮": [t: "ozdobnik znaku krótkości pod spodem"] # 0x32e
+ - "̯": [t: "odwrócony ozdobnik znaku krótkości pod spodem"] # 0x32f
+ - "̰": [t: "tylda pod ozdobnik"]           # 0x330
+ - "̱": [t: "ozdobnik makronu pod"]          # 0x331
+ - "̲": [t: "dolny linia ozdobnik"]              # 0x332
+ - "̳": [t: "podwójny dolny linia ozdobnik"]       # 0x333
+ - "̴": [t: "tylda nakładka ozdobnik"]         # 0x334
+ - "̵": [t: "krótkie przekreślenie nakładane jako ozdobnik"]  # 0x335
+ - "̶": [t: "długie przekreślenie nakładane jako ozdobnik"]   # 0x336
+ - "̷": [t: "krótki ukośnik nakładka ozdobnik"] # 0x337
+ - "̸": [t: "długi ukośnik nakładka ozdobnik"]  # 0x338
+ - "̹": [t: "prawa połowa pierścień pod ozdobnik"] # 0x339
+ - "̺": [t: "odwrócony mostek pod ozdobnik"] # 0x33a
+ - "̻": [t: "kwadrat pod ozdobnik"]          # 0x33b
+ - "̼": [t: "ozdobnik mewy pod spodem"]     # 0x33c
+ - "̽": [t: "X nad ozdobnik"]               # 0x33d
+ - "̾": [t: "pionowy ozdobnik tyldy"]        # 0x33e
+ - "̿": [t: "ozdobnik podwójnej kreski górnej"]       # 0x33f
+ - "̀": [t: "grawis tonowy znak ozdobnik"]       # 0x340
+ - "́": [t: "akut tonowy znak ozdobnik"]       # 0x341
+ - "͆": [t: "mostek nad"]                        # 0x346
+
+ - "ΪΫϏ":                                          # 0x3aa, 0x3ab, 0x3cf
+    - test: 
+        if: "$CapitalLetters_Beep"
+        then:
+        - audio:
+            value: "beep.mp4"
+            replace: []
+    - test: 
+        if: "$CapitalLetters_UseWord"
+        then_test:
+          if: "$SpeechOverrides_CapitalLetters = ''"
+          then_test:
+            if: "$Impairment = 'Blindness'"
+            then: [t: "wielka"]
+          else: [x: "$SpeechOverrides_CapitalLetters"] 
+    - pitch:
+        value: "$CapitalLetters_Pitch"
+        replace: [spell: "translate('.', 'ΪΫϏ', 'ιυϗ')"]
+    - t: "z dialityką"
+ - "ϊ": [t: "jota z dialityką"]                 # 0x3ca
+ - "ϋ": [t: "ypsilon z dialityką"]              # 0x3cb
+ - "ό": [t: "omikron z tonosem"]                # 0x3cc
+ - "ύ": [t: "ypsilon z tonosem"]                # 0x3cd
+ - "ώ": [t: "omega z tonosem"]                  # 0x3ce
+ - "ϐ": [t: "beta"]                                # 0x3d0
+ - "ϑ": [t: "theta"]                               # 0x3d1
+ - "ϒ": [t: "ypsilon z haczykiem"]              # 0x3d2
+ - "ϓ": [t: "ypsilon z akutem i haczykiem"]     # 0x3d3
+ - "ϔ": [t: "ypsilon z dierezą i haczykiem"]    # 0x3d4
+ - "ϕ": [t: "fi"]                                 # 0x3d5
+ - "ϖ": [t: "pi"]                                  # 0x3d6
+ - "ϗ": [t: "kai"]                                 # 0x3d7
+ - "Ϙ": [t: "wielka archaiczna koppa"]          # 0x3d8
+ - "ϙ": [t: "archaiczna koppa"]                 # 0x3d9
+ - "ϵ": [t: "epsilon"]                             # 0x3f5
+ - "϶": [t: "odwrócony epsilon"]                    # 0x3f6
+ - "А-Я":                                          # 0x410 - 0x42f
+    - test: 
+        if: "$CapitalLetters_Beep"
+        then:
+        - audio:
+            value: "beep.mp4"
+            replace: []
+    - test: 
+        if: "$CapitalLetters_UseWord"
+        then_test:
+          if: "$SpeechOverrides_CapitalLetters = ''"
+          then_test:
+            if: "$Impairment = 'Blindness'"
+            then: [t: "wielka"]
+          else: [x: "$SpeechOverrides_CapitalLetters"] 
+    - pitch:
+        value: "$CapitalLetters_Pitch"
+        replace: [spell: "translate('.', 'АБВГДЕЖЗИЙКЛМНОПРСТУФХЦЧШЩЪЫЬЭЮЯ', 'абвгдежзийклмнопрстуфхцчшщъыьэюя')"]
+ - "а": [T: "a"]                                   # 0x430
+ - "б": [t: "be"]                                  # 0x431
+ - "в": [t: "we"]                                  # 0x432
+ - "г": [t: "ge"]                                 # 0x433
+ - "д": [t: "de"]                                  # 0x434
+ - "е": [t: "je"]                                  # 0x435
+ - "ж": [t: "że"]                                 # 0x436
+ - "з": [t: "ze"]                                  # 0x437
+ - "и": [t: "i"]                                   # 0x438
+ - "й": [t: "krótkie i"]                             # 0x439
+ - "к": [t: "ka"]                                  # 0x43a
+ - "л": [t: "eł"]                                  # 0x43b
+ - "м": [t: "em"]                                  # 0x43c
+ - "н": [t: "en"]                                  # 0x43d
+ - "о": [t: "o"]                                   # 0x43e
+ - "п": [t: "pe"]                                  # 0x43f
+ - "р": [t: "er"]                                  # 0x440
+ - "с": [t: "es"]                                  # 0x441
+ - "т": [t: "te"]                                  # 0x442
+ - "у": [t: "u"]                                   # 0x443
+ - "ф": [t: "ef"]                                  # 0x444
+ - "х": [t: "cha"]                                  # 0x445
+ - "ц": [t: "ce"]                                 # 0x446
+ - "ч": [t: "cze"]                                 # 0x447
+ - "ш": [t: "sza"]                                 # 0x448
+ - "щ": [t: "szcza"]                               # 0x449
+ - "ъ": [t: "twardy znak"]                         # 0x44a
+ - "ы": [t: "jery"]                                # 0x44b
+ - "ь": [t: "miękki znak"]                         # 0x44c
+ - "э": [t: "e"]                                   # 0x44d
+ - "ю": [t: "ju"]                                  # 0x44e
+ - "я": [t: "ja"]                                  # 0x44f
+ - "؆": [t: "arabsko-indyjski pierwiastek sześcienny"]              # 0x606
+ - "؇": [t: "arabsko-indyjski czwarty pierwiastek"]            # 0x607
+ - "؈": [t: "arabski półprosta"]                          # 0x608
+ - "‐": [t: "łącznik"]                              # 0x2010
+ - "‑": [t: "łącznik"]                              # 0x2011
+ - "‒": [t: "pauza cyfrowa"]                       # 0x2012
+ - "–": [t: "półpauza"]                             # 0x2013
+ - "—": [t: "pauza"]                             # 0x2014
+ - "―": [t: "kreska pozioma"]                      # 0x2015
+ - "‖": [t: "podwójna pionowa kreska"]                # 0x2016
+ - "†": [t: "obelisk"]                              # 0x2020
+ - "‡": [t: "podwójny obelisk"]                       # 0x2021
+
+ - " - ": [t: " "]                                 # 0x2000 - 0x2007
+
+ - "•":                                            # 0x2022
+    - test: 
+        if: "@data-chem-formula-op"
+        then: [T: "kropka"]
+        else: [t: "punkt"]
+
+ - "…":                                          # 0x2026
+    test:
+        if:
+            - "$SpeechStyle != 'ClearSpeak' or $ClearSpeak_Ellipses = 'Auto' or"
+               # must be ClearSpeak and $ClearSpeak_Ellipses = 'AndSoOn'
+               # speak '…' as 'and so on...' unless expr starts with '…'
+            - "../*[1][.='…']"
+        then: [t: "trzy kropki"]
+        else_test:  # must have $ClearSpeak_Ellipses = 'AndSoOn'
+            if: "count(following-sibling::*) = 0"
+            then: [t: "i tak dalej"]
+            else: [t: "i tak dalej aż do"]
+
+ - "‰": [t: "promil"]                           # 0x2030
+ - "‱": [t: "na dziesięć tysięcy"]                    # 0x2031
+ - "′": [t: "prim"]                               # 0x2032
+ - "″": [t: "podwójny prim"]                        # 0x2033
+ - "‴": [t: "potrójny prim"]                        # 0x2034
+ - "‵": [t: "odwrócony prim"]                      # 0x2035
+ - "‶": [t: "odwrócony podwójny prim"]               # 0x2036
+ - "‷": [t: "odwrócony potrójny prim"]               # 0x2037
+ - "‸": [T: "do potęgi"]                              # 0x2038
+ - "‹": [t: "pojedynczy lewy cudzysłów ostrokątny"] # 0x2039
+ - "›": [t: "pojedynczy prawy cudzysłów ostrokątny"] # 0x203a
+ - "‼":                                            # 0x203c
+    - test:
+        if: "ancestor-or-self::*[contains(@data-intent-property, ':literal:')]"
+        then: [t: "podwójny wykrzyknik punkt"]      # 0x203c
+        else: [t: "podwójny silnia"]              # 0x203c
+ - "⁄":                                            # 0x2044
+    - test:
+        if: "ancestor-or-self::*[contains(@data-intent-property, ':literal:')]"
+        then: [t: "duży ukośnik"]      # 0x203c
+        else: [T: "podzielone przez"]              # 0x203c
+ - "⁅": [t: "lewy kwadratowy nawias z piórem"]      # 0x2045
+ - "⁆": [t: "prawy kwadratowy nawias z piórem"]     # 0x2046
+ - "※": [t: "znak odsyłacza"]                    # 0x203b
+ - "‿": [t: "łuk dolny"]                         # 0x203F
+ - "⁀": [t: "łuk górny"]                         # 0x2040
+ - "⁎": [t: "dolna gwiazdka"]                        # 0x204e
+ - "⁏": [t: "odwrócony średnik"]                  # 0x204f
+ - "⁐": [t: "zamknij górny"]                           # 0x2050
+ - "⁑": [t: "dwie pionowe gwiazdki"]              # 0x2051
+ - "⁒": [t: "handlowy znak minus"]               # 0x2052
+ - "⁗": [t: "poczwórny prim"]                     # 0x2057
+ - "⁠": [t: ""]                                     # 0x2060
+ - "⁰": [t: "do zerowej potęgi"]                 # 0x2070
+ - "ⁱ": [t: "do potęgi i"]                     # 0x2071
+ - "⁴": [t: "do czwartej potęgi"]                 # 0x2074
+ - "⁵": [t: "do piątej potęgi"]                  # 0x2075
+ - "⁶": [t: "do szóstej potęgi"]                  # 0x2076
+ - "⁷": [t: "do siódmej potęgi"]                # 0x2077
+ - "⁸": [t: "do ósmej potęgi"]                 # 0x2078
+ - "⁹": [t: "do dziewiątej potęgi"]                  # 0x2079
+ - "⁺": [t: "znak plus w indeksie górnym"]               # 0x207a
+ - "⁻": [t: "znak minus w indeksie górnym"]                   # 0x207b
+ - "⁼": [t: "znak równości w indeksie górnym"]             # 0x207c
+ - "⁽": [t: "lewy nawias w indeksie górnym"]        # 0x207d
+ - "⁾": [t: "prawy nawias w indeksie górnym"]       # 0x207e
+ - "ⁿ": [t: "do potęgi n"]                     # 0x207f
+ - "₀": [t: "indeks dolny zero"]                            # 0x2080
+ - "₁": [t: "indeks dolny jeden"]                             # 0x2081
+ - "₂": [t: "indeks dolny dwa"]                             # 0x2082
+ - "₃": [t: "indeks dolny trzy"]                           # 0x2083
+ - "₄": [t: "indeks dolny cztery"]                            # 0x2084
+ - "₅": [t: "indeks dolny pięć"]                            # 0x2085
+ - "₆": [t: "indeks dolny sześć"]                             # 0x2086
+ - "₇": [t: "indeks dolny siedem"]                           # 0x2087
+ - "₈": [t: "indeks dolny osiem"]                           # 0x2088
+ - "₉": [t: "indeks dolny dziewięć"]                            # 0x2089
+ - "₊": [t: "znak plus w indeksie dolnym"]                 # 0x208a
+ - "₋": [t: "znak minus w indeksie dolnym"]                # 0x208b
+ - "₌": [t: "znak równości w indeksie dolnym"]               # 0x208c
+ - "₍": [t: "lewy nawias w indeksie dolnym"]          # 0x208d
+ - "₎": [t: "prawy nawias w indeksie dolnym"]         # 0x208e
+ - "ₐ": [t: "indeks dolny a"]                               # 0x2090
+ - "ₑ": [t: "indeks dolny e"]                               # 0x2091
+ - "ₒ": [t: "indeks dolny o"]                               # 0x2092
+ - "ₓ": [t: "indeks dolny X"]                               # 0x2093
+ - "ₕ": [t: "indeks dolny h"]                               # 0x2095
+ - "ₖ": [t: "indeks dolny k"]                               # 0x2096
+ - "ₗ": [t: "indeks dolny L"]                               # 0x2097
+ - "ₘ": [t: "indeks dolny M"]                               # 0x2098
+ - "ₙ": [t: "indeks dolny N"]                               # 0x2099
+ - "ₚ": [t: "indeks dolny p"]                               # 0x209a
+ - "ₛ": [t: "indeks dolny s"]                               # 0x209b
+ - "ₜ": [t: "indeks dolny t"]                               # 0x209c
+ - "₠": [t: "europejska jednostka walutowa"]             # 0x20a0
+ - "₡": [t: "kolon"]                              # 0x20a1
+ - "₢": [t: "znak cruzeiro"]                            # 0x20a2
+ - "₣": [t: "frank"]                               # 0x20a3
+ - "₤": [t: "lira"]                                # 0x20a4
+ - "₥": [t: "mille"]                               # 0x20a5
+ - "₦": [t: "naira"]                               # 0x20a6
+ - "₧": [t: "peseta"]                              # 0x20a7
+ - "₨": [t: "rupie"]                              # 0x20a8
+ - "₩": [t: "won"]                                 # 0x20a9
+ - "₪": [t: "nowe szekle"]                         # 0x20aa
+ - "₫": [t: "dong"]                                # 0x20ab
+ - "€": [t: "euro"]                               # 0x20ac
+ - "₭": [t: "kip"]                                 # 0x20ad
+ - "₮": [t: "tugrik"]                              # 0x20ae
+ - "₯": [t: "drachma"]                             # 0x20af
+ - "₰": [t: "niemieckie fenigi"]                      # 0x20b0
+ - "₱": [t: "peso"]                               # 0x20b1
+ - "₲": [t: "guarani"]                            # 0x20b2
+ - "₳": [t: "australe"]                            # 0x20b3
+ - "₴": [t: "hrywny"]                            # 0x20b4
+ - "₵": [t: "cedi"]                               # 0x20b5
+ - "₶": [t: "liwr turoński"]                      # 0x20b6
+ - "₷": [t: "spesmilos"]                           # 0x20b7
+ - "₸": [t: "tenge"]                              # 0x20b8
+ - "₹": [t: "rupie indyjskie"]                       # 0x20b9
+ - "₺": [t: "liry tureckie"]                       # 0x20ba
+ - "⃐": [t: "lewy harpun nad ozdobnik"]    # 0x20d0
+ - "⃑": [t: "prawy harpun nad ozdobnik"]   # 0x20d1
+ - "⃒": [t: "ozdobnik długiej pionowej kreski nakładanej"] # 0x20d2
+ - "⃓": [t: "ozdobnik krótkiej pionowej kreski nakładanej"] # 0x20d3
+ - "⃔": [t: "strzałka nad przeciwnie do ruchu wskazówek zegara, ozdobnik"] # 0x20d4
+ - "⃕": [t: "strzałka nad zgodnie z ruchem wskazówek zegara, ozdobnik"] # 0x20d5
+ - "⃖": [t: "strzałka w lewo nad ozdobnik"]      # 0x20d6
+ - "⃗": [t: "strzałka w prawo nad ozdobnik"]     # 0x20d7
+ - "⃘": [t: "pierścień nakładka ozdobnik"]          # 0x20d8
+ - "⃙": [t: "pierścień zgodnie z ruchem wskazówek zegara, ozdobnik nakładany"] # 0x20d9
+ - "⃚": [t: "pierścień przeciwnie do ruchu wskazówek zegara, ozdobnik nakładany"] # 0x20da
+ - "⃛": [t: "potrójny kropka"]      # 0x20db
+ - "⃜": [t: "poczwórny kropka"]       # 0x20dc
+ - "⃝": [t: "obejmujący okrąg ozdobnik"]      # 0x20dd
+ - "⃞": [t: "obejmujący kwadrat ozdobnik"]      # 0x20de
+ - "⃟": [t: "obejmujący romb ozdobnik"]     # 0x20df
+ - "⃠": [t: "obejmujący okrąg ukośnik odwrotny ozdobnik"] # 0x20e0
+ - "⃡": [t: "lewy strzałka w prawo nad ozdobnik"] # 0x20e1
+ - "⃢": [t: "obejmujący ekran, ozdobnik"]      # 0x20e2
+ - "⃣": [t: "obejmujący nasadkę klawisza, ozdobnik"]      # 0x20e3
+ - "⃤": [t: "obejmujący w górę skierowany trójkąt ozdobnik"] # 0x20e4
+ - "⃥": [t: "odwrotny ukośnik nakładka ozdobnik"] # 0x20e5
+ - "⃦": [t: "ozdobnik podwójnej pionowej kreski"] # 0x20e6
+ - "⃧": [t: "symbol renty, ozdobnik"]        # 0x20e7
+ - "⃨": [t: "potrójna kropka pod spodem"]       # 0x20e8
+ - "⃩": [t: "szeroki mostek nad, ozdobnik"]     # 0x20e9
+ - "⃪": [t: "strzałka w lewo nakładka ozdobnik"] # 0x20ea
+ - "⃫": [t: "długi podwójny ukośnik nakładka ozdobnik"] # 0x20eb
+ - "⃬": [t: "prawy harpun z grotem dolnym ozdobnik"] # 0x20ec
+ - "⃭": [t: "lewy harpun z grotem dolnym ozdobnik"] # 0x20ed
+ - "⃮": [t: "strzałka w lewo pod ozdobnik"]      # 0x20ee
+ - "⃯": [t: "strzałka w prawo pod ozdobnik"]     # 0x20ef
+ - "⃰": [t: "gwiazdka nad ozdobnik"]        # 0x20f0
+ - "℄": [t: "symbol linii środkowej"]                  # 0x2104
+ - "℅": [t: "do rąk"]                             # 0x2105
+ - "℆": [t: "każda"]                            # 0x2106
+ - "ℇ": [t: "stała Eulera"]                  # 0x2107
+ - "℈": [t: "skrupule"]                            # 0x2108
+ - "℉": [t: "stopnie Fahrenheita"]                  # 0x2109
+ - "ℊ": [t: "pisane g"]                            # 0x210a
+ - "ℌℑℨℭ":                                # 0x210c, 0x2111, 0x2128, 0x212d
+    - t: "fraktura"
+    - spell: "translate('.', 'ℌℑℨℭ', 'HIZC')"
+
+ - "ℍℙℾℿ":                                          # 0x210d, 0x2119, 0x213e, 0x213f
+    - t: "dwukreskowe"
+    - spell: "translate('.', 'ℍℙℾℿ', 'HPΓΠ')" 
+
+ - "ℎ": [t: "stała Plancka"]                     # 0x210e
+ - "ℏ": [t: "h kreślone"]                               # 0x210f
+
+ - "ℐℒ℘ℬℰℱℳ":                          # 0x2110, 0x2112, 0x2118, 0x2130, 0x2131, 0x2133
+    - t: "pisane"
+    - spell: "translate('.', 'ℐℒ℘ℬℰℱℳ', 'ILPBEFM')"
+
+ - "ℓ": [t: "pisane L"]                            # 0x2113
+ - "℔": [t: "funty"]                              # 0x2114
+ - "№": [t: "numer"]                              # 0x2116
+ - "℥": [t: "uncje"]                              # 0x2125
+ - "Ω": [t: "omy"]                                # 0x2126
+ - "℧": [t: "mhos"]                                # 0x2127
+ - "℩": [t: "odwrócony jota"]                         # 0x2129
+ - "K": [t: "kelwin"]                              # 0x212a
+ - "Å": [t: "angstremy"]                           # 0x212b
+ - "ℯ": [t: "pisane e"]                            # 0x212f
+
+   # coalesced some chars that use cap letters
+ - "Ⅎ℺⅁⅂⅃⅄":        # 0x2132, 0x213a, 0x2141, 0x2142, 0x2143, 0x2144 
+    - test:
+      - if: "'.' = '℺'"
+        then: [t: "obrócone"]
+      - else_if: "'.' = 'Ⅎ'"
+        then: [t: "odwrócone"]
+      - else_if: "'.' = '⅃'"
+        then: [t: "odwrócone bezszeryfowe"]
+        else: [t: "odwrócony bezszeryfowe"]
+    - spell: "translate('.', 'Ⅎ℺⅁⅂⅃⅄', 'FQGLLY')"
+
+ - "ℴ": [t: "pisane o"]                             # 0x2134
+ - "ℵ": [t: "pierwsza pozaskończona liczba kardynalna"]           # 0x2135
+ - "ℶ": [t: "druga pozaskończona liczba kardynalna"]          # 0x2136
+ - "ℷ": [t: "trzecia pozaskończona liczba kardynalna"]           # 0x2137
+ - "ℸ": [t: "czwarta pozaskończona liczba kardynalna"]          # 0x2138
+ - "ℼ": [t: "dwukreskowe pi"]                    # 0x213c
+ - "ℽ": [t: "dwukreskowe gamma"]                 # 0x213d
+ - "⅀": [t: "dwukreskowa suma N-arna"]       # 0x2140
+ - "⅋": [t: "odwrócony znak et"]                    # 0x214b
+ - "⅌": [T: "na"]                                 # 0x214c
+ - "ⅎ": [t: "odwrócony f"]                            # 0x214e
+ - "¼": [t: "jedna czwarta"]                         # 0x00bc
+ - "½": [t: "jedna druga"]                            # 0x00bd
+ - "¾": [t: "trzy czwarte"]                      # 0x00be
+ - "⅐": [t: "jeden siódmy"]                         # 0x2150
+ - "⅑": [t: "jeden dziewiąty"]                           # 0x2151
+ - "⅒": [t: "jedna dziesiąta"]                           # 0x2152
+ - "⅓": [t: "jeden trzeci"]                           # 0x2153
+ - "⅔": [t: "dwie trzecie"]                          # 0x2154
+ - "⅕": [t: "jeden piąty"]                           # 0x2155
+ - "⅖": [t: "dwie piąte"]                          # 0x2156
+ - "⅗": [t: "trzy piąte"]                        # 0x2157
+ - "⅘": [t: "cztery piąte"]                         # 0x2158
+ - "⅙": [t: "jeden szósty"]                           # 0x2159
+ - "⅚": [t: "pięć szóstych"]                         # 0x215a
+ - "⅛": [t: "jeden ósmy"]                          # 0x215b
+ - "⅜": [t: "trzy ósme"]                       # 0x215c
+ - "⅝": [t: "pięć ósmych"]                        # 0x215d
+ - "⅞": [t: "siedem ósmych"]                       # 0x215e
+ - "⅟": [t: "jeden przez"]                            # 0x215f
+ - "Ⅰ": [t: "I"]                                   # 0x2160
+ - "Ⅱ": [t: "I I"]                                 # 0x2161
+ - "Ⅲ": [t: "I I I"]                               # 0x2162
+ - "Ⅳ": [t: "I V"]                                 # 0x2163
+ - "Ⅴ": [t: "V"]                                   # 0x2164
+ - "Ⅵ": [t: "V I"]                                 # 0x2165
+ - "Ⅶ": [t: "V I I"]                               # 0x2166
+ - "Ⅷ": [t: "V I I I"]                             # 0x2167
+ - "Ⅸ": [t: "I X"]                                 # 0x2168
+ - "Ⅹ": [t: "X"]                                   # 0x2169
+ - "Ⅺ": [t: "X I"]                                 # 0x216a
+ - "Ⅻ": [t: "X I I"]                               # 0x216b
+ - "Ⅼ": [t: "L"]                                   # 0x216c
+ - "Ⅽ": [t: "C"]                                   # 0x216d
+ - "Ⅾ": [t: "D"]                                   # 0x216e
+ - "Ⅿ": [t: "M"]                                   # 0x216f
+ - "ⅰ": [t: "I"]                                   # 0x2170
+ - "ⅱ": [t: "I I"]                                 # 0x2171
+ - "ⅲ": [t: "I I I"]                               # 0x2172
+ - "ⅳ": [t: "I V"]                                 # 0x2173
+ - "ⅴ": [t: "V"]                                   # 0x2174
+ - "ⅵ": [t: "V I"]                                 # 0x2175
+ - "ⅶ": [t: "V I I"]                               # 0x2176
+ - "ⅷ": [t: "V I I I"]                             # 0x2177
+ - "ⅸ": [t: "I X"]                                 # 0x2178
+ - "ⅹ": [t: "X"]                                   # 0x2179
+ - "ⅺ": [t: "X I"]                                 # 0x217a
+ - "ⅻ": [t: "X I I"]                               # 0x217b
+ - "ⅼ": [t: "L"]                                   # 0x217c
+ - "ⅽ": [t: "C"]                                   # 0x217d
+ - "ⅾ": [t: "D"]                                   # 0x217e
+ - "ⅿ": [t: "M"]                                   # 0x217f
+ - "↉": [t: "zero trzecich"]                         # 0x2189
+ - "↔": [t: "lewy strzałka w prawo"]                    # 0x2194
+ - "↕": [t: "górny strzałka w dół"]                       # 0x2195
+ - "↖": [t: "północ zachód strzałka"]                    # 0x2196
+ - "↗":                                          # 0x2197
+    - test:
+        if: "ancestor::*[2][self::m:limit]"
+        then: [t: "dąży od dołu"]
+        else: [t: "północ wschód strzałka"]
+
+ - "↘":                                          # 0x2198
+    - test:
+        if: "ancestor::*[2][self::m:limit]"
+        then: [t: "dąży od góry"]
+        else: [t: "południe wschód strzałka"]
+
+ - "↙": [t: "południe zachód strzałka"]                    # 0x2199
+ - "↚": [t: "przekreślona strzałka w lewo"]         # 0x219a
+ - "↛": [t: "przekreślona strzałka w prawo"]        # 0x219b
+ - "↜": [t: "falista strzałka w lewo"]                # 0x219c
+ - "↝": [t: "falista strzałka w prawo"]               # 0x219d
+ - "↞": [t: "strzałka w lewo z dwoma grotami"]          # 0x219e
+ - "↟": [t: "strzałka w górę z dwoma grotami"]            # 0x219f
+ - "↠": [t: "strzałka w prawo z dwoma grotami"]         # 0x21a0
+ - "↡": [t: "strzałka w dół z dwoma grotami"]          # 0x21a1
+ - "↢": [t: "strzałka w lewo z ogon"]           # 0x21a2
+ - "↣": [t: "strzałka w prawo z ogon"]          # 0x21a3
+ - "↤": [t: "strzałka w lewo od kreski"]            # 0x21a4
+ - "↥": [t: "strzałka w górę od kreski"]              # 0x21a5
+ - "↦": [t: "strzałka w prawo od kreski"]           # 0x21a6
+ - "↧": [t: "strzałka w dół od kreski"]            # 0x21a7
+ - "↨": [t: "górny strzałka w dół z podstawa"]             # 0x21a8
+ - "↩": [t: "strzałka w lewo z hak"]           # 0x21a9
+ - "↪": [t: "strzałka w prawo z hak"]          # 0x21aa
+ - "↫": [t: "strzałka w lewo z pętlą"]           # 0x21ab
+ - "↬": [t: "strzałka w prawo z pętlą"]          # 0x21ac
+ - "↭": [t: "falista strzałka w lewo i w prawo"]               # 0x21ad
+ - "↮": [t: "przekreślona strzałka w lewo i w prawo"]        # 0x21ae
+ - "↯": [t: "strzałka zygzakowata w dół"]              # 0x21af
+ - "↰": [t: "strzałka w górę z tip lewy"]    # 0x21b0
+ - "↱": [t: "strzałka w górę z tip prawy"]   # 0x21b1
+ - "↲": [t: "strzałka w dół z tip lewy"]  # 0x21b2
+ - "↳": [t: "strzałka w dół z tip prawy"] # 0x21b3
+ - "↴": [t: "strzałka w prawo z narożnikiem w dół"] # 0x21b4
+ - "↵": [t: "strzałka w dół z narożnikiem w lewo"] # 0x21b5
+ - "↶": [t: "strzałka po górnym półokręgu przeciwnie do ruchu wskazówek zegara"]  # 0x21b6
+ - "↷": [t: "strzałka po górnym półokręgu zgodnie z ruchem wskazówek zegara"]      # 0x21b7
+ - "↸": [t: "strzałka północno-zachodnia do długiej kreski"]        # 0x21b8
+ - "↹": [t: "strzałka w lewo do kreski nad strzałką w prawo do kreski"] # 0x21b9
+ - "↺": [t: "strzałka po otwartym okręgu przeciwnie do ruchu wskazówek zegara"]     # 0x21ba
+ - "↻": [t: "strzałka po otwartym okręgu zgodnie z ruchem wskazówek zegara"]         # 0x21bb
+ - "↼": [t: "lewy harpun górny"]                     # 0x21bc
+ - "↽": [t: "lewy harpun dolny"]                   # 0x21bd
+ - "↾": [t: "górny harpun prawy"]                    # 0x21be
+ - "↿": [t: "górny harpun lewy"]                     # 0x21bf
+ - "⇀": [t: "prawy harpun górny"]                    # 0x21c0
+ - "⇁": [t: "prawy harpun dolny"]                  # 0x21c1
+ - "⇂": [t: "dolny harpun prawy"]                  # 0x21c2
+ - "⇃": [t: "dolny harpun lewy"]                   # 0x21c3
+ - "⇄": [t: "strzałka w prawo nad strzałką w lewo"] # 0x21c4
+ - "⇅": [t: "strzałka w górę po lewej i strzałka w dół"] # 0x21c5
+ - "⇆": [t: "strzałka w lewo nad strzałką w prawo"] # 0x21c6
+ - "⇇": [t: "podwójne strzałki w lewo"]             # 0x21c7
+ - "⇈": [t: "podwójne strzałki w górę"]               # 0x21c8
+ - "⇉": [t: "podwójne strzałki w prawo"]            # 0x21c9
+ - "⇊": [t: "podwójne strzałki w dół"]             # 0x21ca
+ - "⇋": [t: "lewy harpun przez prawy harpun"]     # 0x21cb
+ - "⇌": [t: "prawy harpun przez lewy harpun"]     # 0x21cc
+ - "⇍": [T: "nie wynika z"]  # 0x21cd
+ - "⇎": [T: "nie jest równoważne"] # 0x21ce
+ - "⇏": [T: "nie implikuje"] # 0x21cf
+ - "⇐": [T: "wynika z"]              # 0x21d0
+ - "⇑": [t: "podwójna strzałka w górę"]                # 0x21d1
+ - "⇒": [t: "implikuje"]             # 0x21d2
+ - "⇓": [t: "podwójna strzałka w dół"]              # 0x21d3
+ - "⇔": [t: "wtedy i tylko wtedy"]             # 0x21d4
+ - "⇕": [t: "podwójna strzałka w górę i w dół"]                # 0x21d5
+ - "⇖": [t: "podwójna strzałka na północny zachód"]             # 0x21d6
+ - "⇗": [t: "podwójna strzałka na północny wschód"]             # 0x21d7
+ - "⇘": [t: "podwójna strzałka na południowy wschód"]             # 0x21d8
+ - "⇙": [t: "podwójna strzałka na południowy zachód"]             # 0x21d9
+ - "⇚": [t: "lewy potrójny strzałka"]              # 0x21da
+ - "⇛": [t: "prawy potrójny strzałka"]             # 0x21db
+ - "⇜": [t: "falista strzałka w lewo"]            # 0x21dc
+ - "⇝": [t: "falista strzałka w prawo"]           # 0x21dd
+ - "⇞": [t: "strzałka w górę z podwójną kreską"]    # 0x21de
+ - "⇟": [t: "strzałka w dół z podwójną kreską"]  # 0x21df
+ - "⇠": [t: "przerywana strzałka w lewo"]              # 0x21e0
+ - "⇡": [t: "przerywana strzałka w górę"]                # 0x21e1
+ - "⇢": [t: "przerywana strzałka w prawo"]             # 0x21e2
+ - "⇣": [t: "przerywana strzałka w dół"]              # 0x21e3
+ - "⇤": [t: "strzałka w lewo do kreski"]              # 0x21e4
+ - "⇥": [t: "strzałka w prawo do kreski"]             # 0x21e5
+ - "⇦": [t: "biała strzałka w lewo"]               # 0x21e6
+ - "⇧": [t: "biała strzałka w górę"]                 # 0x21e7
+ - "⇨": [t: "biała strzałka w prawo"]              # 0x21e8
+ - "⇩": [t: "biała strzałka w dół"]               # 0x21e9
+ - "⇪": [t: "biała strzałka w górę od kreski"]        # 0x21ea
+ - "⇫": [t: "górna biała strzałka na podstawie"]     # 0x21eb
+ - "⇬": [t: "górna biała strzałka na podstawie z kreską poziomą"] # 0x21ec
+ - "⇭": [t: "górna biała strzałka na podstawie z kreską pionową"] # 0x21ed
+ - "⇮": [t: "górny biały podwójna strzałka"]          # 0x21ee
+ - "⇯": [t: "górna biała podwójna strzałka na podstawie"] # 0x21ef
+ - "⇰": [t: "biała strzałka w prawo od ściany"]    # 0x21f0
+ - "⇱": [t: "strzałka północno-zachodnia do narożnika"]          # 0x21f1
+ - "⇲": [t: "strzałka południowo-wschodnia do narożnika"]          # 0x21f2
+ - "⇳": [t: "biała strzałka w górę i w dół"]                 # 0x21f3
+ - "⇴": [t: "strzałka w prawo z małym okręgiem"]  # 0x21f4
+ - "⇵": [t: "strzałka w dół po lewej od strzałki w górę"] # 0x21f5
+ - "⇶": [t: "trzy strzałki w prawo"]             # 0x21f6
+ - "⇷": [t: "strzałka w lewo z pionową kreską"] # 0x21f7
+ - "⇸": [t: "strzałka w prawo z pionową kreską"] # 0x21f8
+ - "⇹": [t: "strzałki w lewo i w prawo z pionową kreską"] # 0x21f9
+ - "⇺": [t: "strzałka w lewo z podwójną pionową kreską"] # 0x21fa
+ - "⇻": [t: "strzałka w prawo z podwójną pionową kreską"] # 0x21fb
+ - "⇼": [t: "strzałki w lewo i w prawo z podwójną pionową kreską"] # 0x21fc
+ - "⇽": [t: "strzałka w lewo z otwartym grotem"]         # 0x21fd
+ - "⇾": [t: "strzałka w prawo z otwartym grotem"]        # 0x21fe
+ - "⇿": [t: "strzałka w lewo i w prawo z otwartymi grotami"]        # 0x21ff
+ - "∀": [t: "dla każdego"]                             # 0x2200
+ - "∁":                                          # 0x2201
+     - t: "dopełnienie"
+ - "∂":                                          # 0x2202
+     - test: 
+         if: "$Verbosity='Terse'"
+         then: [t: "cząstkowe"]
+         else: [t: "pochodna cząstkowa"]
+ - "∃": [t: "istnieje"]                        # 0x2203
+ - "∄": [t: "nie istnieje"]                # 0x2204
+ - "∅": [T: "zbiór pusty"]                           # 0x2205
+ - "∆":                                          # 0x2206
+     - test:
+         if: "following-sibling::*"
+         then_test:
+            if: "$Verbosity!='Terse'"
+            then: [t: "laplasjan"]     # "LahPlahsian" sounds better than "laplacian" in speech engines tested
+            else: [t: "laplasjan"]
+         else: [t: "laplasjan"]
+
+ - "∇": [t: "nabla"]                           # 0x2207
+ - "∉":                                          # 0x2209
+    # rule is identical to 0x2208
+     - test:
+        if: "$SpeechStyle != 'ClearSpeak'"
+        then: [t: "nie jest elementem zbioru"]
+        # Several options for speaking elements in ClearSpeak -- they split between being inside a set or not and then the option
+        else_test:
+            if: "../../self::m:set or ../../../self::m:set" # inside a set
+            then_test:
+              - if: $ClearSpeak_SetMemberSymbol = 'Auto' or $ClearSpeak_SetMemberSymbol = 'In'
+                then: [t: "nie należy do"]
+              - else_if: $ClearSpeak_SetMemberSymbol = 'Member'
+                then: [t: "nie jest elementem zbioru"]
+              - else_if: $ClearSpeak_SetMemberSymbol = 'Element'
+                then: [t: "nie jest elementem zbioru"]
+              - else: [t: "nienależące do"]             # $ClearSpeak_SetMemberSymbol = 'Belongs'
+            else_test:
+              - if: $ClearSpeak_SetMemberSymbol = 'Auto' or $ClearSpeak_SetMemberSymbol = 'Member'
+                then: [t: "nie jest elementem zbioru"]
+              - else_if: $ClearSpeak_SetMemberSymbol = 'Element'
+                then: [t: "nie jest elementem zbioru"]
+              - else_if: $ClearSpeak_SetMemberSymbol = 'In'
+                then: [t: "nie należy do"]
+              - else: [t: "nie należy do"]              # $ClearSpeak_SetMemberSymbol = 'Belongs'
+ - "∊":                                          # 0x220a
+     - test:
+        if: "$SpeechStyle != 'ClearSpeak'"
+        then:
+        - test:
+            if: "$Verbosity!='Terse' and not(parent::m:set)"    # "the set x is an element of ..." sounds bad
+            then: [T: "jest"]
+        - t: "element zbioru"
+        # Several options for speaking elements in ClearSpeak -- they split between being inside a set or not and then the option
+        else_test:
+            if: "../../self::m:set or ../../../self::m:set" # inside a set
+            then_test:
+              - if: $ClearSpeak_SetMemberSymbol = 'Auto' or $ClearSpeak_SetMemberSymbol = 'In'
+                then: [T: "do"]
+              - else_if: $ClearSpeak_SetMemberSymbol = 'Member'
+                then: [t: "element zbioru"]
+              - else_if: $ClearSpeak_SetMemberSymbol = 'Element'
+                then: [t: "należy do"]
+              - else: [t: "należące do"]             # $ClearSpeak_SetMemberSymbol = 'Belongs'
+            else_test:
+              - if: $ClearSpeak_SetMemberSymbol = 'Auto' or $ClearSpeak_SetMemberSymbol = 'Member'
+                then: [t: "jest elementem zbioru"]
+              - else_if: $ClearSpeak_SetMemberSymbol = 'Element'
+                then: [t: "jest elementem zbioru"]
+              - else_if: $ClearSpeak_SetMemberSymbol = 'In'
+                then: [t: "należy do"]
+              - else: [t: "należy do"]              # $ClearSpeak_SetMemberSymbol = 'Belongs'
+ - "∋": [t: "zawiera element"]                 # 0x220b
+ - "∌": [t: "nie zawiera elementu"]         # 0x220c
+ - "∍": [t: "zawiera element"]                 # 0x220d
+ - "∎": [t: "koniec dowodu"]                        # 0x220e
+ - "∏": [T: "iloczyn"]                             # 0x220f
+ - "∐": [t: "koprodukt"]                           # 0x2210
+ - "∑": [T: "suma"]                                 # 0x2211
+ - "−": [T: "minus"]                               # 0x2212
+ - "∓": [T: "minus plus"]                       # 0x2213
+ - "∔": [t: "kropka plus"]                            # 0x2214
+ - "∕": [T: "podzielone przez"]                          # 0x2215
+ - "∖": [t: "zbiór minus"]                           # 0x2216
+ - "∗": [T: "razy"]                               # 0x2217
+ - "∘": [t: "złożone z"]                       # 0x2218
+ - "∙":                                            # 0x2219
+    - test: 
+        if: "@data-chem-formula-op"
+        then: [T: "kropka"]
+        else: [T: "razy"]
+
+ - "√":                                          # 0x221a
+     - t: "pierwiastek kwadratowy z"
+ - "∛":                                          # 0x221b
+     - t: "pierwiastek sześcienny z"
+ - "∜":                                          # 0x221c
+     - t: "czwarty pierwiastek z"
+ - "∝":                                          # 0x221d
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [T: "jest"]
+     - t: "proporcjonalne do"
+ - "∞":
+    - test:
+        if: "ancestor::*[self::m:limit or self::m:limit-sup or self::m:limit-inf or self::m:large-op]"
+        then: [T: "nieskończoności"]
+        else: [T: "nieskończoność"]                          # 0x221e
+ - "∟": [t: "kąt prosty"]                         # 0x221f
+ - "∠": [t: "kąt"]                               # 0x2220
+ - "∡": [t: "kąt mierzony"]                      # 0x2221
+ - "∢": [t: "kąt sferyczny"]                     # 0x2222
+ - "∣": [T: "dzieli"]                              # 0x2223
+ - "∤": [t: "nie dzieli"]                      # 0x2224
+ - "∧": [T: "i"]                                 # 0x2227
+ - "∨": [T: "lub"]                                  # 0x2228
+ - "∩": [T: "przecięcie"]                        # 0x2229
+ - "∪": [T: "suma zbiorów"]                               # 0x222a
+ - "∫": [T: "całka"]                            # 0x222b
+ - "∬": [t: "całka podwójna"]                     # 0x222c
+ - "∭": [t: "całka potrójna"]                     # 0x222d
+ - "∮": [t: "całka krzywoliniowa"]                    # 0x222e
+ - "∯": [t: "całka powierzchniowa"]                    # 0x222f
+ - "∰": [t: "całka objętościowa"]                     # 0x2230
+ - "∱": [t: "całka zgodnie z ruchem wskazówek zegara"]                  # 0x2231
+ - "∲": [t: "całka krzywoliniowa zgodnie z ruchem wskazówek zegara"]          # 0x2232
+ - "∳": [t: "całka krzywoliniowa przeciwnie do ruchu wskazówek zegara"]      # 0x2233
+ - "∴": [t: "zatem"]                           # 0x2234
+ - "∵": [t: "ponieważ"]                             # 0x2235
+ - "∶":                                          # 0x2236
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [T: "jest"]
+     - T: "do"
+ - "∷": [t: "jako"]                                  # 0x2237
+ - "∸": [t: "kropka minus"]                           # 0x2238
+ - "∹": [t: "ma nadmiar względem"]              # 0x2239
+ - "∺":                                          # 0x223a
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [T: "jest"]
+     - t: "geometrycznie proporcjonalne do"
+ - "∻":                                          # 0x223b
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [T: "jest"]
+     - t: "homotetyczne do"
+ - "∼": [t: "tylda"]                            # 0x223c
+ - "∽": [t: "odwrócona tylda"]                      # 0x223d
+ - "∾":                                          # 0x223e
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [T: "jest"]
+     - t: "most dodatnie"
+ - "∿": [t: "fala sinusoidalna"]                           # 0x223f
+ - "≀": [t: "iloczyn wieńcowy"]                      # 0x2240
+ - "≁": [t: "nie jest podobne"]                           # 0x2241
+ - "≂": [t: "minus tylda"]                         # 0x2242
+ - "≃":                                          # 0x2243
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [T: "jest"]
+     - T: "asymptotycznie równe"
+ - "≄":                                          # 0x2244
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [T: "jest"]
+     - T: "nie asymptotycznie równe"
+ - "≅":                                          # 0x2245
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [T: "jest"]
+     - t: "przystające do"
+ - "≆":                                          # 0x2246
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [T: "jest"]
+     - T: "w przybliżeniu ale nie równe"
+ - "≇":                                          # 0x2247
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [T: "jest"]
+     - t: "nie przystające do"
+ - "≈":                                          # 0x2248
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [T: "jest"]
+     - T: "w przybliżeniu równe"
+ - "≉":                                          # 0x2249
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [T: "jest"]
+     - T: "nie w przybliżeniu równe"
+ - "≊":                                          # 0x224a
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [T: "jest"]
+     - T: "w przybliżeniu równe lub równe"
+ - "≋": [t: "potrójny tylda"]                        # 0x224b
+ - "≌": [T: "wszystkie równe"]                    # 0x224c
+ - "≍":                                          # 0x224d
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [T: "jest"]
+     - t: "Równoważne"
+ - "≎":                                          # 0x224e
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [T: "jest"]
+     - T: "geometrycznie równoważne"
+ - "≏":                                          # 0x224f
+     - t: "różnica między"
+ - "≐": [t: "dąży do granicy"]                # 0x2250
+ - "≑":                                          # 0x2251
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [T: "jest"]
+     - T: "geometrycznie równe"
+ - "≒":                                          # 0x2252
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [T: "jest"]
+     - T: "w przybliżeniu równe lub obrazem"
+ - "≓":                                          # 0x2253
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [t: "jest"]
+     - T: "obrazem lub w przybliżeniu równe"
+ - "≔": [t: "dwukropek równa się"]                        # 0x2254
+ - "≕": [t: "równa się dwukropek"]                        # 0x2255
+ - "≖": [t: "pierścień w znaku równości"]                    # 0x2256
+ - "≗":                                          # 0x2257
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [T: "jest"]
+     - T: "w przybliżeniu równe"
+ - "≘": [t: "odpowiada"]                      # 0x2258
+ - "≙": [t: "estymuje"]                           # 0x2259
+ - "≚":                                          # 0x225a
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [T: "jest"]
+     - t: "równokątne do"
+ - "≛": [t: "gwiazda równa się"]                         # 0x225b
+ - "≜": [t: "delta równa się"]                        # 0x225c
+ - "≝": [t: "jest z definicji równe"]                    # 0x225d
+ - "≞":                                          # 0x225e
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [T: "jest"]
+     - t: "mierzone na"
+ - "≟": [t: "ma nieznaną relację z"]    # 0x225f
+ - "≠":                                          # 0x2260
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [T: "jest"]
+     - T: "nie równa się"
+ - "≡":                                          # 0x2261
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [T: "jest"]
+     - t: "identyczne z"
+ - "≢":                                          # 0x2262
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [T: "jest"]
+     - t: "nie identyczne z"
+ - "≣":                                          # 0x2263
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [T: "jest"]
+     - t: "ściśle równoważne"
+ - "≦": [t: "mniejsze nad równe"]             # 0x2266
+ - "≧": [t: "większe nad równe"]          # 0x2267
+ - "≨":                                          # 0x2268
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [T: "jest"]
+     - t: "mniejsze niż ale nie równa się"
+ - "≩":                                          # 0x2269
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [T: "jest"]
+     - t: "większe niż ale nie równa się"
+ - "≪":                                          # 0x226a
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [T: "jest"]
+     - t: "znacznie mniejsze niż"
+ - "≫":                                          # 0x226b
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [T: "jest"]
+     - t: "znacznie większe niż"
+ - "≬":                                          # 0x226c
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [T: "jest"]
+     - t: "między"
+ - "≭":                                          # 0x226d
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [T: "jest"]
+     - t: "nie równoważne"
+ - "≮":                                          # 0x226e
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [T: "jest"]
+     - t: "nie mniejsze niż"
+ - "≯":                                          # 0x226f
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [T: "jest"]
+     - t: "nie większe niż"
+ - "≰":                                          # 0x2270
+     - t: "nie jest mniejsze ani równe"
+ - "≱":                                          # 0x2271
+     - t: "nie jest większe ani równe"
+ - "≲":                                          # 0x2272
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [T: "jest"]
+     - t: "mniejsze niż lub równoważne"
+ - "≳":                                          # 0x2273
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [T: "jest"]
+     - t: "większe niż lub równoważne"
+ - "≴":                                          # 0x2274
+     - t: "nie jest mniejsze ani równoważne"
+ - "≵":                                          # 0x2275
+     - t: "nie jest większe ani równoważne"
+ - "≶":                                          # 0x2276
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [T: "jest"]
+     - t: "mniejsze lub większe niż"
+ - "≷":                                          # 0x2277
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [T: "jest"]
+     - t: "większe lub mniejsze niż"
+ - "≸":                                          # 0x2278
+     - t: "nie jest mniejsze ani większe niż"
+ - "≹":                                          # 0x2279
+     - t: "nie jest większe ani mniejsze niż"
+ - "≺": [t: "poprzedza"]                            # 0x227a
+ - "≻": [t: "następuje po"]                            # 0x227b
+ - "≼": [T: "poprzedza lub jest równe"]             # 0x227c
+ - "≽": [T: "następuje po lub jest równe"]             # 0x227d
+ - "≾": [t: "poprzedza lub jest równoważne"]        # 0x227e
+ - "≿": [t: "następuje po lub jest równoważne"]        # 0x227f
+ - "⊀": [T: "nie poprzedza"]                    # 0x2280
+ - "⊁": [T: "nie następuje po"]                    # 0x2281
+ - "⊂":                                          # 0x2282
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [t: "jest"]
+     - t: "podzbiór"
+ - "⊃":                                          # 0x2283
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [t: "jest"]
+     - t: "nadzbiór"
+ - "⊄":                                          # 0x2284
+     - t: "nie jest podzbiorem"
+ - "⊅":                                          # 0x2285
+     - t: "nie jest nadzbiorem"
+ - "⊆":                                          # 0x2286
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [t: "jest"]
+     - t: "podzbiór lub równy"
+ - "⊇":                                          # 0x2287
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [t: "jest"]
+     - t: "nadzbiór lub równy"
+ - "⊈":                                          # 0x2288
+     - t: "nie jest podzbiorem ani nie jest równe"
+ - "⊉":                                          # 0x2289
+     - t: "nie jest nadzbiorem ani nie jest równe"
+ - "⊊": [t: "podzbiór z nie równa się"]         # 0x228a
+ - "⊋": [t: "nadzbiór z nie równa się"]       # 0x228b
+ - "⊌": [t: "wielozbiór"]                            # 0x228c
+ - "⊍": [t: "mnożenie wielozbiorów"]             # 0x228d
+ - "⊎": [t: "suma wielozbiorów"]                      # 0x228e
+ - "⊏": [T: "kwadratowo poprzedza"]                     # 0x228f
+ - "⊐": [T: "kwadratowo następuje po"]                  # 0x2290
+ - "⊑": [T: "kwadratowo poprzedza lub jest równe"]         # 0x2291
+ - "⊒": [T: "kwadratowo następuje po lub jest równe"]      # 0x2292
+ - "⊓": [t: "kwadratowa część wspólna"]                          # 0x2293
+ - "⊔": [t: "kwadratowa suma zbiorów"]                          # 0x2294
+ - "⊕": [t: "w kółku plus"]                        # 0x2295
+ - "⊖": [t: "w kółku minus"]                       # 0x2296
+ - "⊗": [t: "w kółku razy"]                       # 0x2297
+ - "⊘": [t: "w kółku ukośnik"]                       # 0x2298
+ - "⊙": [t: "kropka w kółku"]                # 0x2299
+ - "⊚": [t: "pierścień w kółku"]                        # 0x229a
+ - "⊛": [t: "gwiazdka w kółku"]                    # 0x229b
+ - "⊜": [t: "równa się w kółku"]                      # 0x229c
+ - "⊝": [t: "kreska w kółku"]                        # 0x229d
+ - "⊞": [t: "plus w kwadracie"]                        # 0x229e
+ - "⊟": [t: "minus w kwadracie"]                       # 0x229f
+ - "⊠": [t: "razy w kwadracie"]                       # 0x22a0
+ - "⊡": [t: "kropka w kwadracie"]                # 0x22a1
+ - "⊢": [t: "dowodzi"]                              # 0x22a2
+ - "⊣": [t: "jest dowodzone przez"]                      # 0x22a3
+ - "⊤": [t: "góra"]                                 # 0x22a4
+ - "⊥":                                          # 0x22a5
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [T: "jest"]
+     - t: "dół"
+ - "⊦": [t: "redukuje się do"]                          # 0x22a6
+ - "⊧": [t: "modeluje"]                              # 0x22a7
+ - "⊨":                                          # 0x22a8
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [T: "jest"]
+     - t: "prawdziwe"
+ - "⊩": [t: "wymusza"]                              # 0x22a9
+ - "⊪": [t: "potrójna pionowa kreska z prawym znacznikiem dedukcji"] # 0x22aa
+ - "⊫": [t: "podwójna pionowa kreska z podwójnym prawym znacznikiem dedukcji"] # 0x22ab
+ - "⊬": [t: "nie dowodzi"]                      # 0x22ac
+ - "⊭":                                          # 0x22ad
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [T: "jest"]
+     - t: "nie jest prawdziwe"
+ - "⊮": [t: "nie wymusza"]                      # 0x22ae
+ - "⊯": [t: "zanegowana podwójna pionowa kreska z podwójnym prawym znacznikiem dedukcji"] # 0x22af
+ - "⊰": [t: "poprzedza pod relacją"]             # 0x22b0
+ - "⊱": [t: "następuje po pod relacją"]             # 0x22b1
+ - "⊲":                                          # 0x22b2
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [T: "jest"]
+     - t: "normalną podgrupą"
+ - "⊳": [t: "zawiera jako normalną podgrupę"]       # 0x22b3
+ - "⊴":                                          # 0x22b4
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [T: "jest"]
+     - t: "normalną podgrupą lub równe"
+ - "⊵": [t: "zawiera jako normalną podgrupę lub jest równe"] # 0x22b5
+ - "⊶":                                          # 0x22b6
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [T: "jest"]
+     - t: "oryginałem"
+ - "⊷":                                          # 0x22b7
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [T: "jest"]
+     - t: "obrazem"
+ - "⊸": [t: "multimapa"]                            # 0x22b8
+ - "⊹": [t: "macierz sprzężona hermitowsko"]          # 0x22b9
+ - "⊺": [t: "interkalacja"]                         # 0x22ba
+ - "⊻": [t: "alternatywa wykluczająca"]                                 # 0x22bb
+ - "⊼": [t: "negacja koniunkcji"]                                # 0x22bc
+ - "⊽": [t: "negacja alternatywy"]                                 # 0x22bd
+ - "⊾": [t: "kąt prosty z łukiem"]                # 0x22be
+ - "⊿": [t: "prawy trójkąt"]                      # 0x22bf
+ - "⋀": [t: "logiczne I"]                         # 0x22c0
+ - "⋁": [t: "logiczne lub"]                          # 0x22c1
+ - "⋂": [T: "przecięcie"]                        # 0x22c2
+ - "⋃": [T: "suma zbiorów"]                               # 0x22c3
+ - "⋄": [t: "operator rombu"]                    # 0x22c4
+ - "⋅":                                             # 0x22c5
+    - test: 
+        if: "@data-chem-formula-op"
+        then: [T: "kropka"]
+        else: [T: "razy"]
+
+ - "⋆": [T: "razy"]                               # 0x22c6
+ - "⋇": [t: "znak dzielenia razy"]                      # 0x22c7
+ - "⋈": [t: "muszka"]                              # 0x22c8
+ - "⋉":                                          # 0x22c9
+    - test: 
+        if: "$Verbosity!='Terse'"
+        then: [T: "jest"]
+    - t: "lewym iloczynem półprostym z czynnikiem normalnym"
+ - "⋊":                                          # 0x22ca
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [T: "jest"]
+     - t: "prawym iloczynem półprostym z czynnikiem normalnym"
+ - "⋋":                                          # 0x22cb
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [T: "jest"]
+     - t: "lewym iloczynem półprostym"
+ - "⋌":                                          # 0x22cc
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [T: "jest"]
+     - t: "prawym iloczynem półprostym"
+ - "⋍": [t: "odwrócona tylda równa się"]               # 0x22cd
+ - "⋎": [t: "zakręcone logiczne lub"]                    # 0x22ce
+ - "⋏": [t: "zakręcone logiczne i"]                   # 0x22cf
+ - "⋐":                                          # 0x22d0
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [T: "jest"]
+     - t: "podwójnym podzbiorem"
+ - "⋑":                                          # 0x22d1
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [T: "jest"]
+     - t: "podwójnym nadzbiorem"
+ - "⋒":                                          # 0x22d2
+     - t: "podwójna część wspólna"
+ - "⋓":                                          # 0x22d3
+     - t: "podwójna suma zbiorów"
+ - "⋔":                                          # 0x22d4
+     - t: "właściwa część wspólna"
+ - "⋕":                                          # 0x22d5
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [T: "jest"]
+     - t: "równe i równoległe do"
+ - "⋖": [t: "mniejsze niż z kropką"]                  # 0x22d6
+ - "⋗": [t: "większe niż z kropką"]               # 0x22d7
+ - "⋘":                                          # 0x22d8
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [T: "jest"]
+     - t: "bardzo znacznie mniejsze niż"
+ - "⋙":                                          # 0x22d9
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [T: "jest"]
+     - t: "bardzo znacznie większe niż"
+ - "⋚":                                          # 0x22da
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [T: "jest"]
+     - t: "mniejsze niż, równe lub większe niż"
+ - "⋛":                                          # 0x22db
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [T: "jest"]
+     - t: "większe niż, równe lub mniejsze niż"
+ - "⋜":                                          # 0x22dc
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [T: "jest"]
+     - t: "równe lub mniejsze niż"
+ - "⋝":                                          # 0x22dd
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [T: "jest"]
+     - t: "równe lub większe niż"
+ - "⋞":                                          # 0x22de
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [T: "jest"]
+     - t: "równe lub poprzedza"
+ - "⋟":                                          # 0x22df
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [T: "jest"]
+     - t: "równe lub następuje po"
+ - "⋠": [t: "nie poprzedza ani nie jest równe"]    # 0x22e0
+ - "⋡": [t: "nie następuje po ani nie jest równe"]    # 0x22e1
+ - "⋢": [t: "nie poprzedza kwadratowo ani nie jest równe"]     # 0x22e2
+ - "⋣": [t: "nie następuje kwadratowo po ani nie jest równe"]  # 0x22e3
+ - "⋤": [t: "poprzedza kwadratowo, ale nie jest równe"]     # 0x22e4
+ - "⋥": [t: "następuje kwadratowo po, ale nie jest równe"]  # 0x22e5
+ - "⋦":                                          # 0x22e6
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [T: "jest"]
+     - t: "mniejsze niż, ale nie równoważne"
+ - "⋧":                                          # 0x22e7
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [T: "jest"]
+     - t: "większe niż, ale nie równoważne"
+ - "⋨": [t: "poprzedza, ale nie jest równoważne"]   # 0x22e8
+ - "⋩": [t: "następuje po, ale nie jest równoważne"]   # 0x22e9
+ - "⋪":                                          # 0x22ea
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [T: "jest"]
+     - t: "nie jest normalną podgrupą"
+ - "⋫": [t: "nie zawiera jako normalnej podgrupy"] # 0x22eb
+ - "⋬":                                          # 0x22ec
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [T: "jest"]
+     - t: "nie jest normalną podgrupą ani równe"
+ - "⋭": [t: "nie zawiera jako normalnej podgrupy ani równe"] # 0x22ed
+ - "⋮": [t: "pionowy wielokropek"]                   # 0x22ee
+ - "⋯": [t: "trzy kropki"]                         # 0x22ef
+ - "⋰": [t: "ukośny wielokropek w górę"]           # 0x22f0
+ - "⋱": [t: "ukośny wielokropek w dół"]                   # 0x22f1
+ - "⋲": [t: "należy do z długą poziomą kreską"] # 0x22f2
+ - "⋳": [t: "należy do z pionową kreską na końcu i poziomą kreską"] # 0x22f3
+ - "⋴": [t: "należy do z pionową kreską na końcu i poziomą kreską"] # 0x22f4
+ - "⋵": [t: "należy do z kropką nad"]           # 0x22f5
+ - "⋶": [t: "należy do z kreską nad"]             # 0x22f6
+ - "⋷": [t: "należy do z kreską nad"]             # 0x22f7
+ - "⋸": [t: "należy do z podkreśleniem"]            # 0x22f8
+ - "⋹": [t: "należy do z dwiema poziomymi kreskami"] # 0x22f9
+ - "⋺": [t: "zawiera z długą poziomą kreską"] # 0x22fa
+ - "⋻": [t: "zawiera z pionową kreską na końcu i poziomą kreską"] # 0x22fb
+ - "⋼": [t: "zawiera z pionową kreską na końcu i poziomą kreską"] # 0x22fc
+ - "⋽": [t: "zawiera z kreską nad"]               # 0x22fd
+ - "⋾": [t: "zawiera z kreską nad"]               # 0x22fe
+ - "⋿": [t: "przynależność do wielozbioru w notacji Z"]           # 0x22ff
+ - "⌀": [t: "znak średnicy"]                            # 0x2300
+ - "⌁": [t: "strzałka elektryczna"]                      # 0x2301
+ - "⌂": [t: "dom"]                               # 0x2302
+ - "⌃": [t: "górny grot strzałki"]                        # 0x2303
+ - "⌄": [t: "dolny grot strzałki"]                      # 0x2304
+ - "⌅": [t: "rzutowy"]                          # 0x2305
+ - "⌆": [t: "perspektywiczny"]                         # 0x2306
+ - "⌇": [t: "linia falista"]                           # 0x2307
+ - "⌈": [t: "lewy sufit"]                        # 0x2308
+ - "⌉": [t: "prawy sufit"]                       # 0x2309
+ - "⌊": [t: "lewa podłoga"]                          # 0x230a
+ - "⌋": [t: "prawa podłoga"]                         # 0x230b
+ - "⌌": [t: "dolny prawy znacznik kadrowania"]                   # 0x230c
+ - "⌍": [t: "dolny lewy znacznik kadrowania"]                    # 0x230d
+ - "⌎": [t: "górny prawy znacznik kadrowania"]                      # 0x230e
+ - "⌏": [t: "górny lewy znacznik kadrowania"]                       # 0x230f
+ - "⌐": [t: "odwrócony nie znak"]                   # 0x2310
+ - "⌑": [t: "kwadrat romb"]                      # 0x2311
+ - "⌒": [T: "łuk"]                                 # 0x2312
+ - "⌓": [t: "odcinek"]                             # 0x2313
+ - "⌔": [t: "sektor"]                              # 0x2314
+ - "⌕": [t: "rejestrator telefoniczny"]                  # 0x2315
+ - "⌖": [t: "celownik wskaźnika pozycji"]       # 0x2316
+ - "⌗": [t: "kwadrat danych ekranowych"]                     # 0x2317
+ - "⌘": [t: "znak miejsca zainteresowania"]              # 0x2318
+ - "⌙": [t: "odwrócony nie znak"]                     # 0x2319
+ - "⌚": [t: "zegarek"]                               # 0x231a
+ - "⌛": [t: "klepsydra"]                           # 0x231b
+ - "⌜": [t: "górny lewy narożnik"]                     # 0x231c
+ - "⌝": [t: "górny prawy narożnik"]                    # 0x231d
+ - "⌞": [t: "dolny lewy narożnik"]                  # 0x231e
+ - "⌟": [t: "dolny prawy narożnik"]                 # 0x231f
+ - "⌠": [t: "górna połowa całki"]                   # 0x2320
+ - "⌡": [t: "dolna połowa całki"]                # 0x2321
+ - "⌢": [t: "łuk w dół"]                               # 0x2322
+ - "⌣": [t: "łuk w górę"]                               # 0x2323
+ - "⌤": [t: "górny grot strzałki między dwiema poziomymi kreskami"] # 0x2324
+ - "⌥": [t: "klawisz opcji"]                          # 0x2325
+ - "⌦": [t: "wymaż w prawo"]                  # 0x2326
+ - "⌧": [t: "X w prostokątnej ramce"]                # 0x2327
+ - "⌨": [t: "klawiatura"]                            # 0x2328
+ - "〈": [t: "kąt skierowany w lewo nawias kwadratowy"]         # 0x2329
+ - "〉": [t: "kąt skierowany w prawo nawias kwadratowy"]        # 0x232a
+ - "⌫": [t: "wymaż w lewo"]                   # 0x232b
+ - "⌬": [t: "pierścień benzenowy"]                        # 0x232c
+ - "⌭": [t: "walcowość"]                        # 0x232d
+ - "⌮": [t: "profil dookoła"]                  # 0x232e
+ - "⌯": [t: "symetria"]                            # 0x232f
+ - "⌰": [t: "bicie całkowite"]                        # 0x2330
+ - "⌱": [t: "początek wymiarowania"]                    # 0x2331
+ - "⌲": [t: "stożkowatość"]                       # 0x2332
+ - "⌳": [t: "nachylenie"]                               # 0x2333
+ - "⌴": [t: "pogłębienie walcowe"]                         # 0x2334
+ - "⌵": [t: "pogłębienie stożkowe"]                         # 0x2335
+ - "⌶": [t: "belka i APL"]                         # 0x2336
+ - "⌽": [t: "okrąg z kreską pionową APL"]                   # 0x233d
+ - "⌿": [t: "apl ukośnik kreska"]                      # 0x233f
+ - "⍰": [t: "nieznana ramka"]                        # 0x2370
+ - "⍼": [t: "kąt prosty z dolną strzałką zygzakowatą"]       # 0x237c
+ - "⎔": [t: "sześciokąt"]                            # 0x2394
+ - "⎕": [t: "ramka"]                                # 0x2395
+ - "⎶": [t: "dolny nawias kwadratowy nad górnym nawiasem kwadratowym"] # 0x23b6
+ - "⏜": [t: "górny nawias"]                           # 0x23dc
+ - "⏝": [t: "dolny nawias"]                        # 0x23dd
+ - "⏞": [t: "górny nawias klamrowy"]                           # 0x23de
+ - "⏟": [t: "dolny nawias klamrowy"]                        # 0x23df
+ - "⏠": [t: "górny nawias skorupowy"]          # 0x23e0
+ - "⏡": [t: "dolny nawias skorupowy"]        # 0x23e1
+ - "⏢": [t: "biały trapez"]                    # 0x23e2
+ - "⏣": [t: "benzenowy pierścień z okręgiem po prawej"]          # 0x23e3
+ - "⏤": [t: "prostoliniowość"]                       # 0x23e4
+ - "⏥": [t: "płaskość"]                           # 0x23e5
+ - "⏦": [t: "prąd przemienny"]                   # 0x23e6
+ - "⏧": [t: "symbol elektrycznego przecięcia"]            # 0x23e7
+ - "①-⑨":    # 0x2460 - 0x2469
+    - t: "w kółku"
+    - spell: "translate('.', '①②③④⑤⑥⑦⑧⑨', '123456789')"
+ - "⑩": [t: "w kółku dziesięć"]                         # 0x2469
+ - "⑪": [t: "w kółku jedenaście"]                      # 0x246a
+ - "⑫": [t: "w kółku dwanaście"]                      # 0x246b
+ - "⑬": [t: "w kółku trzynaście"]                    # 0x246c
+ - "⑭": [t: "w kółku czternaście"]                    # 0x246d
+ - "⑮": [t: "w kółku piętnaście"]                     # 0x246e
+ - "⑯": [t: "w kółku szesnaście"]                     # 0x246f
+ - "⑰": [t: "w kółku siedemnaście"]                   # 0x2470
+ - "⑱": [t: "w kółku osiemnaście"]                    # 0x2471
+ - "⑳": [t: "w kółku dwadzieścia"]                      # 0x2473
+ - "⑴-⑼":    # 0x2474 - 0x247d
+    - t: "w nawiasie"
+    - spell: "translate('.', '⑴⑵⑶⑷⑸⑹⑺⑻⑼', '123456789')"
+ - "⑽": [t: "w nawiasie dziesięć"]                   # 0x247d
+ - "⑾": [t: "w nawiasie jedenaście"]                # 0x247e
+ - "⑿": [t: "w nawiasie dwanaście"]                # 0x247f
+ - "⒀": [t: "w nawiasie trzynaście"]              # 0x2480
+ - "⒁": [t: "w nawiasie czternaście"]              # 0x2481
+ - "⒂": [t: "w nawiasie piętnaście"]               # 0x2482
+ - "⒃": [t: "w nawiasie szesnaście"]               # 0x2483
+ - "⒄": [t: "w nawiasie siedemnaście"]             # 0x2484
+ - "⒅": [t: "w nawiasie osiemnaście"]              # 0x2485
+ - "⒆": [t: "w nawiasie dziewiętnaście"]              # 0x2486
+ - "⒇": [t: "w nawiasie dwadzieścia"]                # 0x2487
+ - "⒈-⒐":    # 0x2488 - 0x2491
+    - spell: "translate('.', '⒈⒉⒊⒋⒌⒍⒎⒏⒐', '123456789')"
+    - t: "z kropką"
+ - "⒑": [t: "dziesięć z kropką"]                     # 0x2491
+ - "⒒": [t: "jedenaście z kropką"]                  # 0x2492
+ - "⒓": [t: "dwanaście z kropką"]                  # 0x2493
+ - "⒔": [t: "trzynaście z kropką"]                # 0x2494
+ - "⒕": [t: "czternaście z kropką"]                # 0x2495
+ - "⒖": [t: "piętnaście z kropką"]                 # 0x2496
+ - "⒗": [t: "szesnaście z kropką"]                 # 0x2497
+ - "⒘": [t: "siedemnaście z kropką"]               # 0x2498
+ - "⒙": [t: "osiemnaście z kropką"]                # 0x2499
+ - "⒚": [t: "dziewiętnaście z kropką"]                # 0x249a
+ - "⒛": [t: "dwadzieścia z kropką"]                  # 0x249b
+ - "⒜-⒵":                                         # 0x249c - 0x24b5
+    - t: "w nawiasie"
+    - spell: "translate('.', '⒜⒝⒞⒟⒠⒡⒢⒣⒤⒥⒦⒧⒨⒩⒪⒫⒬⒭⒮⒯⒰⒱⒲⒳⒴⒵', 'abcdefghijklmnopqrstuvwxyz')"
+
+ - "Ⓐ-ⓩ":                                         # 0x24b6 - 0x24cf
+    - t: "w kółku"
+    - spell: "translate('.', 'ⒶⒷⒸⒹⒺⒻⒼⒽⒾⒿⓀⓁⓂⓃⓄⓅⓆⓇⓈⓉⓊⓋⓌⓍⓎⓏ', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ')"
+
+ - "🅐-🅩":                                         # 0x1f150 - 0x1f169
+    - t: "czarny w kółku"
+    - spell: "translate('.', '🅐🅑🅒🅓🅔🅕🅖🅗🅘🅙🅚🅛🅜🅝🅞🅟🅠🅡🅢🅣🅤🅥🅦🅧🅨🅩', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ')"
+
+ - "ⓐ-ⓩ":                                         # 0x24d0 - 0x24e9
+    - t: "w kółku"
+    - spell: "translate('.', 'ⓐⓑⓒⓓⓔⓕⓖⓗⓘⓙⓚⓛⓜⓝⓞⓟⓠⓡⓢⓣⓤⓥⓦⓧⓨⓩ', 'abcdefghijklmnopqrstuvwxyz')"
+ - "⓪": [t: "w kółku zero"]                        # 0x24ea
+ - "⓫": [t: "czarny w kółku jedenaście"]                # 0x24eb
+ - "⓬": [t: "czarny w kółku dwanaście"]                # 0x24ec
+ - "⓭": [t: "czarny w kółku trzynaście"]              # 0x24ed
+ - "⓮": [t: "czarny w kółku czternaście"]              # 0x24ee
+ - "⓯": [t: "czarny w kółku piętnaście"]               # 0x24ef
+ - "⓰": [t: "czarny w kółku szesnaście"]               # 0x24f0
+ - "⓱": [t: "czarny w kółku siedemnaście"]             # 0x24f1
+ - "⓲": [t: "czarny w kółku osiemnaście"]              # 0x24f2
+ - "⓳": [t: "czarny w kółku dziewiętnaście"]              # 0x24f3
+ - "⓴": [t: "czarny w kółku dwadzieścia"]                # 0x24f4
+ - "⓵-⓽":    # 0x24f5 - 0x24fe
+    - t: "podwójny w kółku"
+    - spell: "translate('.', '⓵⓶⓷⓸⓹⓺⓻⓼⓽', '123456789')"
+ - "⓾": [t: "podwójny w kółku dziesięć"]                  # 0x24fe
+ - "⓿": [t: "czarny w kółku zero"]                  # 0x24ff
+ - "■": [t: "czarny kwadrat"]                        # 0x25a0
+ - "□": [t: "biały kwadrat"]                        # 0x25a1
+ - "▢": [t: "biały kwadrat z zaokrąglonymi narożnikami"]   # 0x25a2
+ - "▣": [t: "biały kwadrat zawierający mały czarny kwadrat"] # 0x25a3
+ - "▤": [t: "kwadrat z poziomym wypełnieniem"]      # 0x25a4
+ - "▥": [t: "kwadrat z pionowym wypełnieniem"]      # 0x25a5
+ - "▦": [t: "kwadrat z ortogonalnym kreskowanym wypełnieniem"] # 0x25a6
+ - "▧": [t: "kwadrat z wypełnieniem od góry po lewej do dołu po prawej"] # 0x25a7
+ - "▨": [t: "kwadrat z wypełnieniem od góry po prawej do dołu po lewej"] # 0x25a8
+ - "▩": [t: "kwadrat z ukośnym kreskowanym wypełnieniem"] # 0x25a9
+ - "▪": [t: "czarny mały kwadrat"]                  # 0x25aa
+ - "▫": [t: "biały mały kwadrat"]                  # 0x25ab
+ - "▬": [t: "czarny prostokąt"]                     # 0x25ac
+ - "▭": [t: "biały prostokąt"]                     # 0x25ad
+ - "▮": [t: "czarny pionowy prostokąt"]            # 0x25ae
+ - "▯": [t: "biały pionowy prostokąt"]            # 0x25af
+ - "▰": [t: "czarny Równoległobok"]                 # 0x25b0
+ - "▱": [t: "biały Równoległobok"]                 # 0x25b1
+ - "▲": [t: "czarny trójkąt skierowany w górę"]          # 0x25b2
+ - "△": [t: "trójkąt"]                            # 0x25b3
+ - "▴": [t: "czarny mały trójkąt skierowany w górę"]    # 0x25b4
+ - "▵": [t: "biały mały trójkąt skierowany w górę"]    # 0x25b5
+ - "▶": [t: "czarny trójkąt skierowany w prawo"]       # 0x25b6
+ - "▷": [t: "biały trójkąt skierowany w prawo"]       # 0x25b7
+ - "▸": [t: "czarny mały trójkąt skierowany w prawo"] # 0x25b8
+ - "▹": [t: "biały mały trójkąt skierowany w prawo"] # 0x25b9
+ - "►": [t: "czarny wskaźnik skierowany w prawo"]        # 0x25ba
+ - "▻": [t: "biały wskaźnik skierowany w prawo"]        # 0x25bb
+ - "▼": [t: "czarny trójkąt skierowany w dół"]        # 0x25bc
+ - "▽": [t: "biały trójkąt skierowany w dół"]        # 0x25bd
+ - "▾": [t: "czarny mały trójkąt skierowany w dół"]  # 0x25be
+ - "▿": [t: "biały mały trójkąt skierowany w dół"]  # 0x25bf
+ - "◀": [t: "czarny trójkąt skierowany w lewo"]        # 0x25c0
+ - "◁": [t: "biały trójkąt skierowany w lewo"]        # 0x25c1
+ - "◂": [t: "czarny mały trójkąt skierowany w lewo"]  # 0x25c2
+ - "◃": [t: "biały mały trójkąt skierowany w lewo"]  # 0x25c3
+ - "◄": [t: "czarny wskaźnik skierowany w lewo"]         # 0x25c4
+ - "◅": [t: "biały wskaźnik skierowany w lewo"]         # 0x25c5
+ - "◆": [t: "czarny romb"]                       # 0x25c6
+ - "◇": [t: "biały romb"]                       # 0x25c7
+ - "◈": [t: "biały romb zawierający czarny mały romb"] # 0x25c8
+ - "◉": [t: "rybie oko"]                             # 0x25c9
+ - "◊": [t: "romb"]                             # 0x25ca
+ - "○": [t: "białe koło"]                        # 0x25cb
+ - "◌": [t: "kropkowany okrąg"]                       # 0x25cc
+ - "◍": [t: "okrąg z pionowe wypełnienie"]           # 0x25cd
+ - "◎": [t: "tarcza"]                            # 0x25ce
+ - "●": [t: "czarne koło"]                        # 0x25cf
+ - "◐": [t: "okrąg z czarną lewą połową"]         # 0x25d0
+ - "◑": [t: "okrąg z czarną prawą połową"]        # 0x25d1
+ - "◒": [t: "okrąg z czarną dolną połową"]        # 0x25d2
+ - "◓": [t: "okrąg z czarną górną połową"]        # 0x25d3
+ - "◔": [t: "okrąg z czarną górną prawą ćwiartką"] # 0x25d4
+ - "◕": [t: "okrąg czarny poza górną lewą ćwiartką"] # 0x25d5
+ - "◖": [t: "czarne koło z lewą połową"]              # 0x25d6
+ - "◗": [t: "czarne koło z prawą połową"]             # 0x25d7
+ - "◘": [t: "odwrotność punkt"]                      # 0x25d8
+ - "◙": [t: "odwrotność białe koło"]                # 0x25d9
+ - "◚": [t: "górna połowa odwrotność białe koło"]     # 0x25da
+ - "◛": [t: "dolna połowa odwrotność białe koło"]     # 0x25db
+ - "◜": [t: "górny lewy ćwiartka łuk kołowy"]    # 0x25dc
+ - "◝": [t: "górny prawy ćwiartka łuk kołowy"]   # 0x25dd
+ - "◞": [t: "dolny prawy ćwiartka łuk kołowy"]   # 0x25de
+ - "◟": [t: "dolny lewy ćwiartka łuk kołowy"]    # 0x25df
+ - "◠": [t: "górna połowa okrąg"]                   # 0x25e0
+ - "◡": [t: "dolna połowa okrąg"]                   # 0x25e1
+ - "◢": [t: "czarny dolny prawy trójkąt"]          # 0x25e2
+ - "◣": [t: "czarny dolny lewy trójkąt"]           # 0x25e3
+ - "◤": [t: "czarny górny lewy trójkąt"]           # 0x25e4
+ - "◥": [t: "czarny górny prawy trójkąt"]          # 0x25e5
+ - "◦": [t: "złożenie"]                         # 0x25e6
+ - "◧": [t: "kwadrat z czarną lewą połową"]         # 0x25e7
+ - "◨": [t: "kwadrat z czarną prawą połową"]        # 0x25e8
+ - "◩": [t: "kwadrat z czarną górną lewą połową"]   # 0x25e9
+ - "◪": [t: "kwadrat z czarną dolną prawą połową"]  # 0x25ea
+ - "◫": [t: "biały kwadrat z linią dzielącą na pół"] # 0x25eb
+ - "◬": [t: "biały trójkąt skierowany w górę z kropką"] # 0x25ec
+ - "◭": [t: "trójkąt skierowany w górę z czarną lewą połową"] # 0x25ed
+ - "◮": [t: "trójkąt skierowany w górę z czarną prawą połową"] # 0x25ee
+ - "◯": [t: "duży okrąg"]                        # 0x25ef
+ - "◰": [t: "biały kwadrat z górną lewą ćwiartką"] # 0x25f0
+ - "◱": [t: "biały kwadrat z dolną lewą ćwiartką"] # 0x25f1
+ - "◲": [t: "biały kwadrat z dolną prawą ćwiartką"] # 0x25f2
+ - "◳": [t: "biały kwadrat z górną prawą ćwiartką"] # 0x25f3
+ - "◴": [t: "białe koło z górną lewą ćwiartką"] # 0x25f4
+ - "◵": [t: "białe koło z dolną lewą ćwiartką"] # 0x25f5
+ - "◶": [t: "białe koło z dolną prawą ćwiartką"] # 0x25f6
+ - "◷": [t: "białe koło z górną prawą ćwiartką"] # 0x25f7
+ - "◸": [t: "górny lewy trójkąt"]                 # 0x25f8
+ - "◹": [t: "górny prawy trójkąt"]                # 0x25f9
+ - "◺": [t: "dolny lewy trójkąt"]                 # 0x25fa
+ - "◻": [t: "biały średni kwadrat"]                 # 0x25fb
+ - "◼": [t: "czarny średni kwadrat"]                 # 0x25fc
+ - "◽": [t: "biały średni mały kwadrat"]           # 0x25fd
+ - "◾": [t: "czarny średni mały kwadrat"]           # 0x25fe
+ - "◿": [t: "dolny prawy trójkąt"]                # 0x25ff
+ - "★": [t: "czarna gwiazda"]                          # 0x2605
+ - "☆": [t: "biały gwiazda"]                          # 0x2606
+ - "☉": [t: "słońce"]                                 # 0x2609
+ - "☌": [t: "koniunkcja"]                         # 0x260c
+ - "☒": [t: "ramka wyboru z iksem"]                   # 0x2612
+ - "☽": [t: "przybywający księżyc"]                         # 0x263d
+ - "☾": [t: "ubywający księżyc"]                         # 0x263e
+ - "☿": [t: "Merkury"]                             # 0x263f
+ - "♀": [t: "żeńskie"]                              # 0x2640
+ - "♁": [t: "Ziemia"]                               # 0x2641
+ - "♂": [t: "męskie"]                                # 0x2642
+ - "♃": [t: "Jowisz"]                            # 0x2643
+ - "♄": [t: "Saturn"]                             # 0x2644
+ - "♅": [t: "Uran"]                             # 0x2645
+ - "♆": [t: "Neptun"]                           # 0x2646
+ - "♇": [t: "Pluton"]                             # 0x2647
+ - "♈": [t: "Baran"]                           # 0x2648
+ - "♉": [t: "Byk"]                          # 0x2649
+ - "♩": [t: "ćwierćnuta"]                      # 0x2669
+ - "♭": [t: "bemol"]                              # 0x266d
+ - "♮": [t: "kasownik"]                           # 0x266e
+ - "♯": [t: "krzyżyk"]                             # 0x266f
+ - "♠": [t: "czarny pik"]                  # 0x2660
+ - "♡": [t: "biały kier"]                  # 0x2661
+ - "♢": [t: "biały karo"]                # 0x2662
+ - "♣": [t: "czarny trefl"]                   # 0x2663
+ - "♤": [t: "biały pik"]                  # 0x2664
+ - "♥": [t: "czarny kier"]                  # 0x2665
+ - "♦": [t: "czarny karo"]                # 0x2666
+ - "♧": [t: "biały trefl"]                   # 0x2667
+ - "⚀": [t: "ścianka kostki 1"]                        # 0x2680
+ - "⚁": [t: "ścianka kostki 2"]                        # 0x2681
+ - "⚂": [t: "ścianka kostki 3"]                        # 0x2682
+ - "⚃": [t: "ścianka kostki 4"]                        # 0x2683
+ - "⚄": [t: "ścianka kostki 5"]                        # 0x2684
+ - "⚅": [t: "ścianka kostki 6"]                        # 0x2685
+ - "⚆": [t: "białe koło z kropką prawy"]       # 0x2686
+ - "⚇": [t: "białe koło z dwiema kropkami"]        # 0x2687
+ - "⚈": [t: "czarne koło z kropką prawy"]       # 0x2688
+ - "⚉": [t: "czarne koło z dwiema kropkami"]        # 0x2689
+ - "⚪": [t: "średni białe koło"]              # 0x26aa
+ - "⚫": [t: "średni czarne koło"]              # 0x26ab
+ - "⚬": [t: "średni mały białe koło"]          # 0x26ac
+ - "⚲": [t: "neutralny"]                            # 0x26b2
+ - "✓": [t: "haczek znak"]                        # 0x2713
+ - "✠": [t: "krzyż maltański"]                     # 0x2720
+ - "✪": [t: "w kółku biały gwiazda"]                # 0x272a
+ - "✶": [t: "czarna sześcioramienna gwiazda"]            # 0x2736
+ - "❨": [t: "średni lewy ornament nawiasu okrągłego"]   # 0x2768
+ - "❩": [t: "średni prawy ornament nawiasu okrągłego"]  # 0x2769
+ - "❪": [t: "średni spłaszczony lewy ornament nawiasu okrągłego"] # 0x276a
+ - "❫": [t: "średni spłaszczony prawy ornament nawiasu okrągłego"] # 0x276b
+ - "❬": [t: "średni kąt skierowany w lewo nawias kwadratowy ornament"] # 0x276c
+ - "❭": [t: "średni kąt skierowany w prawo nawias kwadratowy ornament"] # 0x276d
+ - "❮": [t: "gruby kąt skierowany w lewo cudzysłów ornament"] # 0x276e
+ - "❯": [t: "gruby kąt skierowany w prawo cudzysłów ornament"] # 0x276f
+ - "❰": [t: "gruby kąt skierowany w lewo nawias kwadratowy ornament"] # 0x2770
+ - "❱": [t: "gruby kąt skierowany w prawo nawias kwadratowy ornament"] # 0x2771
+ - "❲": [t: "lekki lewy nawias skorupowy ornament"] # 0x2772
+ - "❳": [t: "lekki prawy nawias skorupowy ornament"] # 0x2773
+ - "❴": [t: "średni lewy nawias klamrowy ornament"]          # 0x2774
+ - "❵": [t: "średni prawy nawias klamrowy ornament"]         # 0x2775
+ - "❶": [t: "czarny w kółku jeden"]                   # 0x2776
+ - "❷": [t: "czarny w kółku dwa"]                   # 0x2777
+ - "❸": [t: "czarny w kółku trzy"]                 # 0x2778
+ - "❹": [t: "czarny w kółku cztery"]                  # 0x2779
+ - "❺": [t: "czarny w kółku pięć"]                  # 0x277a
+ - "❻": [t: "czarny w kółku sześć"]                   # 0x277b
+ - "❼": [t: "czarny w kółku siedem"]                 # 0x277c
+ - "❽": [t: "czarny w kółku osiem"]                 # 0x277d
+ - "❾": [t: "czarny w kółku dziewięć"]                  # 0x277e
+ - "❿": [t: "czarny w kółku dziesięć"]                   # 0x277f
+ - "➀": [t: "w kółku bezszeryfowe jeden"]              # 0x2780
+ - "➁": [t: "w kółku bezszeryfowe dwa"]              # 0x2781
+ - "➂": [t: "w kółku bezszeryfowe trzy"]            # 0x2782
+ - "➃": [t: "w kółku bezszeryfowe cztery"]             # 0x2783
+ - "➄": [t: "w kółku bezszeryfowe pięć"]             # 0x2784
+ - "➅": [t: "w kółku bezszeryfowe sześć"]              # 0x2785
+ - "➆": [t: "w kółku bezszeryfowe siedem"]            # 0x2786
+ - "➇": [t: "w kółku bezszeryfowe osiem"]            # 0x2787
+ - "➈": [t: "w kółku bezszeryfowe dziewięć"]             # 0x2788
+ - "➉": [t: "w kółku bezszeryfowe dziesięć"]              # 0x2789
+ - "➊": [t: "czarny w kółku bezszeryfowe jeden"]        # 0x278a
+ - "➋": [t: "czarny w kółku bezszeryfowe dwa"]        # 0x278b
+ - "➌": [t: "czarny w kółku bezszeryfowe trzy"]      # 0x278c
+ - "➍": [t: "czarny w kółku bezszeryfowe cztery"]       # 0x278d
+ - "➎": [t: "czarny w kółku bezszeryfowe pięć"]       # 0x278e
+ - "➏": [t: "czarny w kółku bezszeryfowe sześć"]        # 0x278f
+ - "➐": [t: "czarny w kółku bezszeryfowe siedem"]      # 0x2790
+ - "➑": [t: "czarny w kółku bezszeryfowe osiem"]      # 0x2791
+ - "➒": [t: "czarny w kółku bezszeryfowe dziewięć"]       # 0x2792
+ - "➓": [t: "czarny w kółku bezszeryfowe dziesięć"]        # 0x2793
+ - "➔": [t: "gruba strzałka w prawo z szerokim grotem"]  # 0x2794
+ - "➕": [t: "gruby znak plus"]                     # 0x2795
+ - "➖": [t: "gruby znak minus"]                    # 0x2796
+ - "➗": [t: "gruby znak dzielenia"]                  # 0x2797
+ - "➘": [t: "gruba strzałka na południowy wschód"]              # 0x2798
+ - "➙": [t: "gruby strzałka w prawo"]              # 0x2799
+ - "➚": [t: "gruba strzałka na północny wschód"]              # 0x279a
+ - "➛": [t: "strzałka w prawo z grotem kreślarskim"]     # 0x279b
+ - "➜": [t: "gruba strzałka w prawo z okrągłym grotem"] # 0x279c
+ - "➝": [t: "strzałka w prawo z trójkątnym grotem"]    # 0x279d
+ - "➞": [t: "gruba strzałka w prawo z trójkątnym grotem"] # 0x279e
+ - "➟": [t: "kreskowana strzałka w prawo z trójkątnym grotem"] # 0x279f
+ - "➠": [t: "gruba kreskowana strzałka w prawo z trójkątnym grotem"] # 0x27a0
+ - "➡": [t: "czarny strzałka w prawo"]              # 0x27a1
+ - "➢": [t: "trójwymiarowa strzałka w prawo podświetlona od góry"] # 0x27a2
+ - "➣": [t: "trójwymiarowa strzałka w prawo podświetlona od dołu"] # 0x27a3
+ - "➤": [t: "czarny prawy grot strzałki"]          # 0x27a4
+ - "➥": [t: "gruba czarna zakrzywiona dolna strzałka w prawo"] # 0x27a5
+ - "➦": [t: "gruba czarna zakrzywiona górna strzałka w prawo"] # 0x27a6
+ - "➧": [t: "krótki czarny strzałka w prawo"]        # 0x27a7
+ - "➨": [t: "gruba czarna wklęsła ostro zakończona strzałka w prawo"] # 0x27a8
+ - "➩": [t: "prawostronnie cieniowana biała strzałka w prawo"] # 0x27a9
+ - "➪": [t: "lewostronnie cieniowana biała strzałka w prawo"]  # 0x27aa
+ - "➫": [t: "biała strzałka w prawo pochylona do tyłu z cieniem"] # 0x27ab
+ - "➬": [t: "biała strzałka w prawo pochylona do przodu z cieniem"] # 0x27ac
+ - "➭": [t: "gruba biała strzałka w prawo z cieniem w dolnym prawym rogu"] # 0x27ad
+ - "➮": [t: "gruba biała strzałka w prawo z cieniem w górnym prawym rogu"] # 0x27ae
+ - "➯": [t: "biała strzałka w prawo z dolnym prawym wcięciem i cieniem"] # 0x27af
+ - "➱": [t: "biała strzałka w prawo z górnym prawym wcięciem i cieniem"] # 0x27b1
+ - "➲": [t: "gruba biała strzałka w prawo w kółku"] # 0x27b2
+ - "➳": [t: "biała pierzasta strzałka w prawo"]    # 0x27b3
+ - "➴": [t: "czarna pierzasta strzałka południowo-wschodnia"]    # 0x27b4
+ - "➵": [t: "czarna pierzasta strzałka w prawo"]    # 0x27b5
+ - "➶": [t: "czarny pierzasty północ wschód strzałka"]    # 0x27b6
+ - "➷": [t: "gruby czarna pierzasta strzałka południowo-wschodnia"] # 0x27b7
+ - "➸": [t: "gruby czarna pierzasta strzałka w prawo"] # 0x27b8
+ - "➹": [t: "gruby czarny pierzasty północ wschód strzałka"] # 0x27b9
+ - "➺": [t: "strzałka w prawo z łezkowatym grotem z zadziorami"]    # 0x27ba
+ - "➻": [t: "gruba strzałka w prawo z łezkowatym grotem i trzonkiem"] # 0x27bb
+ - "➼": [t: "strzałka w prawo z klinowym ogonem"]       # 0x27bc
+ - "➽": [t: "gruby strzałka w prawo z klinowym ogonem"] # 0x27bd
+ - "➾": [t: "otwarta konturowa strzałka w prawo"]      # 0x27be
+ - "⟀": [t: "trójwymiarowy kąt"]             # 0x27c0
+ - "⟁": [t: "biały trójkąt zawierający mały biały trójkąt"] # 0x27c1
+ - "⟂":                                          # 0x27c2
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [T: "jest"]
+     - t: "prostopadłe do"
+ - "⟃":                                          # 0x27c3
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [T: "jest"]
+     - t: "otwórz podzbiór"
+ - "⟄":                                          # 0x27c4
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [T: "jest"]
+     - t: "otwórz nadzbiór"
+ - "⟅": [t: "lewy ogranicznik workowy w kształcie S"]         # 0x27c5
+ - "⟆": [t: "prawy ogranicznik workowy w kształcie S"]        # 0x27c6
+ - "⟇": [t: "lub z kropką wewnątrz"]                  # 0x27c7
+ - "⟈": [t: "odwrotny ukośnik poprzedzający podzbiór"]   # 0x27c8
+ - "⟉": [t: "nadzbiór poprzedzający ukośnik"]         # 0x27c9
+ - "⟊": [t: "pionowa kreska z poziomą kreską"] # 0x27ca
+ - "⟋": [t: "matematyczny ukośnik wznoszący"]        # 0x27cb
+ - "⟌": [t: "dzielenie pisemne"]                       # 0x27cc
+ - "⟍": [t: "matematyczny ukośnik opadający"]       # 0x27cd
+ - "⟎": [t: "kwadratowa koniunkcja logiczna"]      # 0x27ce
+ - "⟏": [t: "do kwadratu logiczne lub"]                  # 0x27cf
+ - "⟐": [t: "biały romb z wyśrodkowaną kropką"]     # 0x27d0
+ - "⟑": [t: "i z kropką"]                        # 0x27d1
+ - "⟒": [t: "należy do z otwarciem u góry"]         # 0x27d2
+ - "⟓": [t: "prawy dolny narożnik z kropką"]         # 0x27d3
+ - "⟔": [t: "górny lewy narożnik z kropką"]          # 0x27d4
+ - "⟕": [t: "lewe złączenie zewnętrzne"]                     # 0x27d5
+ - "⟖": [t: "prawe złączenie zewnętrzne"]                    # 0x27d6
+ - "⟗": [t: "pełne złączenie zewnętrzne"]                     # 0x27d7
+ - "⟘": [t: "duży górny znacznik"]                       # 0x27d8
+ - "⟙": [t: "duży dolny znacznik"]                     # 0x27d9
+ - "⟚": [t: "lewy i prawy podwójny znacznik dedukcji"]     # 0x27da
+ - "⟛": [t: "lewy i prawy znacznik"]                 # 0x27db
+ - "⟜": [t: "lewa multimapa"]                       # 0x27dc
+ - "⟝": [t: "długi prawy znacznik"]                     # 0x27dd
+ - "⟞": [t: "długi lewy znacznik"]                      # 0x27de
+ - "⟟": [t: "górny znacznik z okręgiem nad"]           # 0x27df
+ - "⟠": [t: "romb podzielony poziomą kreską"]  # 0x27e0
+ - "⟡": [t: "biały romb o wklęsłych bokach"]         # 0x27e1
+ - "⟢": [t: "biały romb o wklęsłych bokach z lewym haczykiem"] # 0x27e2
+ - "⟣": [t: "biały romb o wklęsłych bokach z prawym haczykiem"] # 0x27e3
+ - "⟤": [t: "biały kwadrat z lewym haczykiem"]    # 0x27e4
+ - "⟥": [t: "biały kwadrat z prawym haczykiem"]   # 0x27e5
+ - "⟦": [t: "lewy biały nawias kwadratowy"]           # 0x27e6
+ - "⟧": [t: "prawy biały nawias kwadratowy"]          # 0x27e7
+ - "⟨": [t: "lewy nawias kątowy"]                  # 0x27e8
+ - "⟩": [t: "prawy nawias kątowy"]                 # 0x27e9
+ - "⟪": [t: "lewy podwójny nawias kątowy"]           # 0x27ea
+ - "⟫": [t: "prawy podwójny nawias kątowy"]          # 0x27eb
+ - "⟬": [t: "lewy biały nawias skorupowy"]   # 0x27ec
+ - "⟭": [t: "prawy biały nawias skorupowy"]  # 0x27ed
+ - "⟮": [t: "lewy spłaszczony nawias"]          # 0x27ee
+ - "⟯": [t: "prawy spłaszczony nawias"]         # 0x27ef
+ - "⟰": [t: "poczwórna strzałka w górę"]             # 0x27f0
+ - "⟱": [t: "poczwórna strzałka w dół"]           # 0x27f1
+ - "⟲": [t: "okrężna strzałka z przerwą przeciwnie do ruchu wskazówek zegara"]   # 0x27f2
+ - "⟳": [t: "okrężna strzałka z przerwą zgodnie z ruchem wskazówek zegara"]       # 0x27f3
+ - "⟴": [t: "strzałka w prawo z plusem w kółku"]       # 0x27f4
+ - "⟵": [t: "długa strzałka w lewo"]                # 0x27f5
+ - "⟶": [t: "długa strzałka w prawo"]               # 0x27f6
+ - "⟷": [t: "długa strzałka w lewo i w prawo"]               # 0x27f7
+ - "⟸": [t: "długa podwójna strzałka w lewo"]         # 0x27f8
+ - "⟹": [t: "implikuje"]        # 0x27f9
+ - "⟺": [t: "wtedy i tylko wtedy"]        # 0x27fa
+ - "⟻": [t: "długa strzałka w lewo od kreski"]       # 0x27fb
+ - "⟼": [t: "długa strzałka w prawo od kreski"]      # 0x27fc
+ - "⟽": [t: "długa podwójna strzałka w lewo od kreski"] # 0x27fd
+ - "⟾": [t: "długa podwójna strzałka w prawo od kreski"] # 0x27fe
+ - "⟿": [t: "długa falista strzałka w prawo"]      # 0x27ff
+ - "⤀": [t: "strzałka w prawo z dwoma grotami i pionowym przekreśleniem"] # 0x2900
+ - "⤁": [t: "strzałka w prawo z dwoma grotami i podwójnym pionowym przekreśleniem"] # 0x2901
+ - "⤂": [t: "podwójna strzałka w lewo z pionową kreską"] # 0x2902
+ - "⤃": [t: "podwójna strzałka w prawo z pionową kreską"] # 0x2903
+ - "⤄": [t: "podwójna strzałka w lewo i w prawo z pionową kreską"] # 0x2904
+ - "⤅": [t: "strzałka w prawo z dwoma grotami od kreski"] # 0x2905
+ - "⤆": [t: "podwójna strzałka w lewo od kreski"]     # 0x2906
+ - "⤇": [t: "podwójna strzałka w prawo od kreski"]    # 0x2907
+ - "⤈": [t: "strzałka w dół z poziomą kreską"] # 0x2908
+ - "⤉": [t: "strzałka w górę z poziomą kreską"] # 0x2909
+ - "⤊": [t: "górny potrójny strzałka"]                # 0x290a
+ - "⤋": [t: "dolny potrójny strzałka"]              # 0x290b
+ - "⤌": [t: "lewy podwójny kreska strzałka"]         # 0x290c
+ - "⤍": [t: "prawy podwójny kreska strzałka"]        # 0x290d
+ - "⤎": [t: "lewy potrójny kreska strzałka"]         # 0x290e
+ - "⤏": [t: "prawy potrójny kreska strzałka"]        # 0x290f
+ - "⤐": [t: "strzałka w prawo z dwoma grotami i potrójną kreską"] # 0x2910
+ - "⤑": [t: "strzałka w prawo z kropkowanym trzonem"] # 0x2911
+ - "⤒": [t: "strzałka w górę do kreski"]                # 0x2912
+ - "⤓": [t: "strzałka w dół do kreski"]              # 0x2913
+ - "⤔": [t: "strzałka w prawo z ogonem i pionową kreską"] # 0x2914
+ - "⤕": [t: "strzałka w prawo z ogonem i podwójną pionową kreską"] # 0x2915
+ - "⤖": [t: "strzałka w prawo z dwoma grotami i ogonem"] # 0x2916
+ - "⤗": [t: "strzałka w prawo z dwoma grotami, ogonem i pionowym przekreśleniem"] # 0x2917
+ - "⤘": [t: "strzałka w prawo z dwoma grotami, ogonem i podwójnym pionowym przekreśleniem"] # 0x2918
+ - "⤙": [t: "strzałka w lewo ogon"]                # 0x2919
+ - "⤚": [t: "strzałka w prawo ogon"]               # 0x291a
+ - "⤛": [t: "lewy podwójna strzałka ogon"]         # 0x291b
+ - "⤜": [t: "prawy podwójna strzałka ogon"]        # 0x291c
+ - "⤝": [t: "strzałka w lewo do wypełnionego rombu"]   # 0x291d
+ - "⤞": [t: "strzałka w prawo do wypełnionego rombu"]  # 0x291e
+ - "⤟": [t: "strzałka w lewo od kreski do wypełnionego rombu"] # 0x291f
+ - "⤠": [t: "strzałka w prawo od kreski do wypełnionego rombu"] # 0x2920
+ - "⤡": [t: "strzałka północno-zachodnia i południowo-wschodnia"] # 0x2921
+ - "⤢": [t: "strzałka północno-wschodnia i południowo-zachodnia"] # 0x2922
+ - "⤣": [t: "strzałka północno-zachodnia z hakiem"]          # 0x2923
+ - "⤤": [t: "strzałka północno-wschodnia z hakiem"]          # 0x2924
+ - "⤥": [t: "strzałka południowo-wschodnia z hakiem"]          # 0x2925
+ - "⤦": [t: "strzałka południowo-zachodnia z hakiem"]          # 0x2926
+ - "⤧": [t: "strzałka północno-zachodnia i strzałka północno-wschodnia"] # 0x2927
+ - "⤨": [t: "strzałka północno-wschodnia i strzałka południowo-wschodnia"] # 0x2928
+ - "⤩": [t: "strzałka południowo-wschodnia i strzałka południowo-zachodnia"] # 0x2929
+ - "⤪": [t: "strzałka południowo-zachodnia i strzałka północno-zachodnia"] # 0x292a
+ - "⤫": [t: "ukośna wznosząca przecinająca ukośną opadającą"] # 0x292b
+ - "⤬": [t: "ukośna opadająca przecinająca ukośną wznoszącą"] # 0x292c
+ - "⤭": [t: "strzałka południowo-wschodnia przecinająca strzałkę północno-wschodnią"] # 0x292d
+ - "⤮": [t: "strzałka północno-wschodnia przecinająca strzałkę południowo-wschodnią"] # 0x292e
+ - "⤯": [t: "ukośna opadająca przecinająca strzałkę północno-wschodnią"] # 0x292f
+ - "⤰": [t: "ukośna wznosząca przecinająca strzałkę południowo-wschodnią"] # 0x2930
+ - "⤱": [t: "strzałka północno-wschodnia przecinająca strzałkę północno-zachodnią"] # 0x2931
+ - "⤲": [t: "strzałka północno-zachodnia przecinająca strzałkę północno-wschodnią"] # 0x2932
+ - "⤳": [t: "falista strzałka skierowana bezpośrednio w prawo"]  # 0x2933
+ - "⤴": [t: "strzałka skierowana w prawo, potem zakrzywiona w górę"] # 0x2934
+ - "⤵": [t: "strzałka skierowana w prawo, potem zakrzywiona w dół"] # 0x2935
+ - "⤶": [t: "strzałka skierowana w dół, potem zakrzywiona w lewo"] # 0x2936
+ - "⤷": [t: "strzałka skierowana w dół, potem zakrzywiona w prawo"] # 0x2937
+ - "⤸": [t: "prawostronna strzałka łukowa zgodna z ruchem wskazówek zegara"] # 0x2938
+ - "⤹": [t: "lewostronna strzałka łukowa przeciwna do ruchu wskazówek zegara"] # 0x2939
+ - "⤺": [t: "górna strzałka łukowa przeciwna do ruchu wskazówek zegara"] # 0x293a
+ - "⤻": [t: "dolna strzałka łukowa przeciwna do ruchu wskazówek zegara"] # 0x293b
+ - "⤼": [t: "górna strzałka łukowa zgodna z ruchem wskazówek zegara z minusem"] # 0x293c
+ - "⤽": [t: "górna strzałka łukowa przeciwna do ruchu wskazówek zegara z plusem"] # 0x293d
+ - "⤾": [t: "dolna prawa strzałka półokrągła zgodna z ruchem wskazówek zegara"] # 0x293e
+ - "⤿": [t: "dolna lewa strzałka półokrągła przeciwna do ruchu wskazówek zegara"] # 0x293f
+ - "⥀": [t: "zamknięta strzałka okrężna przeciwna do ruchu wskazówek zegara"] # 0x2940
+ - "⥁": [t: "zamknięta strzałka okrężna zgodna z ruchem wskazówek zegara"] # 0x2941
+ - "⥂": [t: "strzałka w prawo nad krótką strzałką w lewo"] # 0x2942
+ - "⥃": [t: "strzałka w lewo nad krótką strzałką w prawo"] # 0x2943
+ - "⥄": [t: "krótka strzałka w prawo nad strzałką w lewo"] # 0x2944
+ - "⥅": [t: "strzałka w prawo z plusem pod spodem"] # 0x2945
+ - "⥆": [t: "strzałka w lewo z plusem pod spodem"] # 0x2946
+ - "⥇": [t: "strzałka w prawo przez X"]          # 0x2947
+ - "⥈": [t: "strzałka w lewo i w prawo przez okrąg"]     # 0x2948
+ - "⥉": [t: "strzałka w górę z dwoma grotami od okręgu"] # 0x2949
+ - "⥊": [t: "lewy grot górny prawy grot dolny harpun"] # 0x294a
+ - "⥋": [t: "lewy grot dolny prawy grot górny harpun"] # 0x294b
+ - "⥌": [t: "górny grot prawy dolny grot lewy harpun"] # 0x294c
+ - "⥍": [t: "górny grot lewy dolny grot prawy harpun"] # 0x294d
+ - "⥎": [t: "lewy grot górny prawy grot górny harpun"]  # 0x294e
+ - "⥏": [t: "górny grot prawy dolny grot prawy harpun"] # 0x294f
+ - "⥐": [t: "lewy grot dolny prawy grot dolny harpun"] # 0x2950
+ - "⥑": [t: "górny grot lewy dolny grot lewy harpun"] # 0x2951
+ - "⥒": [t: "lewy harpun z grotem górnym do kreski"] # 0x2952
+ - "⥓": [t: "prawy harpun z grotem górnym do kreski"] # 0x2953
+ - "⥔": [t: "górny harpun z grotem prawym do kreski"] # 0x2954
+ - "⥕": [t: "dolny harpun z grotem prawym do kreski"] # 0x2955
+ - "⥖": [t: "lewy harpun z grotem dolnym do kreski"] # 0x2956
+ - "⥗": [t: "prawy harpun z grotem dolnym do kreski"] # 0x2957
+ - "⥘": [t: "górny harpun z grotem lewym do kreski"] # 0x2958
+ - "⥙": [t: "dolny harpun z grotem lewym do kreski"] # 0x2959
+ - "⥚": [t: "lewy harpun z grotem górnym od kreski"] # 0x295a
+ - "⥛": [t: "prawy harpun z grotem górnym od kreski"] # 0x295b
+ - "⥜": [t: "górny harpun z grotem prawym od kreski"] # 0x295c
+ - "⥝": [t: "dolny harpun z grotem prawym od kreski"] # 0x295d
+ - "⥞": [t: "lewy harpun z grotem dolnym od kreski"] # 0x295e
+ - "⥟": [t: "prawy harpun z grotem dolnym od kreski"] # 0x295f
+ - "⥠": [t: "górny harpun z grotem lewym od kreski"] # 0x2960
+ - "⥡": [t: "dolny harpun z grotem lewym od kreski"] # 0x2961
+ - "⥢": [t: "lewy harpun z grotem górnym nad lewy harpun z grotem dolnym"] # 0x2962
+ - "⥣": [t: "górny harpun z grotem w lewo obok górnego harpuna z grotem w prawo"] # 0x2963
+ - "⥤": [t: "prawy harpun z grotem górnym nad prawy harpun z grotem dolnym"] # 0x2964
+ - "⥥": [t: "dolny harpun z grotem w lewo obok dolnego harpuna z grotem w prawo"] # 0x2965
+ - "⥦": [t: "lewy harpun z grotem górnym nad prawy harpun z grotem górnym"] # 0x2966
+ - "⥧": [t: "lewy harpun z grotem dolnym nad prawy harpun z grotem dolnym"] # 0x2967
+ - "⥨": [t: "prawy harpun z grotem górnym nad lewy harpun z grotem górnym"] # 0x2968
+ - "⥩": [t: "prawy harpun z grotem dolnym nad lewy harpun z grotem dolnym"] # 0x2969
+ - "⥪": [t: "lewy harpun z grotem górnym nad długą kreską"] # 0x296a
+ - "⥫": [t: "lewy harpun z grotem dolnym pod długą kreską"] # 0x296b
+ - "⥬": [t: "prawy harpun z grotem górnym nad długą kreską"] # 0x296c
+ - "⥭": [t: "prawy harpun z grotem dolnym pod długą kreską"] # 0x296d
+ - "⥮": [t: "górny harpun z grotem w lewo obok dolnego harpuna z grotem w prawo"] # 0x296e
+ - "⥯": [t: "dolny harpun z grotem w lewo obok górnego harpuna z grotem w prawo"] # 0x296f
+ - "⥰": [t: "podwójna strzałka w prawo z zaokrąglonym grotem"] # 0x2970
+ - "⥱": [t: "równa się nad strzałka w prawo"]       # 0x2971
+ - "⥲": [t: "operator tyldy nad strzałką w prawo"] # 0x2972
+ - "⥳": [t: "strzałka w lewo nad operatorem tyldy"] # 0x2973
+ - "⥴": [t: "strzałka w prawo nad operatorem tyldy"] # 0x2974
+ - "⥵": [t: "strzałka w prawo nad znakiem przybliżonej równości"] # 0x2975
+ - "⥶": [t: "mniejsze niż nad strzałka w lewo"]     # 0x2976
+ - "⥷": [t: "strzałka w lewo przez znak mniejsze niż"]   # 0x2977
+ - "⥸": [t: "większe niż nad strzałka w prawo"] # 0x2978
+ - "⥹": [t: "podzbiór nad strzałka w prawo"]       # 0x2979
+ - "⥺": [t: "strzałka w lewo przez znak podzbioru"]      # 0x297a
+ - "⥻": [t: "nadzbiór nad strzałka w lewo"]      # 0x297b
+ - "⥼": [t: "lewy rybi ogon"]                      # 0x297c
+ - "⥽": [t: "prawy rybi ogon"]                     # 0x297d
+ - "⥾": [t: "górny rybi ogon"]                        # 0x297e
+ - "⥿": [t: "dolny rybi ogon"]                      # 0x297f
+ - "⦀": [t: "potrójna pionowa kreska jako ogranicznik"]       # 0x2980
+ - "⦁": [t: "punkt w notacji Z"]                     # 0x2981
+ - "⦂": [t: "dwukropek typu w notacji Z"]               # 0x2982
+ - "⦃": [t: "lewy biały nawias klamrowy"]                    # 0x2983
+ - "⦄": [t: "prawy biały nawias klamrowy"]                   # 0x2984
+ - "⦅": [t: "lewy biały nawias"]              # 0x2985
+ - "⦆": [t: "prawy biały nawias"]             # 0x2986
+ - "⦇": [t: "lewy nawias kwadratowy obrazu w notacji Z"]       # 0x2987
+ - "⦈": [t: "prawy nawias kwadratowy obrazu w notacji Z"]      # 0x2988
+ - "⦉": [t: "lewy nawias kwadratowy wiązania w notacji Z"]     # 0x2989
+ - "⦊": [t: "prawy nawias kwadratowy wiązania w notacji Z"]    # 0x298a
+ - "⦋": [t: "lewy nawias kwadratowy z podkreśleniem"]   # 0x298b
+ - "⦌": [t: "prawy nawias kwadratowy z podkreśleniem"]  # 0x298c
+ - "⦍": [t: "lewy nawias kwadratowy z haczykiem w górnym rogu"] # 0x298d
+ - "⦎": [t: "prawy nawias kwadratowy z haczykiem w dolnym rogu"] # 0x298e
+ - "⦏": [t: "lewy nawias kwadratowy z haczykiem w dolnym rogu"] # 0x298f
+ - "⦐": [t: "prawy nawias kwadratowy z haczykiem w górnym rogu"] # 0x2990
+ - "⦑": [t: "lewy kąt nawias kwadratowy z kropką"]         # 0x2991
+ - "⦒": [t: "prawy nawias kątowy z kropką"]        # 0x2992
+ - "⦓": [t: "lewy łuk mniejsze niż nawias kwadratowy"]          # 0x2993
+ - "⦔": [t: "prawy łuk większe niż nawias kwadratowy"]      # 0x2994
+ - "⦕": [t: "podwójny lewy łuk większe niż nawias kwadratowy"] # 0x2995
+ - "⦖": [t: "podwójny prawy łuk mniejsze niż nawias kwadratowy"]  # 0x2996
+ - "⦗": [t: "lewy czarny nawias skorupowy"]   # 0x2997
+ - "⦘": [t: "prawy czarny nawias skorupowy"]  # 0x2998
+ - "⦙": [t: "kropkowany ogranicznik"]                        # 0x2999
+ - "⦚": [t: "pionowa linia zygzakowata"]                # 0x299a
+ - "⦛": [t: "kąt mierzony otwarty w lewo"]         # 0x299b
+ - "⦜": [t: "wariant kąta prostego z kwadratem"]     # 0x299c
+ - "⦝": [t: "mierzony kąt prosty z kropką"]       # 0x299d
+ - "⦞": [t: "kąt z s wewnątrz"]                 # 0x299e
+ - "⦟": [t: "akut kąt"]                         # 0x299f
+ - "⦠": [t: "kąt sferyczny otwarty w lewo"]        # 0x29a0
+ - "⦡": [t: "kąt sferyczny otwarty w górę"]          # 0x29a1
+ - "⦢": [t: "odwrócony kąt"]                        # 0x29a2
+ - "⦣": [t: "kąt odwrócony"]                      # 0x29a3
+ - "⦤": [t: "kąt z podkreśleniem"]                 # 0x29a4
+ - "⦥": [t: "kąt odwrócony z podkreśleniem"]        # 0x29a5
+ - "⦦": [t: "kąt ukośny otwarty w górę"]            # 0x29a6
+ - "⦧": [t: "kąt ukośny otwarty w dół"]          # 0x29a7
+ - "⦨": [t: "kąt mierzony z otwartym ramieniem zakończonym strzałką skierowaną w górę i w prawo"] # 0x29a8
+ - "⦩": [t: "kąt mierzony z otwartym ramieniem zakończonym strzałką skierowaną w górę i w lewo"] # 0x29a9
+ - "⦪": [t: "kąt mierzony z otwartym ramieniem zakończonym strzałką skierowaną w dół i w prawo"] # 0x29aa
+ - "⦫": [t: "kąt mierzony z otwartym ramieniem zakończonym strzałką skierowaną w dół i w lewo"] # 0x29ab
+ - "⦬": [t: "kąt mierzony z otwartym ramieniem zakończonym strzałką skierowaną w prawo i w górę"] # 0x29ac
+ - "⦭": [t: "kąt mierzony z otwartym ramieniem zakończonym strzałką skierowaną w lewo i w górę"] # 0x29ad
+ - "⦮": [t: "kąt mierzony z otwartym ramieniem zakończonym strzałką skierowaną w prawo i w dół"] # 0x29ae
+ - "⦯": [t: "kąt mierzony z otwartym ramieniem zakończonym strzałką skierowaną w lewo i w dół"] # 0x29af
+ - "⦰": [t: "odwrócony zbiór pusty"]                  # 0x29b0
+ - "⦱": [t: "zbiór pusty z kreską nad"]              # 0x29b1
+ - "⦲": [t: "zbiór pusty z małym okręgiem nad"]   # 0x29b2
+ - "⦳": [t: "zbiór pusty ze strzałką w prawo nad"]    # 0x29b3
+ - "⦴": [t: "zbiór pusty ze strzałką w lewo nad"] # 0x29b4
+ - "⦵": [t: "okrąg z kreską poziomą"]          # 0x29b5
+ - "⦶": [t: "pionowa kreska w kółku"]                # 0x29b6
+ - "⦷": [t: "w kółku równoległe"]                    # 0x29b7
+ - "⦸": [t: "ukośnik odwrotny w kółku"]             # 0x29b8
+ - "⦹": [t: "w kółku prostopadłe"]               # 0x29b9
+ - "⦺": [t: "okrąg podzielony kreską poziomą, z górną połową podzieloną kreską pionową"] # 0x29ba
+ - "⦻": [t: "okrąg z nałożonym X"]          # 0x29bb
+ - "⦼": [t: "znak dzielenia w kółku obrócony przeciwnie do ruchu wskazówek zegara"] # 0x29bc
+ - "⦽": [t: "strzałka w górę przez okrąg"]             # 0x29bd
+ - "⦾": [t: "w kółku biały punkt"]                # 0x29be
+ - "⦿": [t: "w kółku punkt"]                      # 0x29bf
+ - "⧀": [t: "w kółku mniejsze niż"]                   # 0x29c0
+ - "⧁": [t: "w kółku większe niż"]                # 0x29c1
+ - "⧂": [t: "okrąg z małym okręgiem po prawej"] # 0x29c2
+ - "⧃": [t: "okrąg z dwiema poziomymi kreskami po prawej"] # 0x29c3
+ - "⧄": [t: "kwadrat z ukośnikiem wznoszącym"]       # 0x29c4
+ - "⧅": [t: "kwadrat z ukośnikiem opadającym"]      # 0x29c5
+ - "⧆": [t: "do kwadratu gwiazdka"]                    # 0x29c6
+ - "⧇": [t: "do kwadratu mały okrąg"]                # 0x29c7
+ - "⧈": [t: "do kwadratu kwadrat"]                      # 0x29c8
+ - "⧉": [t: "dwa połączone kwadraty"]                  # 0x29c9
+ - "⧊": [t: "trójkąt z kropką nad"]             # 0x29ca
+ - "⧋": [t: "trójkąt z podkreśleniem"]              # 0x29cb
+ - "⧌": [t: "s w trójkąt"]                       # 0x29cc
+ - "⧍": [t: "trójkąt z szeryfami u dołu"]      # 0x29cd
+ - "⧎": [t: "prawy trójkąt nad lewy trójkąt"]  # 0x29ce
+ - "⧏": [t: "lewy trójkąt obok pionowej kreski"]   # 0x29cf
+ - "⧐": [t: "pionowa kreska obok prawego trójkąta"]  # 0x29d0
+ - "⧑": [t: "kokarda z lewą połową czarną"]         # 0x29d1
+ - "⧒": [t: "kokarda z prawą połową czarną"]        # 0x29d2
+ - "⧓": [t: "czarna kokarda"]                        # 0x29d3
+ - "⧔": [t: "znak mnożenia z lewą połową czarną"]          # 0x29d4
+ - "⧕": [t: "znak mnożenia z prawą połową czarną"]         # 0x29d5
+ - "⧖": [t: "biały klepsydra"]                     # 0x29d6
+ - "⧗": [t: "czarny klepsydra"]                     # 0x29d7
+ - "⧘": [t: "lewy falisty ogranicznik"]                   # 0x29d8
+ - "⧙": [t: "prawy falisty ogranicznik"]                  # 0x29d9
+ - "⧚": [t: "lewy podwójny falisty ogranicznik"]            # 0x29da
+ - "⧛": [t: "prawy podwójny falisty ogranicznik"]           # 0x29db
+ - "⧜": [t: "niepełna nieskończoność"]                 # 0x29dc
+ - "⧝": [t: "wiązanie nad nieskończonością"]                   # 0x29dd
+ - "⧞": [t: "zanegowana nieskończoność z kreską pionową"]  # 0x29de
+ - "⧟": [t: "podwójnie zakończona strzałka mapująca"]               # 0x29df
+ - "⧠": [t: "kwadrat z konturowym obrysem"]       # 0x29e0
+ - "⧡": [t: "wzrasta jak"]                        # 0x29e1
+ - "⧢": [t: "iloczyn przetasowania"]                     # 0x29e2
+ - "⧣": [t: "znak równości i ukośne równoległe"]    # 0x29e3
+ - "⧤": [t: "znak równości i ukośne równoległe z tyldą nad"] # 0x29e4
+ - "⧥": [t: "identyczne i ukośne równoległe"]   # 0x29e5
+ - "⧦": [t: "równoliczne"]                        # 0x29e6
+ - "⧧": [t: "termodynamiczny"]                       # 0x29e7
+ - "⧨": [t: "trójkąt skierowany w dół z lewą połową czarną"] # 0x29e8
+ - "⧩": [t: "trójkąt skierowany w dół z prawą połową czarną"] # 0x29e9
+ - "⧪": [t: "czarny romb ze strzałką w dół"]      # 0x29ea
+ - "⧫": [t: "czarny romb"]                       # 0x29eb
+ - "⧬": [t: "białe koło ze strzałką w dół"]       # 0x29ec
+ - "⧭": [t: "czarne koło ze strzałką w dół"]      # 0x29ed
+ - "⧮": [t: "biały kwadrat z przekreśleniem błędu"]           # 0x29ee
+ - "⧯": [t: "czarny kwadrat z przekreśleniem błędu"]           # 0x29ef
+ - "⧰": [t: "biały romb z przekreśleniem błędu"]          # 0x29f0
+ - "⧱": [t: "czarny romb z przekreśleniem błędu"]          # 0x29f1
+ - "⧲": [t: "białe koło z przekreśleniem błędu"]           # 0x29f2
+ - "⧳": [t: "czarne koło z przekreśleniem błędu"]           # 0x29f3
+ - "⧴": [t: "opóźniona reguła"]                        # 0x29f4
+ - "⧵": [t: "operator ukośnika odwrotnego"]            # 0x29f5
+ - "⧶": [t: "ukośnik z kreską nad"]                # 0x29f6
+ - "⧷": [t: "ukośnik odwrotny z poziomą kreską"] # 0x29f7
+ - "⧸": [t: "duży ukośnik"]                         # 0x29f8
+ - "⧹": [t: "duży ukośnik odwrotny"]                 # 0x29f9
+ - "⧺": [t: "podwójny plus"]                         # 0x29fa
+ - "⧻": [t: "potrójny plus"]                         # 0x29fb
+ - "⧼": [t: "lewy zakrzywiony nawias kątowy"]  # 0x29fc
+ - "⧽": [t: "prawy zakrzywiony nawias kątowy"] # 0x29fd
+ - "⧾": [t: "maleńki"]                                # 0x29fe
+ - "⧿": [t: "mini"]                                # 0x29ff
+ - "⨀": [t: "operator kropka w kółku"]                # 0x2a00
+ - "⨁": [t: "operator plus w kółku"]               # 0x2a01
+ - "⨂": [t: "operator razy w kółku"]              # 0x2a02
+ - "⨃": [t: "operator sumy zbiorów z kropką"]             # 0x2a03
+ - "⨄": [t: "operator sumy zbiorów z plusem"]            # 0x2a04
+ - "⨅": [t: "operator kwadratowej części wspólnej"]        # 0x2a05
+ - "⨆": [t: "operator kwadratowej sumy zbiorów"]               # 0x2a06
+ - "⨇": [t: "operator podwójnej koniunkcji logicznej"] # 0x2a07
+ - "⨈": [t: "dwa logiczne lub operator"]             # 0x2a08
+ - "⨉": [t: "razy operator"]                      # 0x2a09
+ - "⨊": [t: "suma modulo dwa"]                      # 0x2a0a
+ - "⨋": [t: "suma z całką"]             # 0x2a0b
+ - "⨌": [t: "operator poczwórnej całki"]         # 0x2a0c
+ - "⨍": [t: "całka części skończonej"]                # 0x2a0d
+ - "⨎": [t: "całka z podwójnym przekreśleniem"]         # 0x2a0e
+ - "⨏": [t: "całka uśredniona z ukośnikiem"]         # 0x2a0f
+ - "⨐": [t: "funkcja cyrkulacji"]                # 0x2a10
+ - "⨑": [t: "całka przeciwna do ruchu wskazówek zegara"] # 0x2a11
+ - "⨒": [t: "całka liniowa po prostokątnej ścieżce wokół bieguna"] # 0x2a12
+ - "⨓": [t: "całka liniowa po półokrągłej ścieżce wokół bieguna"] # 0x2a13
+ - "⨔": [t: "całka liniowa bez pola"] # 0x2a14
+ - "⨕": [t: "operator całki wokół punktu"]    # 0x2a15
+ - "⨖": [t: "operator całki kwaternionowej"]        # 0x2a16
+ - "⨗": [t: "całka ze strzałką w lewo z haczykiem"] # 0x2a17
+ - "⨘": [t: "całka ze znakiem razy"]           # 0x2a18
+ - "⨙": [t: "całka z częścią wspólną"]         # 0x2a19
+ - "⨚": [t: "całka z sumą zbiorów"]            # 0x2a1a
+ - "⨛": [t: "całka z kreską nad"]               # 0x2a1b
+ - "⨜": [t: "całka z podkreśleniem"]              # 0x2a1c
+ - "⨝": [t: "złączenie"]                                # 0x2a1d
+ - "⨞": [t: "duży lewy trójkąt operator"]        # 0x2a1e
+ - "⨟": [t: "składanie schematów w notacji Z"]       # 0x2a1f
+ - "⨠": [t: "potok schematów w notacji Z"]            # 0x2a20
+ - "⨡": [t: "rzutowanie schematów w notacji Z"]        # 0x2a21
+ - "⨢": [t: "znak plus z okręgiem nad"]        # 0x2a22
+ - "⨣": [t: "znak plus z daszkiem nad"]        # 0x2a23
+ - "⨤": [t: "znak plus z tyldą nad"]           # 0x2a24
+ - "⨥": [t: "znak plus z kropką pod"]          # 0x2a25
+ - "⨦": [t: "znak plus z tyldą pod"]           # 0x2a26
+ - "⨧": [t: "znak plus z indeksem dolnym dwa"] # 0x2a27
+ - "⨨": [t: "znak plus z czarnym trójkątem"]   # 0x2a28
+ - "⨩": [t: "znak minus z przecinkiem nad"]    # 0x2a29
+ - "⨪": [t: "znak minus z kropką pod"]         # 0x2a2a
+ - "⨫": [t: "znak minus z kropkami opadającymi"]        # 0x2a2b
+ - "⨬": [t: "znak minus z kropkami wznoszącymi"]         # 0x2a2c
+ - "⨭": [t: "znak plus w lewej połówce okręgu"]       # 0x2a2d
+ - "⨮": [t: "znak plus w prawej połówce okręgu"]      # 0x2a2e
+ - "⨯":                                             # 0x2a2f
+      - test: 
+         if: "$Verbosity='Terse'"
+         then: [t: "krzyż"]
+         else: [t: "krzyż iloczyn"]
+ - "⨰": [t: "znak mnożenia z kropką nad"]  # 0x2a30
+ - "⨱": [t: "znak mnożenia z podkreśleniem"]   # 0x2a31
+ - "⨲": [t: "iloczyn półprosty domknięty od dołu"] # 0x2a32
+ - "⨳": [t: "iloczyn spłaszczony"]                       # 0x2a33
+ - "⨴": [t: "znak mnożenia w lewej połówce okręgu"] # 0x2a34
+ - "⨵": [t: "znak mnożenia w prawej połówce okręgu"] # 0x2a35
+ - "⨶": [t: "znak mnożenia w kółku z daszkiem"] # 0x2a36
+ - "⨷": [t: "znak mnożenia w podwójnym okręgu"] # 0x2a37
+ - "⨸": [t: "znak dzielenia w kółku"]               # 0x2a38
+ - "⨹": [t: "znak plus w trójkącie"]               # 0x2a39
+ - "⨺": [t: "znak minus w trójkącie"]              # 0x2a3a
+ - "⨻": [t: "znak mnożenia w trójkącie"]     # 0x2a3b
+ - "⨼": [t: "iloczyn wewnętrzny"]                    # 0x2a3c
+ - "⨽": [t: "prawostronny iloczyn wewnętrzny"]          # 0x2a3d
+ - "⨾": [t: "składanie relacji w notacji Z"]    # 0x2a3e
+ - "⨿": [t: "amalgamacja lub koprodukt"]           # 0x2a3f
+ - "⩀": [t: "część wspólna z kropką"]               # 0x2a40
+ - "⩁": [t: "suma zbiorów ze znakiem minus"]      # 0x2a41
+ - "⩂": [t: "suma zbiorów z kreską nad"]                  # 0x2a42
+ - "⩃": [t: "część wspólna z kreską nad"]           # 0x2a43
+ - "⩄": [t: "część wspólna z koniunkcją logiczną"] # 0x2a44
+ - "⩅": [t: "suma zbiorów z alternatywą logiczną"] # 0x2a45
+ - "⩆": [t: "suma zbiorów nad część wspólna"]            # 0x2a46
+ - "⩇": [t: "część wspólna nad suma zbiorów"]            # 0x2a47
+ - "⩈": [t: "suma zbiorów nad kreska nad część wspólna"]  # 0x2a48
+ - "⩉": [t: "część wspólna nad kreska nad suma zbiorów"]  # 0x2a49
+ - "⩊": [t: "suma zbiorów obok sumy zbiorów połączona kreską"]  # 0x2a4a
+ - "⩋": [t: "część wspólna obok części wspólnej połączona kreską"] # 0x2a4b
+ - "⩌": [t: "zamknięta suma zbiorów z szeryfami"]            # 0x2a4c
+ - "⩍": [t: "zamknięta część wspólna z szeryfami"]     # 0x2a4d
+ - "⩎": [t: "podwójny kwadrat część wspólna"]          # 0x2a4e
+ - "⩏": [t: "podwójny kwadrat suma zbiorów"]                 # 0x2a4f
+ - "⩐": [t: "zamknięta suma zbiorów z szeryfami i iloczynem spłaszczonym"] # 0x2a50
+ - "⩑": [t: "koniunkcja logiczna z kropką nad"] # 0x2a51
+ - "⩒": [t: "logiczne lub z kropką nad"]           # 0x2a52
+ - "⩓": [t: "podwójna koniunkcja logiczna"]     # 0x2a53
+ - "⩔": [t: "podwójny logiczne lub"]                   # 0x2a54
+ - "⩕": [t: "dwa przecinające się logiczne i"]        # 0x2a55
+ - "⩖": [t: "dwa przecinające się logiczne lub"]         # 0x2a56
+ - "⩗": [t: "skośne duże lub"]                    # 0x2a57
+ - "⩘": [t: "skośne duże i"]                   # 0x2a58
+ - "⩙": [t: "logiczne lub nakładające się na logiczne i"]  # 0x2a59
+ - "⩚": [t: "logiczne i ze środkowym trzonem"]        # 0x2a5a
+ - "⩛": [t: "logiczne lub ze środkowym trzonem"]         # 0x2a5b
+ - "⩜": [t: "koniunkcja logiczna z poziomą kreską"] # 0x2a5c
+ - "⩝": [t: "alternatywa logiczna z poziomą kreską"] # 0x2a5d
+ - "⩞": [t: "logiczne i z podwójną kreską nad"]     # 0x2a5e
+ - "⩟": [t: "koniunkcja logiczna z podkreśleniem"] # 0x2a5f
+ - "⩠": [t: "logiczne i z podwójną kreską pod"]    # 0x2a60
+ - "⩡": [t: "małe logiczne lub z podkreśleniem"]             # 0x2a61
+ - "⩢": [t: "logiczne lub z podwójną kreską nad"]      # 0x2a62
+ - "⩣": [t: "logiczne lub z podwójną kreską pod"]     # 0x2a63
+ - "⩤": [t: "antyograniczenie dziedziny w notacji Z"]   # 0x2a64
+ - "⩥": [t: "antyograniczenie przeciwdziedziny w notacji Z"]    # 0x2a65
+ - "⩦": [t: "znak równości z kropką pod spodem"]          # 0x2a66
+ - "⩧": [t: "identyczne z kropką nad"]            # 0x2a67
+ - "⩨": [t: "potrójna kreska pozioma z podwójną pionową kreską"] # 0x2a68
+ - "⩩": [t: "potrójna kreska pozioma z potrójną pionową kreską"] # 0x2a69
+ - "⩪": [t: "operator tyldy z kropką nad"]       # 0x2a6a
+ - "⩫": [t: "operator tyldy ze wznoszącymi kropkami"]     # 0x2a6b
+ - "⩬": [t: "podobne minus podobne"]               # 0x2a6c
+ - "⩭": [t: "przystające z kropką nad"]            # 0x2a6d
+ - "⩮": [t: "równa się z gwiazdką"]                # 0x2a6e
+ - "⩯": [t: "w przybliżeniu równe z daszkiem"] # 0x2a6f
+ - "⩰": [t: "w przybliżeniu równe lub równe"]  # 0x2a70
+ - "⩱": [t: "znak równości nad znakiem plus"]         # 0x2a71
+ - "⩲": [t: "znak plus nad znakiem równości"]         # 0x2a72
+ - "⩳": [t: "znak równości nad operatorem tyldy"]    # 0x2a73
+ - "⩴": [t: "podwójny dwukropek równe"]                  # 0x2a74
+ - "⩵": [t: "dwa kolejne znaki równości"]        # 0x2a75
+ - "⩶": [t: "trzy kolejne znaki równości"]      # 0x2a76
+ - "⩷": [t: "znak równości z dwiema kropkami nad i dwiema kropkami pod"] # 0x2a77
+ - "⩸": [t: "równoważne z czterema kropkami nad"]     # 0x2a78
+ - "⩹": [t: "mniejsze niż z okrąg wewnątrz"]        # 0x2a79
+ - "⩺": [t: "większe niż z okrąg wewnątrz"]     # 0x2a7a
+ - "⩻": [t: "mniejsze niż ze znakiem zapytania nad"]  # 0x2a7b
+ - "⩼": [t: "większe niż ze znakiem zapytania nad"] # 0x2a7c
+ - "⩽": [t: "mniejsze niż lub ukośnie równe"]       # 0x2a7d
+ - "⩾": [t: "większe niż lub ukośnie równe"]    # 0x2a7e
+ - "⩿": [t: "mniejsze niż lub ukośnie równe z kropką wewnątrz"] # 0x2a7f
+ - "⪀": [t: "większe niż lub ukośnie równe z kropką wewnątrz"] # 0x2a80
+ - "⪁": [t: "mniejsze niż lub ukośnie równe z kropką nad"] # 0x2a81
+ - "⪂": [t: "większe niż lub ukośnie równe z kropką nad"] # 0x2a82
+ - "⪃": [t: "mniejsze niż lub ukośnie równe z kropką nad prawą stroną"] # 0x2a83
+ - "⪄": [t: "większe niż lub ukośnie równe z kropką nad lewą stroną"] # 0x2a84
+ - "⪅": [t: "mniejsze niż lub przybliżone"]            # 0x2a85
+ - "⪆": [t: "większe niż lub przybliżone"]         # 0x2a86
+ - "⪇": [t: "mniejsze niż z pojedynczą linią nierówności"] # 0x2a87
+ - "⪈": [t: "większe niż z pojedynczą linią nierówności"] # 0x2a88
+ - "⪉": [t: "mniejsze niż i nie przybliżone"]       # 0x2a89
+ - "⪊": [t: "większe niż i nie przybliżone"]    # 0x2a8a
+ - "⪋": [t: "mniejsze niż nad podwójną linią równości nad większe niż"] # 0x2a8b
+ - "⪌": [t: "większe niż nad podwójną linią równości nad mniejsze niż"] # 0x2a8c
+ - "⪍": [t: "mniejsze niż nad podobne lub równe"]    # 0x2a8d
+ - "⪎": [t: "większe niż nad podobne lub równe"] # 0x2a8e
+ - "⪏": [t: "mniejsze niż nad podobne nad większe niż"] # 0x2a8f
+ - "⪐": [t: "większe niż nad podobne nad mniejsze niż"] # 0x2a90
+ - "⪑": [t: "mniejsze niż nad większe niż nad podwójną linią równości"] # 0x2a91
+ - "⪒": [t: "większe niż nad mniejsze niż nad podwójną linią równości"] # 0x2a92
+ - "⪓": [t: "mniejsze niż nad ukośnie równe nad większe niż nad ukośnie równe"] # 0x2a93
+ - "⪔": [t: "większe niż nad ukośnie równe nad mniejsze niż nad ukośnie równe"] # 0x2a94
+ - "⪕": [t: "ukośnie równe lub mniejsze niż"]       # 0x2a95
+ - "⪖": [t: "ukośnie równe lub większe niż"]    # 0x2a96
+ - "⪗": [t: "ukośnie równe lub mniejsze niż z kropką wewnątrz"] # 0x2a97
+ - "⪘": [t: "ukośnie równe lub większe niż z kropką wewnątrz"] # 0x2a98
+ - "⪙": [t: "podwójna linia równa lub mniejsze niż"]   # 0x2a99
+ - "⪚": [t: "podwójna linia równa lub większe niż"] # 0x2a9a
+ - "⪛": [t: "podwójna linia ukośnie równa lub mniejsze niż"] # 0x2a9b
+ - "⪜": [t: "podwójna linia ukośnie równa lub większe niż"] # 0x2a9c
+ - "⪝": [t: "podobne lub mniejsze niż"]                # 0x2a9d
+ - "⪞": [t: "podobne lub większe niż"]             # 0x2a9e
+ - "⪟": [t: "podobne nad mniejsze niż nad znakiem równości"] # 0x2a9f
+ - "⪠": [t: "podobne nad większe niż nad znakiem równości"] # 0x2aa0
+ - "⪡": [t: "podwójnie zagnieżdżone mniejsze niż"]             # 0x2aa1
+ - "⪢": [t: "podwójnie zagnieżdżone większe niż"]          # 0x2aa2
+ - "⪣": [t: "podwójnie zagnieżdżone mniejsze niż z podkreśleniem"] # 0x2aa3
+ - "⪤": [t: "większe niż nakładające się na mniejsze niż"]  # 0x2aa4
+ - "⪥": [t: "większe niż obok mniejsze niż"]       # 0x2aa5
+ - "⪦": [t: "mniejsze niż zamknięte krzywą"]           # 0x2aa6
+ - "⪧": [t: "większe niż zamknięte krzywą"]        # 0x2aa7
+ - "⪨": [t: "mniejsze niż zamknięte krzywą nad ukośnie równe"] # 0x2aa8
+ - "⪩": [t: "większe niż zamknięte krzywą nad ukośnie równe"] # 0x2aa9
+ - "⪪": [t: "mniejsze niż"]                        # 0x2aaa
+ - "⪫": [t: "większe niż"]                         # 0x2aab
+ - "⪬": [t: "mniejsze niż lub równe"]            # 0x2aac
+ - "⪭": [t: "większe niż lub równe"]             # 0x2aad
+ - "⪮": [t: "znak równości z garbem nad"]        # 0x2aae
+ - "⪯": [t: "poprzedza nad pojedynczą linią równości"] # 0x2aaf
+ - "⪰": [t: "następuje po nad pojedynczą linią równości"] # 0x2ab0
+ - "⪱": [t: "poprzedza nad pojedynczą linią nierówności"] # 0x2ab1
+ - "⪲": [t: "następuje po nad pojedynczy linia nie równa się"] # 0x2ab2
+ - "⪳": [t: "poprzedza nad znakiem równości"]          # 0x2ab3
+ - "⪴": [t: "następuje po nad znakiem równości"]          # 0x2ab4
+ - "⪵": [t: "poprzedza nad nie równa się"]         # 0x2ab5
+ - "⪶": [t: "następuje po nad nie równa się"]         # 0x2ab6
+ - "⪷": [t: "poprzedza nad znakiem przybliżonej równości"]      # 0x2ab7
+ - "⪸": [t: "następuje po nad znakiem przybliżonej równości"]      # 0x2ab8
+ - "⪹": [t: "poprzedza nad znakiem nie w przybliżeniu równe"]  # 0x2ab9
+ - "⪺": [t: "następuje po nad znakiem nie w przybliżeniu równe"]  # 0x2aba
+ - "⪻": [t: "podwójny poprzedza"]                     # 0x2abb
+ - "⪼": [t: "podwójny następuje po"]                     # 0x2abc
+ - "⪽": [t: "podzbiór z kropką"]                     # 0x2abd
+ - "⪾": [t: "nadzbiór z kropką"]                   # 0x2abe
+ - "⪿": [t: "podzbiór ze znakiem plus pod spodem"] # 0x2abf
+ - "⫀": [t: "nadzbiór ze znakiem plus pod spodem"] # 0x2ac0
+ - "⫁": [t: "podzbiór ze znakiem mnożenia pod"] # 0x2ac1
+ - "⫂": [t: "nadzbiór ze znakiem mnożenia pod"] # 0x2ac2
+ - "⫃": [t: "podzbiór lub równy z kropką nad"] # 0x2ac3
+ - "⫄": [t: "nadzbiór lub równy z kropką nad"] # 0x2ac4
+ - "⫅": [t: "podzbiór nad znakiem równości"]         # 0x2ac5
+ - "⫆": [t: "nadzbiór nad znakiem równości"]       # 0x2ac6
+ - "⫇": [t: "podzbiór nad operatorem tyldy"]      # 0x2ac7
+ - "⫈": [t: "nadzbiór nad operatorem tyldy"]    # 0x2ac8
+ - "⫉": [t: "podzbiór nad znakiem przybliżonej równości"]     # 0x2ac9
+ - "⫊": [t: "nadzbiór nad znakiem przybliżonej równości"]   # 0x2aca
+ - "⫋": [t: "podzbiór nad nie równa się"]           # 0x2acb
+ - "⫌": [t: "nadzbiór nad nie równa się"]      # 0x2acc
+ - "⫍": [t: "kwadrat lewy otwórz ramka operator"]       # 0x2acd
+ - "⫎": [t: "kwadrat prawy otwórz ramka operator"]      # 0x2ace
+ - "⫏": [t: "zamknięty podzbiór"]                       # 0x2acf
+ - "⫐": [t: "zamknięty nadzbiór"]                     # 0x2ad0
+ - "⫑": [t: "zamknięty podzbiór lub równe"]           # 0x2ad1
+ - "⫒": [t: "zamknięty nadzbiór lub równe"]         # 0x2ad2
+ - "⫓": [t: "podzbiór nad nadzbiór"]               # 0x2ad3
+ - "⫔": [t: "nadzbiór nad podzbiór"]               # 0x2ad4
+ - "⫕": [t: "podzbiór nad podzbiór"]                 # 0x2ad5
+ - "⫖": [t: "nadzbiór nad nadzbiór"]             # 0x2ad6
+ - "⫗": [t: "nadzbiór obok podzbioru"]              # 0x2ad7
+ - "⫘": [t: "nadzbiór obok podzbioru połączony kreską"] # 0x2ad8
+ - "⫙": [t: "należy do otwarte od dołu"]        # 0x2ad9
+ - "⫚": [t: "widły z górną poprzeczką"]              # 0x2ada
+ - "⫛": [t: "poprzeczna część wspólna"]            # 0x2adb
+ - "⫝̸": [t: "rozwidlanie"]                             # 0x2adc
+ - "⫝": [t: "nierozwidlanie"]                          # 0x2add
+ - "⫞": [t: "krótki lewy znacznik"]                     # 0x2ade
+ - "⫟": [t: "krótki dolny znacznik"]                     # 0x2adf
+ - "⫠": [t: "krótki górny znacznik"]                       # 0x2ae0
+ - "⫡": [t: "prostopadłe z literą s"]                # 0x2ae1
+ - "⫢": [t: "pionowa kreska z potrójnym prawym znacznikiem dedukcji"] # 0x2ae2
+ - "⫣": [t: "podwójna pionowa kreska z lewym znacznikiem dedukcji"]  # 0x2ae3
+ - "⫤": [t: "pionowa kreska z podwójnym lewym znacznikiem dedukcji"]  # 0x2ae4
+ - "⫥": [t: "podwójna pionowa kreska z podwójnym lewym znacznikiem dedukcji"] # 0x2ae5
+ - "⫦": [t: "długa kreska od lewego elementu z podwójną pionową kreską"] # 0x2ae6
+ - "⫧": [t: "krótki dolny znacznik z kreską nad"]        # 0x2ae7
+ - "⫨": [t: "krótki górny znacznik z podkreśleniem"]         # 0x2ae8
+ - "⫩": [t: "krótki górny znacznik nad krótkim dolnym znacznikiem"] # 0x2ae9
+ - "⫪": [t: "podwójny dolny znacznik"]                    # 0x2aea
+ - "⫫": [t: "podwójny górny znacznik"]                      # 0x2aeb
+ - "⫬": [t: "znak negacji z podwójnym przekreśleniem"]              # 0x2aec
+ - "⫭": [t: "odwrócony znak negacji z podwójnym przekreśleniem"]     # 0x2aed
+ - "⫮": [t: "nie dzieli z odwróconym ukośnikiem negacji"] # 0x2aee
+ - "⫯": [t: "pionowa linia z okręgiem nad"]     # 0x2aef
+ - "⫰": [t: "pionowa linia z okręgiem pod"]     # 0x2af0
+ - "⫱": [t: "dolny znacznik z okręgiem pod"]         # 0x2af1
+ - "⫲": [t: "równoległe z poziomą kreską"]     # 0x2af2
+ - "⫳": [t: "równoległe z operatorem tyldy"]     # 0x2af3
+ - "⫴": [t: "potrójna pionowa kreska jako relacja binarna"] # 0x2af4
+ - "⫵": [t: "potrójna pionowa kreska z poziomą kreską"] # 0x2af5
+ - "⫶": [t: "potrójny dwukropek operator"]               # 0x2af6
+ - "⫷": [t: "potrójnie zagnieżdżone mniejsze niż"]             # 0x2af7
+ - "⫸": [t: "potrójnie zagnieżdżone większe niż"]          # 0x2af8
+ - "⫹": [t: "podwójna linia ukośnie mniejsze lub równe"] # 0x2af9
+ - "⫺": [t: "podwójna linia ukośnie większe lub równe"] # 0x2afa
+ - "⫻": [t: "potrójny ukośnik jako relacja binarna"]      # 0x2afb
+ - "⫼": [t: "operator dużej potrójnej pionowej kreski"]  # 0x2afc
+ - "⫽": [t: "podwójny ukośnik operator"]             # 0x2afd
+ - "⫾": [t: "biała pionowa kreska"]                  # 0x2afe
+ - "⫿": [t: "biała pionowa kreska"]                  # 0x2aff
+ - "⬀": [t: "biała strzałka na północny wschód"]              # 0x2b00
+ - "⬁": [t: "biała strzałka na północny zachód"]              # 0x2b01
+ - "⬂": [t: "biała strzałka na południowy wschód"]              # 0x2b02
+ - "⬃": [t: "biała strzałka na południowy zachód"]              # 0x2b03
+ - "⬄": [t: "biała strzałka w lewo i w prawo"]              # 0x2b04
+ - "⬅": [t: "lewy czarny strzałka"]               # 0x2b05
+ - "⬆": [t: "górny czarny strzałka"]                 # 0x2b06
+ - "⬇": [t: "dolny czarny strzałka"]               # 0x2b07
+ - "⬈": [t: "północ wschód czarny strzałka"]              # 0x2b08
+ - "⬉": [t: "północ zachód czarny strzałka"]              # 0x2b09
+ - "⬊": [t: "południe wschód czarny strzałka"]              # 0x2b0a
+ - "⬋": [t: "południe zachód czarny strzałka"]              # 0x2b0b
+ - "⬌": [t: "lewy prawy czarny strzałka"]              # 0x2b0c
+ - "⬍": [t: "górny dolny czarny strzałka"]                 # 0x2b0d
+ - "⬎": [t: "strzałka w prawo z dolnym czubkiem"] # 0x2b0e
+ - "⬏": [t: "strzałka w prawo z górnym czubkiem"]   # 0x2b0f
+ - "⬐": [t: "strzałka w lewo z dolnym czubkiem"]  # 0x2b10
+ - "⬑": [t: "strzałka w lewo z górnym czubkiem"]    # 0x2b11
+ - "⬒": [t: "kwadrat z górną połową czarną"]          # 0x2b12
+ - "⬓": [t: "kwadrat z dolną połową czarną"]       # 0x2b13
+ - "⬔": [t: "kwadrat z górną prawą ukośną połową czarną"] # 0x2b14
+ - "⬕": [t: "kwadrat z dolną lewą ukośną połową czarną"] # 0x2b15
+ - "⬖": [t: "romb z lewą połową czarną"]        # 0x2b16
+ - "⬗": [t: "romb z prawą połową czarną"]       # 0x2b17
+ - "⬘": [t: "romb z górną połową czarną"]         # 0x2b18
+ - "⬙": [t: "romb z dolną połową czarną"]      # 0x2b19
+ - "⬚": [t: "ramka"]                                 # 0x2b1a
+ - "⬛": [t: "czarny duży kwadrat"]                  # 0x2b1b
+ - "⬜": [t: "biały duży kwadrat"]                  # 0x2b1c
+ - "⬝": [t: "czarny bardzo mały kwadrat"]             # 0x2b1d
+ - "⬞": [t: "biały bardzo mały kwadrat"]             # 0x2b1e
+ - "⬟": [t: "czarny pięciokąt"]                      # 0x2b1f
+ - "⬠": [t: "biały pięciokąt"]                      # 0x2b20
+ - "⬡": [t: "biały sześciokąt"]                       # 0x2b21
+ - "⬢": [t: "czarny sześciokąt"]                       # 0x2b22
+ - "⬣": [t: "poziomy czarny sześciokąt"]            # 0x2b23
+ - "⬤": [t: "czarny duży okrąg"]                  # 0x2b24
+ - "⬥": [t: "czarny średni romb"]                # 0x2b25
+ - "⬦": [t: "biały średni romb"]                # 0x2b26
+ - "⬧": [t: "czarny średni romb"]                # 0x2b27
+ - "⬨": [t: "biały średni romb"]                # 0x2b28
+ - "⬩": [t: "czarny mały romb"]                 # 0x2b29
+ - "⬪": [t: "czarny mały romb"]                 # 0x2b2a
+ - "⬫": [t: "biały mały romb"]                 # 0x2b2b
+ - "⬬": [t: "czarna pozioma elipsa"]            # 0x2b2c
+ - "⬭": [t: "biała pozioma elipsa"]            # 0x2b2d
+ - "⬮": [t: "czarna pionowa elipsa"]              # 0x2b2e
+ - "⬯": [t: "biała pionowa elipsa"]              # 0x2b2f
+ - "⬰": [t: "strzałka w lewo z małym okręgiem"]        # 0x2b30
+ - "⬱": [t: "trzy strzałki w lewo"]              # 0x2b31
+ - "⬲": [t: "strzałka w lewo z plusem w kółku"]        # 0x2b32
+ - "⬳": [t: "długa falista strzałka w lewo"]       # 0x2b33
+ - "⬴": [t: "strzałka w lewo z dwoma grotami i pionowym przekreśleniem"] # 0x2b34
+ - "⬵": [t: "strzałka w lewo z dwoma grotami i podwójnym pionowym przekreśleniem"] # 0x2b35
+ - "⬶": [t: "strzałka w lewo z dwoma grotami od kreski"] # 0x2b36
+ - "⬷": [t: "strzałka w lewo z dwoma grotami i potrójną kreską"] # 0x2b37
+ - "⬸": [t: "strzałka w lewo z kropkowanym trzonem"]    # 0x2b38
+ - "⬹": [t: "strzałka w lewo z ogonem i pionową kreską"] # 0x2b39
+ - "⬺": [t: "strzałka w lewo z ogonem i podwójną pionową kreską"] # 0x2b3a
+ - "⬻": [t: "strzałka w lewo z dwoma grotami i ogonem"] # 0x2b3b
+ - "⬼": [t: "strzałka w lewo z dwoma grotami, ogonem i pionowym przekreśleniem"] # 0x2b3c
+ - "⬽": [t: "strzałka w lewo z dwoma grotami, ogonem i podwójnym pionowym przekreśleniem"] # 0x2b3d
+ - "⬾": [t: "strzałka w lewo przez X"]           # 0x2b3e
+ - "⬿": [t: "falista strzałka skierowana bezpośrednio w lewo"]   # 0x2b3f
+ - "⭀": [t: "znak równości nad strzałką w lewo"]   # 0x2b40
+ - "⭁": [t: "operator odwrotnej tyldy nad strzałką w lewo"] # 0x2b41
+ - "⭂": [t: "strzałka w lewo nad odwróconym znakiem przybliżonej równości"] # 0x2b42
+ - "⭃": [t: "strzałka w prawo przez znak większe niż"] # 0x2b43
+ - "⭄": [t: "strzałka w prawo przez znak nadzbioru"]   # 0x2b44
+ - "⭅": [t: "lewy poczwórny strzałka"]           # 0x2b45
+ - "⭆": [t: "prawy poczwórny strzałka"]          # 0x2b46
+ - "⭇": [t: "operator odwrotnej tyldy nad strzałką w prawo"] # 0x2b47
+ - "⭈": [t: "strzałka w prawo nad odwróconym znakiem przybliżonej równości"] # 0x2b48
+ - "⭉": [t: "operator tyldy nad strzałką w lewo"] # 0x2b49
+ - "⭊": [t: "strzałka w lewo nad znakiem przybliżonej równości"] # 0x2b4a
+ - "⭋": [t: "strzałka w lewo nad operatorem odwrotnej tyldy"] # 0x2b4b
+ - "⭌": [t: "strzałka w prawo nad operatorem odwrotnej tyldy"] # 0x2b4c
+ - "⭐": [t: "biały średni gwiazda"]                   # 0x2b50
+ - "⭑": [t: "czarny mały gwiazda"]                    # 0x2b51
+ - "⭒": [t: "biały mały gwiazda"]                    # 0x2b52
+ - "⭓": [t: "czarny prawy skierowany pięciokąt"]       # 0x2b53
+ - "⭔": [t: "biały prawy skierowany pięciokąt"]       # 0x2b54
+ - "⭕": [t: "gruby duży okrąg"]                  # 0x2b55
+ - "⭖": [t: "gruby owal z owalem wewnątrz"]      # 0x2b56
+ - "⭗": [t: "gruby okrąg z okręgiem wewnątrz"]   # 0x2b57
+ - "⭘": [t: "gruby okrąg"]                        # 0x2b58
+ - "⭙": [t: "gruby ukośny krzyż w kółku"]         # 0x2b59
+ - "⸀": [t: "kąt prosty znacznik podstawienia"]     # 0x2e00
+ - "⸁": [t: "kąt prosty kropkowany znacznik podstawienia"] # 0x2e01
+ - "⸂": [t: "lewy nawias kwadratowy podstawienia"] # 0x2e02
+ - "⸃": [t: "prawy nawias kwadratowy podstawienia"] # 0x2e03
+ - "⸄": [t: "lewy kropkowany nawias kwadratowy podstawienia"] # 0x2e04
+ - "⸅": [t: "prawy kropkowany nawias kwadratowy podstawienia"] # 0x2e05
+ - "⸆": [t: "podniesiony znacznik interpolacji"]         # 0x2e06
+ - "⸇": [t: "podniesiony kropkowany znacznik interpolacji"]  # 0x2e07
+ - "⸈": [t: "kropkowany znacznik transpozycji"]  # 0x2e08
+ - "⸉": [t: "lewy nawias kwadratowy transpozycji"] # 0x2e09
+ - "⸊": [t: "prawy nawias kwadratowy transpozycji"] # 0x2e0a
+ - "⸋": [t: "podniesiony kwadrat"]                       # 0x2e0b
+ - "⸌": [t: "lewy podniesiony pominięcia nawias kwadratowy"]        # 0x2e0c
+ - "⸍": [t: "prawy podniesiony pominięcia nawias kwadratowy"]       # 0x2e0d
+ - "⸎": [t: "redakcyjny koronis"]                 # 0x2e0e
+ - "⸏": [t: "paragraphos"]                         # 0x2e0f
+ - "⸐": [t: "rozwidlony paragrafos"]                  # 0x2e10
+ - "⸑": [t: "odwrócony rozwidlony paragrafos"]         # 0x2e11
+ - "⸒": [t: "hypodiastole"]                        # 0x2e12
+ - "⸓": [t: "kropkowany obelos"]                       # 0x2e13
+ - "⸔": [t: "dolny ancora"]                    # 0x2e14
+ - "⸕": [t: "górny ancora"]                      # 0x2e15
+ - "⸖": [t: "kropkowany kąt skierowany w prawo"]         # 0x2e16
+ - "⸗": [t: "podwójny ukośny łącznik"]            # 0x2e17
+ - "⸘": [t: "odwrócony interrobang"]                # 0x2e18
+ - "⸙": [t: "gałązka palmowa"]                         # 0x2e19
+ - "⸚": [t: "łącznik z dierezą"]                 # 0x2e1a
+ - "⸛": [t: "tylda z pierścieniem nad"]          # 0x2e1b
+ - "⸜": [t: "lewy dolny nawias kwadratowy parafrazy"] # 0x2e1c
+ - "⸝": [t: "prawy dolny nawias kwadratowy parafrazy"] # 0x2e1d
+ - "⸞": [t: "tylda z kropką nad"]                # 0x2e1e
+ - "⸟": [t: "tylda z kropką pod"]                # 0x2e1f
+ - "⸠": [t: "lewa pionowa kreska z piórem"]        # 0x2e20
+ - "⸡": [t: "prawa pionowa kreska z piórem"]       # 0x2e21
+ - "⸢": [t: "górny lewa połowa nawias kwadratowy"]               # 0x2e22
+ - "⸣": [t: "górny prawa połowa nawias kwadratowy"]              # 0x2e23
+ - "⸤": [t: "dolny lewa połowa nawias kwadratowy"]            # 0x2e24
+ - "⸥": [t: "dolny prawa połowa nawias kwadratowy"]           # 0x2e25
+ - "⸦": [t: "lewy obrócony nawias kwadratowy u"] # 0x2e26
+ - "⸧": [t: "prawy obrócony nawias kwadratowy u"] # 0x2e27
+ - "⸨": [t: "lewy podwójny nawias okrągły"]             # 0x2e28
+ - "⸩": [t: "prawy podwójny nawias okrągły"]            # 0x2e29
+ - "⸪": [t: "dwie kropki nad jedną kropką interpunkcyjną"]   # 0x2e2a
+ - "⸫": [t: "jedna kropka nad dwiema kropkami interpunkcyjnymi"]   # 0x2e2b
+ - "⸬": [t: "do kwadratu cztery kropka interpunkcyjny"]        # 0x2e2c
+ - "⸭": [t: "pięć kropka znak"]                       # 0x2e2d
+ - "⸮": [t: "odwrócony zapytania znak"]              # 0x2e2e
+ - "ⸯ": [t: "pionowy tylda"]                      # 0x2e2f
+ - "⸰": [t: "pierścień punkt"]                          # 0x2e30
+ - "⸱": [t: "separator wyrazów środkowa kropka"]           # 0x2e31
+ - "⸲": [t: "odwrócony przecinek"]                        # 0x2e32
+ - "⸳": [t: "podniesiony kropka"]                          # 0x2e33
+ - "⸴": [t: "podniesiony przecinek"]                        # 0x2e34
+ - "⸵": [t: "odwrócony średnik"]                    # 0x2e35
+ - "⸶": [t: "obelisk z lewą osłoną"]             # 0x2e36
+ - "⸷": [t: "obelisk z prawą osłoną"]            # 0x2e37
+ - "⸸": [t: "odwrócony obelisk"]                       # 0x2e38
+ - "⸹": [t: "górna połowa paragraf znak"]               # 0x2e39
+ - "⸺": [t: "dwa pauza"]                         # 0x2e3a
+ - "⸻": [t: "trzy pauza"]                       # 0x2e3b
+ - "〃": [t: "znak powtórzenia"]                  # 0x3003
+ - "〈": [t: "lewy nawias kątowy"]                  # 0x3008
+ - "〉": [t: "prawy nawias kątowy"]                 # 0x3009
+ - "《": [t: "lewy podwójny nawias kątowy"]           # 0x300a
+ - "》": [t: "prawy podwójny nawias kątowy"]          # 0x300b
+ - "「": [t: "lewy nawias narożny"]                 # 0x300c
+ - "」": [t: "prawy nawias narożny"]                # 0x300d
+ - "『": [t: "lewy biały nawias narożny"]           # 0x300e
+ - "』": [t: "prawy biały nawias narożny"]          # 0x300f
+ - "【": [t: "lewy czarny nawias soczewkowy"]       # 0x3010
+ - "】": [t: "prawy czarny nawias soczewkowy"]      # 0x3011
+ - "〔": [t: "lewy nawias skorupowy"]         # 0x3014
+ - "〕": [t: "prawy nawias skorupowy"]        # 0x3015
+ - "〖": [t: "lewy biały nawias soczewkowy"]       # 0x3016
+ - "〗": [t: "prawy biały nawias soczewkowy"]      # 0x3017
+ - "〘": [t: "lewy biały nawias skorupowy"]   # 0x3018
+ - "〙": [t: "prawy biały nawias skorupowy"]  # 0x3019
+ - "〚": [t: "lewy biały nawias kwadratowy"]           # 0x301a
+ - "〛": [t: "prawy biały nawias kwadratowy"]          # 0x301b
+ - "〜": [t: "falista kreska"]                           # 0x301c
+ - "〰": [t: "falista kreska"]                           # 0x3030
+ - "㉈": [t: "liczba dziesięć w kółku na czarnym kwadracie"]  # 0x3248
+ - "㉉": [t: "liczba dwadzieścia w kółku na czarnym kwadracie"] # 0x3249
+ - "㉊": [t: "liczba trzydzieści w kółku na czarnym kwadracie"] # 0x324a
+ - "㉋": [t: "liczba czterdzieści w kółku na czarnym kwadracie"] # 0x324b
+ - "㉌": [t: "liczba pięćdziesiąt w kółku na czarnym kwadracie"] # 0x324c
+ - "㉍": [t: "liczba sześćdziesiąt w kółku na czarnym kwadracie"] # 0x324d
+ - "㉎": [t: "liczba siedemdziesiąt w kółku na czarnym kwadracie"] # 0x324e
+ - "㉏": [t: "liczba osiemdziesiąt w kółku na czarnym kwadracie"] # 0x324f
+ - "㉑": [t: "w kółku numer dwadzieścia jeden"]           # 0x3251
+ - "㉒": [t: "w kółku numer dwadzieścia dwa"]           # 0x3252
+ - "㉓": [t: "w kółku numer dwadzieścia trzy"]         # 0x3253
+ - "㉔": [t: "w kółku numer dwadzieścia cztery"]          # 0x3254
+ - "㉕": [t: "w kółku numer dwadzieścia pięć"]          # 0x3255
+ - "㉖": [t: "w kółku numer dwadzieścia sześć"]           # 0x3256
+ - "㉗": [t: "w kółku numer dwadzieścia siedem"]         # 0x3257
+ - "㉘": [t: "w kółku numer dwadzieścia osiem"]         # 0x3258
+ - "㉙": [t: "w kółku numer dwadzieścia dziewięć"]          # 0x3259
+ - "㉚": [t: "w kółku numer trzydzieści"]               # 0x325a
+ - "㉛": [t: "w kółku numer trzydzieści jeden"]           # 0x325b
+ - "㉜": [t: "w kółku numer trzydzieści dwa"]           # 0x325c
+ - "㉝": [t: "w kółku numer trzydzieści trzy"]         # 0x325d
+ - "㉞": [t: "w kółku numer trzydzieści cztery"]          # 0x325e
+ - "㉟": [t: "w kółku numer trzydzieści pięć"]          # 0x325f
+ - "㊱": [t: "w kółku numer trzydzieści sześć"]           # 0x32b1
+ - "㊲": [t: "w kółku numer trzydzieści siedem"]         # 0x32b2  (GPT-5.4 translation)
+ - "㊳": [t: "w kółku numer trzydzieści osiem"]         # 0x32b3  (GPT-5.4 translation)
+ - "㊴": [t: "w kółku numer trzydzieści dziewięć"]          # 0x32b4  (GPT-5.4 translation)
+ - "㊵": [t: "w kółku numer czterdzieści"]                # 0x32b5  (GPT-5.4 translation)
+ - "㊶": [t: "w kółku numer czterdzieści jeden"]            # 0x32b6  (GPT-5.4 translation)
+ - "㊷": [t: "w kółku numer czterdzieści dwa"]            # 0x32b7  (GPT-5.4 translation)
+ - "㊸": [t: "w kółku numer czterdzieści trzy"]          # 0x32b8  (GPT-5.4 translation)
+ - "㊹": [t: "w kółku numer czterdzieści cztery"]           # 0x32b9  (GPT-5.4 translation)
+ - "㊺": [t: "w kółku numer czterdzieści pięć"]           # 0x32ba  (GPT-5.4 translation)
+ - "㊻": [t: "w kółku numer czterdzieści sześć"]            # 0x32bb  (GPT-5.4 translation)
+ - "㊼": [t: "w kółku numer czterdzieści siedem"]          # 0x32bc  (GPT-5.4 translation)
+ - "㊽": [t: "w kółku numer czterdzieści osiem"]          # 0x32bd  (GPT-5.4 translation)
+ - "㊾": [t: "w kółku numer czterdzieści dziewięć"]           # 0x32be  (GPT-5.4 translation)
+ - "㊿": [t: "w kółku numer pięćdziesiąt"]                # 0x32bf  (GPT-5.4 translation)
+ - "㋌": [t: "Merkury"]                             # 0x32cc
+ - "㋍": [t: "ergi"]                                # 0x32cd
+ - "㋎": [t: "elektron wolty"]                      # 0x32ce
+ - "㋏": [t: "znak ograniczonej odpowiedzialności"]              # 0x32cf
+ - "㍱": [t: "hektopaskale"]                        # 0x3371
+ - "㍲": [t: "daltony"]                             # 0x3372
+ - "㍳": [t: "jednostki astronomiczne"]                  # 0x3373
+ - "㍴": [t: "bary"]                                # 0x3374
+ - "㍵": [t: "o V"]                                 # 0x3375
+ - "㍶": [t: "parseki"]                             # 0x3376
+ - "㍷": [t: "decymetry"]                          # 0x3377
+ - "㍸": [t: "decymetry do kwadratu"]                  # 0x3378
+ - "㍹": [t: "decymetry do sześcianu"]                    # 0x3379
+ - "㍺": [t: "jednostki międzynarodowe"]                  # 0x337a
+ - "㎀": [t: "pikoampery"]                            # 0x3380
+ - "㎁": [t: "nanoampery"]                            # 0x3381
+ - "㎂": [t: "mikroampery"]                           # 0x3382
+ - "㎃": [t: "miliampery"]                           # 0x3383
+ - "㎄": [t: "kiloampery"]                            # 0x3384
+ - "㎅": [t: "kilobajty"]                           # 0x3385
+ - "㎆": [t: "megabajty"]                           # 0x3386
+ - "㎇": [t: "gigabajty"]                           # 0x3387
+ - "㎈": [t: "kalorie"]                            # 0x3388
+ - "㎉": [t: "kilokalorie"]                        # 0x3389
+ - "㎊": [t: "pikofarady"]                          # 0x338a
+ - "㎋": [t: "nanofarady"]                          # 0x338b
+ - "㎌": [t: "mikrofarady"]                         # 0x338c
+ - "㎍": [t: "mikrogramy"]                          # 0x338d
+ - "㎎": [t: "miligramy"]                          # 0x338e
+ - "㎏": [t: "kilogramy"]                           # 0x338f
+ - "㎐": [t: "herce"]                               # 0x3390
+ - "㎑": [t: "kiloherce"]                           # 0x3391
+ - "㎒": [t: "megaherce"]                           # 0x3392
+ - "㎓": [t: "gigaherce"]                           # 0x3393
+ - "㎔": [t: "teraherce"]                           # 0x3394
+ - "㎕": [t: "mikrolitry"]                         # 0x3395
+ - "㎖": [t: "mililitry"]                         # 0x3396
+ - "㎗": [t: "decylitry"]                          # 0x3397
+ - "㎘": [t: "kilolitry"]                          # 0x3398
+ - "㎙": [t: "femtometry"]                         # 0x3399
+ - "㎚": [t: "nanometry"]                          # 0x339a
+ - "㎛": [t: "mikrometry"]                         # 0x339b
+ - "㎜": [t: "milimetry"]                         # 0x339c
+ - "㎝": [t: "centymetry"]                         # 0x339d
+ - "㎞": [t: "kilometry"]                          # 0x339e
+ - "㎟": [t: "milimetry do kwadratu"]                 # 0x339f
+ - "㎠": [t: "centymetry do kwadratu"]                 # 0x33a0
+ - "㎡": [t: "metry do kwadratu"]                      # 0x33a1
+ - "㎢": [t: "kilometry do kwadratu"]                  # 0x33a2
+ - "㎣": [t: "milimetry do sześcianu"]                   # 0x33a3
+ - "㎤": [t: "centymetry do sześcianu"]                   # 0x33a4
+ - "㎥": [t: "metry do sześcianu"]                        # 0x33a5
+ - "㎦": [t: "kilometry do sześcianu"]                    # 0x33a6
+ - "㎧": [t: "metry na drugi"]                   # 0x33a7
+ - "㎨": [t: "metry na drugi do kwadratu"]           # 0x33a8
+ - "㎩": [t: "paskale"]                             # 0x33a9
+ - "㎪": [t: "kilopaskale"]                         # 0x33aa
+ - "㎫": [t: "megapaskale"]                         # 0x33ab
+ - "㎬": [t: "gigapaskale"]                         # 0x33ac
+ - "㎭": [t: "radiany"]                                # 0x33ad
+ - "㎮": [t: "radiany na sekundę"]                     # 0x33ae
+ - "㎯": [t: "radiany na sekundę do kwadratu"]             # 0x33af
+ - "㎰": [t: "pikosekundy"]                         # 0x33b0
+ - "㎱": [t: "nanosekundy"]                         # 0x33b1
+ - "㎲": [t: "mikrosekundy"]                        # 0x33b2
+ - "㎳": [t: "milisekundy"]                        # 0x33b3
+ - "㎴": [t: "pikowolty"]                           # 0x33b4
+ - "㎵": [t: "nanowolty"]                           # 0x33b5
+ - "㎶": [t: "mikrowolty"]                          # 0x33b6
+ - "㎷": [t: "miliwolty"]                          # 0x33b7
+ - "㎸": [t: "kilowolty"]                           # 0x33b8
+ - "㎹": [t: "megawolty"]                           # 0x33b9
+ - "㎺": [t: "pikowaty"]                           # 0x33ba
+ - "㎻": [t: "nanowaty"]                           # 0x33bb
+ - "㎼": [t: "mikrowaty"]                          # 0x33bc
+ - "㎽": [t: "miliwaty"]                          # 0x33bd
+ - "㎾": [t: "kilowaty"]                           # 0x33be
+ - "㎿": [t: "megawaty"]                           # 0x33bf
+ - "㏀": [t: "kilo omy"]                           # 0x33c0
+ - "㏁": [t: "megaomy"]                            # 0x33c1
+ - "㏂": [t: "A M"]                          # 0x33c2
+ - "㏃": [t: "bekerele"]                          # 0x33c3
+ - "㏄": [t: "centymetry sześcienne"]                   # 0x33c4
+ - "㏅": [t: "kandele"]                            # 0x33c5
+ - "㏆": [t: "kulomby na kilogram"]               # 0x33c6
+ - "㏇": [t: "wielkie C, o, kropka"]                    # 0x33c7 (I have no idea what this is)
+ - "㏈": [t: "decybele"]                            # 0x33c8
+ - "㏉": [t: "greje"]                               # 0x33c9
+ - "㏊": [t: "hektary"]                            # 0x33ca
+ - "㏋": [t: "konie mechaniczne"]                          # 0x33cb
+ - "㏌": [t: "cale"]                                # 0x33cc
+ - "㏍": [t: "kilokelwiny"]                         # 0x33cd
+ - "㏎": [t: "kilometry"]                          # 0x33ce
+ - "㏏": [t: "węzły"]                               # 0x33cf
+ - "㏐": [t: "lumeny"]                              # 0x33d0
+ - "㏑": [T: "logarytm naturalny"]                         # 0x33d1
+ - "㏒": [t: "logarytm"]                            # 0x33d2
+ - "㏓": [t: "luksy"]                               # 0x33d3
+ - "㏔": [t: "milibarny"]                           # 0x33d4
+ - "㏕": [t: "mile"]                                # 0x33d5
+ - "㏖": [t: "mole"]                                # 0x33d6
+ - "㏗": [t: "p h"]                                 # 0x33d7
+ - "㏘": [t: "pikometry"]                           # 0x33d8
+ - "㏙": [t: "części na milion"]                    # 0x33d9
+ - "㏚": [t: "petarentgeny"]                        # 0x33da
+ - "㏛": [t: "steradiany"]                          # 0x33db
+ - "㏜": [t: "siwerty"]                             # 0x33dc
+ - "㏝": [t: "webery"]                              # 0x33dd
+ - "㏞": [t: "wolty na metr"]                     # 0x33de
+ - "㏟": [t: "ampery na metr"]                    # 0x33df
+ - "㏿": [t: "galony"]                             # 0x33ff
+ - "": [t: "równa się z daszkiem pod"]               # 0xe900
+ - "": [t: "równa się z plusem nad"]             # 0xe901
+ - "": [t: "równa się z plusem pod"]             # 0xe902
+ - "": [t: "tylda z plusem nad"]                 # 0xe903
+ - "": [t: "tylda z plusem pod"]                 # 0xe904
+ - "": [t: "równe podwójny przez większe niż"]      # 0xe908
+ - "": [t: "równe podwójny przez mniejsze niż"]         # 0xe909
+ - "": [t: "zawiera lub równe"]                # 0xe90a
+ - "": [t: "nadzbiór lub równy"]             # 0xe90b
+ - "": [t: "podzbiór lub równy"]               # 0xe90c
+ - "": [t: "równe przez mniejsze niż"]                # 0xe90d
+ - "": [t: "należy do lub równe"]              # 0xe912
+ - "": [t: "równe lub większe niż"]            # 0xe913
+ - "": [t: "przybliżone nadzbiór"]             # 0xe914
+ - "": [t: "przybliżone podzbiór"]               # 0xe915
+ - "": [t: "nadzbiór z kropką zawiera jako relację indeksu dolnego"] # 0xe916
+ - "": [t: "podzbiór z kropką jest zawarty jako relacja indeksu dolnego"] # 0xe917
+ - "": [t: "równe z kropką pod"]                # 0xe918
+ - "": [t: "lewy kropka nad minus przez prawy kropka"]  # 0xe919
+ - "": [t: "prawy kropka nad minus przez lewy kropka"]  # 0xe91a
+ - "": [t: "w przybliżeniu równe minus"]               # 0xe91f
+ - "": [t: "podwójna kwadratowa suma zbiorów"]                   # 0xe920
+ - "": [t: "podwójny kwadrat wielka"]                   # 0xe921
+ - "": [t: "mniejsze niż równe lub większe niż"]  # 0xe922
+ - "": [t: "tylda z kropką"]                      # 0xe924
+ - "": [t: "tylda z dwiema kropkami"]                 # 0xe925
+ - "": [t: "mniejsze niż większe lub równe"]  # 0xe926
+ - "": [t: "większe niż mniejsze lub równe"]  # 0xe927
+ - "": [t: "Równoważne lub mniejsze niż"]          # 0xe928
+ - "": [t: "Równoważne lub większe niż"]       # 0xe929
+ - "": [t: "lewy otwórz ramka operator"]              # 0xe92a
+ - "": [t: "prawy otwórz ramka operator"]             # 0xe92b
+ - "": [t: "identyczne z kropką"]                # 0xe92c
+ - "": [t: "większe niż równe lub mniejsze niż"]  # 0xe92d
+ - "": [t: "kreska operator"]                        # 0xe92e
+ - "": [t: "podwójny kreska operator"]                 # 0xe92f
+ - "": [t: "potrójny kreska operator"]                 # 0xe930
+ - "": [t: "mniejsze niż lub w przybliżeniu równe"] # 0xe932
+ - "": [t: "większe niż lub w przybliżeniu równe"] # 0xe933
+ - "": [t: "zagnieżdżone mniejsze niż"]                    # 0xe936
+ - "": [t: "zagnieżdżone większe niż"]                 # 0xe937
+ - "": [t: "poprzedza lub Równoważne"]           # 0xe93a
+ - "": [t: "następuje po lub Równoważne"]           # 0xe93b
+ - "": [t: "poprzedza nad równe"]                 # 0xe940
+ - "": [t: "następuje po nad równe"]                 # 0xe941
+ - "": [t: "mniejsze niż nad ukośnie równe nad większe niż"] # 0xe942
+ - "": [t: "większe niż nad ukośnie równe nad mniejsze niż"] # 0xe943
+ - "": [t: "spełnione przez"]                        # 0xe948
+ - "": [t: "leniwe s"]                              # 0xe949
+ - "": [t: "nie asercja"]                       # 0xe94a
+ - "": [t: "podwójny równe"]                        # 0xe94b
+ - "": [t: "potrójny równe"]                        # 0xe94c
+ - "": [t: "reguła opóźniona"]                        # 0xe94d
+ - "": [t: "alias ogranicznika"]                     # 0xe94e
+ - "": [t: "normalna podgrupa z kreską"]          # 0xe950
+ - "": [t: "zawiera jako normalny podgrupa z kreską"] # 0xe951
+ - "": [t: "zaokrąglone implikuje"]                       # 0xe954
+ - "": [t: "uśmiech pod kreską"]                     # 0xe955
+ - "": [t: "smutek przez kreskę"]                      # 0xe956
+ - "": [t: "nadzbiór lub w przybliżeniu równe"]      # 0xe957
+ - "": [t: "podzbiór lub w przybliżeniu równe"]        # 0xe958
+ - "": [t: "większe niż w przybliżeniu równe lub mniejsze niż"] # 0xe959
+ - "": [t: "mniejsze niż w przybliżeniu równe lub większe niż"] # 0xe95a
+ - "": [t: "podwójny logiczne lub"]                   # 0xe95c
+ - "": [t: "podwójna koniunkcja logiczna"]     # 0xe95d
+ - "": [t: "alternatywa logiczna z podwójną kreską pod"] # 0xe95e
+ - "": [t: "logiczne lub z kreską pod"]           # 0xe95f
+ - "": [t: "w przybliżeniu równe nad równe"]             # 0xe962
+ - "": [t: "trójkąt skierowany w lewo z kreską dzielącą"] # 0xe964
+ - "": [t: "trójkąt skierowany w prawo z kreską dzielącą"] # 0xe965
+ - "": [t: "równa się z kropkowaną górną linią"] # 0xe966
+ - "": [t: "poprzedza z dwukropkiem"]             # 0xe967
+ - "": [t: "następuje po z dwukropkiem"]          # 0xe968
+ - "": [t: "mniejsze niż lub ukośnie równe"]       # 0xe969
+ - "": [t: "większe niż lub ukośnie równe"]        # 0xe96a
+ - "": [t: "zagnieżdżone bardzo znacznie mniejsze niż"]          # 0xe96b
+ - "": [t: "zagnieżdżone bardzo znacznie większe niż"]       # 0xe96c
+ - "": [t: "wariant różnicy między"]          # 0xe96d
+ - "": [t: "mniejsze niż większe niż nakładka"]      # 0xe96e
+ - "": [t: "alternatywa logiczna z nałożoną koniunkcją logiczną"] # 0xe96f
+ - "": [t: "nadzbiór przez nadzbiór"]              # 0xe970
+ - "": [t: "podzbiór przez podzbiór"]                  # 0xe971
+ - "": [t: "nadzbiór przez podzbiór"]                # 0xe972
+ - "": [t: "podzbiór przez nadzbiór"]                # 0xe973
+ - "": [t: "potrójna pionowa kreska"]                 # 0xe979
+ - "": [t: "sparowane poczwórne pionowe kropki"]      # 0xe97a
+ - "": [t: "prostopadłe przez kreskę"]              # 0xe97b
+ - "": [t: "lewy znak dedukcji z podwójną pionową kreską"] # 0xe97c
+ - "": [t: "podwójny lewy znak dedukcji z podwójną pionową kreską"] # 0xe97d
+ - "": [t: "prostopadłe przez odwrócony prostopadłe"] # 0xe97e
+ - "": [t: "podwójny lewy znak dedukcji z pionową kreską"] # 0xe97f
+ - "": [t: "kąt sferyczny otwarty w górę"]          # 0xe980
+ - "": [t: "podwójny ukośnik"]                        # 0xe981
+ - "": [t: "kąt prosty z narożnikiem"]             # 0xe982
+ - "": [t: "pionowa kreska w kółku"]                # 0xe984
+ - "": [t: "znak dzielenia w kółku"]               # 0xe985
+ - "": [t: "kreskowany ukośnik"]                      # 0xe986
+ - "": [t: "kreskowany ukośnik odwrotny"]                    # 0xe987
+ - "": [t: "kreskowana linia środkowa"]                     # 0xe988
+ - "": [t: "kreskowana pionowa kreska"]                 # 0xe989
+ - "": [t: "prostopadłe z s"]                # 0xe98a
+ - "": [t: "kąt z s"]                        # 0xe98b
+ - "": [t: "kąt sferyczny otwarty w lewo"]        # 0xe98c
+ - "": [t: "kąt otwarty w lewo"]                  # 0xe98d
+ - "": [t: "pionowa kreska z podwójnym haczykiem"] # 0xe98e
+ - "": [t: "operator średniej kropki wolnego rodnika"]    # 0xe98f
+ - "": [t: "biały trójkąt skierowany w górę nad kreską"] # 0xe990
+ - "": [t: "identyczne i równoległe do"]       # 0xe991
+ - "": [t: "iloczyn spłaszczony"]                       # 0xe992
+ - "": [t: "potrójny operator kreski z kreską poziomą"] # 0xe993
+ - "": [t: "identyczne z podwójnym ukośnikiem"]  # 0xe994
+ - "": [t: "potrójne skrzyżowane kreski"]                 # 0xe995
+ - "": [t: "pionowa kreska przez okrąg"]            # 0xe996
+ - "": [t: "pionowy proporcjonalne do"]            # 0xe997
+ - "": [t: "czarna ostatnia kwadra księżyca"]             # 0xe998
+ - "": [t: "czarna pierwsza kwadra księżyca"]            # 0xe999
+ - "": [t: "ujemna fala sinusoidalna"]                  # 0xe9a0
+ - "": [t: "kropka w nawiasach"]                   # 0xe9a1
+ - "": [t: "nawiasy"]                              # 0xe9a2
+ - "": [t: "biały uśmiech"]                         # 0xe9a3
+ - "": [t: "biały smutek"]                         # 0xe9a4
+ - "": [t: "sześciokąt"]                             # 0xe9a5
+ - "": [t: "Równoważne nad plus"]             # 0xe9a6
+ - "": [t: "plus przez Równoważne"]             # 0xe9a7
+ - "": [t: "część wspólna z szeryfami"]                 # 0xe9b0
+ - "": [t: "suma zbiorów z szeryfami"]                        # 0xe9b1
+ - "": [t: "kwadratowa część wspólna z szeryfami"]          # 0xe9b2
+ - "": [t: "kwadratowa suma zbiorów z szeryfami"]                 # 0xe9b3
+ - "": [t: "poprzedza Równoważne lub następuje po"]  # 0xe9e0
+ - "": [t: "następuje po Równoważne lub poprzedza"]  # 0xe9e1
+ - "": [t: "poprzedza w przybliżeniu równe lub następuje po"] # 0xe9e2
+ - "": [t: "następuje po w przybliżeniu równe lub poprzedza"] # 0xe9e3
+ - "": [t: "mniejsze niż Równoważne lub większe niż"] # 0xe9f0
+ - "": [t: "większe niż Równoważne lub mniejsze niż"] # 0xe9f1
+ - "": [t: "pionowo przekreślone znacznie mniejsze niż"]             # 0xea00
+ - "": [t: "pionowo przekreślone znacznie większe niż"]          # 0xea01
+ - "": [t: "nie jest znacznie mniejsze niż, wariant"]          # 0xea02
+ - "": [t: "nie jest znacznie większe niż, wariant"]       # 0xea03
+ - "": [t: "mniejsze niż z pionową kreską i nie podwójne równe"]         # 0xea04
+ - "": [t: "większe niż z pionową kreską i nie podwójne równe"]           # 0xea05
+ - "": [t: "nie mniejsze lub równe"]           # 0xea06
+ - "": [t: "nie większe lub równe"]        # 0xea07
+ - "": [t: "ani równe, ani mniejsze niż"]      # 0xea09
+ - "": [t: "nie zawiera lub równe"]        # 0xea0a
+ - "": [t: "ani nadzbiór, ani równe"]    # 0xea0b
+ - "": [t: "ani podzbiór, ani równe"]      # 0xea0c
+ - "": [t: "ukośnik odwrotny z podzbiorem"]              # 0xea0d
+ - "": [t: "ani równe, ani większe niż"]   # 0xea0e
+ - "": [t: "nie minus operator tyldy"]            # 0xea0f
+ - "": [t: "ani równe, ani mniejsze niż"]      # 0xea10
+ - "": [t: "nie operator tyldy"]                  # 0xea11
+ - "": [t: "nie jest elementem zbioru lub równe"]          # 0xea12
+ - "": [t: "ani równe, ani większe niż"]   # 0xea13
+ - "": [t: "nie w przybliżeniu równe"]                    # 0xea14
+ - "": [t: "nie następuje po podobne"]                # 0xea15
+ - "": [t: "mniejsze niż lub ukośnie równe z ukośnikiem"] # 0xea16
+ - "": [t: "większe niż lub ukośnie równe z ukośnikiem"] # 0xea17
+ - "": [t: "nadzbiór ukośnik"]                    # 0xea1a
+ - "": [t: "nie zawiera"]                    # 0xea1b
+ - "": [t: "nie mniejsze lub równe"]           # 0xea1d
+ - "": [t: "nie większe lub równe"]        # 0xea1e
+ - "": [t: "nie w przybliżeniu równe minus"]           # 0xea1f
+ - "": [t: "zanegowana przynależność do zbioru z kropką nad"]    # 0xea22
+ - "": [t: "nie kąt pionowy"]                      # 0xea2c
+ - "": [t: "nie ukośnie równoległe"]                # 0xea2d
+ - "": [t: "nie kreska operator"]                    # 0xea2e
+ - "": [t: "nie podwójny kreska operator"]             # 0xea2f
+ - "": [t: "nie potrójny kreska operator"]             # 0xea30
+ - "": [t: "mniejsze niż ale nie w przybliżeniu równe"] # 0xea32
+ - "": [t: "większe niż ale nie w przybliżeniu równe"] # 0xea33
+ - "": [t: "mniejsze niż lub nie równa się"]           # 0xea34
+ - "": [t: "większe niż lub nie równa się"]        # 0xea35
+ - "": [t: "nie zagnieżdżone mniejsze niż"]                # 0xea36
+ - "": [t: "nie zagnieżdżone większe niż"]             # 0xea37
+ - "": [t: "nie jest znacznie mniejsze niż"]                  # 0xea38
+ - "": [t: "nie jest znacznie większe niż"]               # 0xea39
+ - "": [t: "poprzedza ale nie Równoważne"]      # 0xea3a
+ - "": [t: "następuje po ale nie Równoważne"]      # 0xea3b
+ - "": [t: "poprzedza ale nie równa się"]           # 0xea3c
+ - "": [t: "następuje po ale nie równa się"]           # 0xea3d
+ - "": [t: "nie równa się ani nie poprzedza"]           # 0xea3e
+ - "": [t: "nie równa się ani nie następuje po"]           # 0xea3f
+ - "": [t: "poprzedza ale nie równa się"]           # 0xea40
+ - "": [t: "następuje po ale nie równa się"]           # 0xea41
+ - "": [t: "ani podzbiór, ani równe"]          # 0xea42
+ - "": [t: "ani nadzbiór, ani równe"]        # 0xea43
+ - "": [t: "podzbiór lub nie równa się"]           # 0xea44
+ - "": [t: "nadzbiór lub nie równa się"]         # 0xea45
+ - "": [t: "ani podzbiór, ani równe"]          # 0xea46
+ - "": [t: "ani nadzbiór, ani równe"]        # 0xea47
+ - "": [t: "nie potrójny mniejsze niż"]                # 0xea48
+ - "": [t: "nie potrójny większe niż"]             # 0xea49
+ - "": [t: "nie poprzedza równa się"]                 # 0xea4c
+ - "": [t: "nie następuje po równa się"]                 # 0xea4d
+ - "": [t: "nie normalna podgrupa z kreską"]      # 0xea50
+ - "": [t: "nie zawiera jako normalnej podgrupy z kreską"] # 0xea51
+ - "": [t: "nie różnica między"]              # 0xea52
+ - "": [t: "nie geometrycznie równoważne"]     # 0xea53
+ - "": [t: "nie pionowo podobne"]                    # 0xea54
+ - "": [t: "nie równe lub podobne"]                # 0xea55
+ - "": [t: "nie pionowo przybliżone"]                # 0xea56
+ - "": [t: "nie w przybliżeniu identyczne z"]      # 0xea57
+ - "": [t: "nie wyboiście równe"]                    # 0xea58
+ - "": [t: "nie wyboiście pojedynczo równe"]             # 0xea59
+ - "": [t: "nie równe kropka"]                       # 0xea5a
+ - "": [t: "odwrotne nie równoważne"]              # 0xea5b
+ - "": [t: "nie kwadrat podzbiór"]                   # 0xea60
+ - "": [t: "nie kwadrat nadzbiór"]                 # 0xea61
+ - "": [t: "nie w przybliżeniu równe nad znakiem równości"]         # 0xea62
+ - "": [t: "nie ściśle równoważne"]          # 0xea63
+ - "": [t: "nie przystające z kropką"]                   # 0xea64
+ - "": [t: "odwrotnie nie równe"]                   # 0xea65
+ - "": [t: "nie pionowy lewy trójkąt równa się"]       # 0xea70
+ - "": [t: "nie pionowy prawy trójkąt równa się"]      # 0xea71
+ - "": [t: "nie cząstkowe"]                         # 0xea80
+ - "": [t: "ozdobnik przedłużenia strzałki"]        # 0xeb00
+ - "": [t: "strzałka prawy przeze strzałką lewy"] # 0xeb01
+ - "": [t: "strzałka prawy przeze strzałką lewy"] # 0xeb02
+ - "": [t: "harpun prawy przez harpun lewy"]     # 0xeb03
+ - "": [t: "harpun prawy przez harpun lewy"]     # 0xeb04
+ - "": [t: "podwójna strzałka północny wschód południowy zachód"]    # 0xeb05
+ - "": [t: "podwójna strzałka północny zachód południowy wschód"]    # 0xeb06
+ - "": [t: "poziome przedłużenie harpuna"]         # 0xeb07
+ - "": [t: "łuk ze strzałką w lewo przeciwnie do ruchu wskazówek zegara"]   # 0xeb08
+ - "": [t: "łuk ze strzałką w prawo przeciwnie do ruchu wskazówek zegara"]  # 0xeb09
+ - "": [t: "duży strzałka w prawo akcent"]       # 0xeb0b
+ - "": [t: "duży strzałka w lewo akcent"]        # 0xeb0c
+ - "": [t: "lewy grot strzałki"]                 # 0xeb0d
+ - "": [t: "prawy grot strzałki"]                # 0xeb0e
+ - "": [t: "duża strzałka w prawo z lewym przekreśleniem"]  # 0xeb0f
+ - "": [t: "poziome przedłużenie podwójnej strzałki"]    # 0xeb10
+ - "": [t: "duża podwójna strzałka w lewo i prawo z przekreśleniem"] # 0xeb11
+ - "": [t: "strzałka w dół po lewej i strzałka w górę"] # 0xeb12
+ - "": [t: "strzałka w lewo z dolnym narożnikiem"] # 0xeb13
+ - "": [t: "strzałka w prawo z górnym narożnikiem"] # 0xeb14
+ - "": [t: "strzałka w lewo z górnym narożnikiem"] # 0xeb15
+ - "": [t: "strzałka po górnym półokręgu przeciwnie do ruchu wskazówek zegara z plusem"] # 0xeb16
+ - "": [t: "strzałka po górnym półokręgu zgodnie z ruchem wskazówek zegara z minusem"] # 0xeb17
+ - "": [t: "strzałka w prawo z ogonem i przekreśleniem"] # 0xeb18
+ - "": [t: "prawy harpun dolny"]                  # 0xeb19
+ - "": [t: "lewy harpun dolny"]                   # 0xeb1a
+ - "": [t: "lewy prawy harpun dolny"]             # 0xeb1b
+ - "": [t: "lewy prawy harpun górny"]               # 0xeb1c
+ - "": [t: "górny dolny harpun lewy"]                # 0xeb1d
+ - "": [t: "górny dolny harpun prawy"]               # 0xeb1e
+ - "": [t: "strzałka w górę w prawo ze strzałką w dół"] # 0xeb1f
+ - "": [t: "lewy harpun do kreski z grotem górnym"] # 0xeb20
+ - "": [t: "prawy harpun do kreski z grotem górnym"] # 0xeb21
+ - "": [t: "lewy harpun do kreski z grotem dolnym"] # 0xeb22
+ - "": [t: "prawy harpun do kreski z grotem dolnym"] # 0xeb23
+ - "": [t: "lewy harpun od kreski z grotem górnym"] # 0xeb24
+ - "": [t: "prawy harpun od kreski z grotem górnym"] # 0xeb25
+ - "": [t: "lewy harpun od kreski z grotem dolnym"] # 0xeb26
+ - "": [t: "prawy harpun od kreski z grotem dolnym"] # 0xeb27
+ - "": [t: "górny harpun do kreski z grotem lewym"] # 0xeb28
+ - "": [t: "dolny harpun do kreski z grotem lewym"] # 0xeb29
+ - "": [t: "górny harpun do kreski z grotem prawym"] # 0xeb2a
+ - "": [t: "dolny harpun do kreski z grotem prawym"] # 0xeb2b
+ - "": [t: "górny harpun od kreski z grotem lewym"] # 0xeb2c
+ - "": [t: "dolny harpun od kreski z grotem lewym"] # 0xeb2d
+ - "": [t: "górny harpun od kreski z grotem prawym"] # 0xeb2e
+ - "": [t: "dolny harpun od kreski z grotem prawym"] # 0xeb2f
+ - "": [t: "strzałka w górę do kreski"]                # 0xeb30
+ - "": [t: "strzałka w dół do kreski"]              # 0xeb31
+ - "": [t: "górny harpun w lewo z dolnym harpunem"] # 0xeb32
+ - "": [t: "górny harpun w prawo z dolnym harpunem"] # 0xeb33
+ - "": [t: "górny grot strzałki"]                   # 0xeb34
+ - "": [t: "dolny grot strzałki"]                 # 0xeb35
+ - "": [t: "podwójny harpun z lewym grotem dolnym i prawym grotem górnym"] # 0xeb36
+ - "": [t: "podwójny harpun z lewym grotem górnym i prawym grotem dolnym"] # 0xeb37
+ - "": [t: "strzałka w lewo przez kreskę"]            # 0xeb38
+ - "": [t: "strzałka w prawo przez kreskę"]           # 0xeb39
+ - "": [t: "strzałka w lewo pod kreski"]           # 0xeb3a
+ - "": [t: "strzałka w prawo pod kreski"]          # 0xeb3b
+ - "": [t: "lewy prawy potrójny strzałka"]             # 0xeb3c
+ - "": [t: "podwójna strzałka północny wschód południowy wschód"]    # 0xeb3f
+ - "": [t: "strzałka po lewym półokręgu przeciwnie do ruchu wskazówek zegara"] # 0xeb40
+ - "": [t: "strzałka po lewym półokręgu zgodnie z ruchem wskazówek zegara"]     # 0xeb41
+ - "": [t: "lewy otwarty okrąg lewy strzałka w prawo"]   # 0xeb42
+ - "": [t: "strzałka w prawo przez tylda"]         # 0xeb44
+ - "": [t: "strzałka w lewo przez tylda"]          # 0xeb45
+ - "": [t: "lewy harpun przez kreskę"]          # 0xeb48
+ - "": [t: "prawy harpun przez kreskę"]         # 0xeb49
+ - "": [t: "lewy harpun pod kreski"]         # 0xeb4a
+ - "": [t: "prawy harpun pod kreski"]        # 0xeb4b
+ - "": [t: "krótka czarna strzałka w lewo"]         # 0xeb4c
+ - "": [t: "strzałka po prawym półokręgu zgodnie z ruchem wskazówek zegara"]    # 0xeb50
+ - "": [t: "strzałka po prawym półokręgu przeciwnie do ruchu wskazówek zegara"] # 0xeb51
+ - "": [t: "lewy otwarty okrąg lewy prawy harpun"] # 0xeb52
+ - "": [t: "strzałka w górę lewy z pionową kreską"] # 0xeb58
+ - "": [t: "strzałka w dół lewy z pionową kreską"] # 0xeb59
+ - "": [t: "strzałka w górę prawy z pionową kreską"] # 0xeb5a
+ - "": [t: "strzałka w dół prawy z pionową kreską"] # 0xeb5b
+ - "": [t: "strzałka w prawo z wydłużonym dolnym hakiem"] # 0xeb5c
+ - "": [t: "strzałka w lewo z wydłużonym hakiem"]  # 0xeb5d
+ - "": [t: "strzałka w lewo z wydłużonym dolnym hakiem"] # 0xeb5e
+ - "": [t: "strzałka w prawo z wydłużonym hakiem"] # 0xeb5f
+ - "": [t: "nie strzałka w prawo falista"]                # 0xeb60
+ - "": [t: "nie strzałka w prawo zakrzywiony"]              # 0xeb61
+ - "": [t: "górny harpun lewy z pionową kreską"] # 0xeb68
+ - "": [t: "dolny harpun lewy z pionową kreską"] # 0xeb69
+ - "": [t: "górny harpun prawy z pionową kreską"] # 0xeb6a
+ - "": [t: "dolny harpun prawy z pionową kreską"] # 0xeb6b
+ - "": [t: "pionowe przedłużenie podwójnej strzałki"]      # 0xeb6c
+ - "": [t: "pionowe przedłużenie harpuna z grotem w lewo"] # 0xeb6d
+ - "": [t: "pionowe przedłużenie harpuna z grotem w prawo"] # 0xeb6e
+ - "": [t: "prawy harpun przez lewy harpun prawy"] # 0xeb6f
+ - "": [t: "prawy harpun przez lewy harpun lewy"] # 0xeb70
+ - "": [t: "lewy harpun przez prawy harpun prawy"] # 0xeb71
+ - "": [t: "lewy harpun przez prawy harpun lewy"] # 0xeb72
+ - "": [t: "strzałka w lewo od kreski z grotem strzałki"]  # 0xeb73
+ - "": [t: "przedłużenie strzałki w prawo od lewej kreski"] # 0xeb74
+ - "": [t: "strzałka w lewo od kreski ogon"]       # 0xeb75
+ - "": [t: "strzałka w prawo od kreski ogon"]      # 0xeb76
+ - "": [t: "strzałka w prawo od kreski z grotem strzałki"] # 0xeb77
+ - "": [t: "górny harpun od kreski z lewym grotem strzałki"] # 0xeb78
+ - "": [t: "strzałka w prawo nad strzałką w lewo prawy"] # 0xeb79
+ - "": [t: "strzałka w prawo nad strzałką w lewo lewy"] # 0xeb7a
+ - "": [t: "strzałka w lewo nad strzałką w prawo prawy"] # 0xeb7b
+ - "": [t: "strzałka w lewo nad strzałką w prawo lewy"] # 0xeb7c
+ - "": [t: "strzałka w górę od kreski z grotem strzałki"]    # 0xeb7d
+ - "": [t: "strzałka w górę od kreski ogon"]         # 0xeb7e
+ - "": [t: "strzałka w dół od kreski ogon"]       # 0xeb7f
+ - "": [t: "strzałka w dół od kreski z grotem strzałki"]  # 0xeb80
+ - "": [t: "dolny harpun od kreski z prawym grotem strzałki"] # 0xeb81
+ - "": [t: "górny harpun w lewo z dolnym harpunem dolny"] # 0xeb82
+ - "": [t: "przedłużenie górnego harpuna w lewo i dolnego harpuna"] # 0xeb83
+ - "": [t: "dolny harpun w lewo z górnym harpunem górny"] # 0xeb84
+ - "": [t: "górny harpun w lewo z dolnym harpunem górny"] # 0xeb85
+ - "": [t: "przedłużenie dolnego harpuna w lewo i górnego harpuna"] # 0xeb86
+ - "": [t: "dolny harpun w lewo z górnym harpunem dolny"] # 0xeb87
+ - "": [t: "strzałka w górę po lewej i strzałka w dół dolny"] # 0xeb88
+ - "": [t: "strzałka w dół po lewej i strzałka w górę górny"] # 0xeb89
+ - "": [t: "strzałka w górę po lewej i strzałka w dół górny"] # 0xeb8a
+ - "": [t: "strzałka w dół po lewej i strzałka w górę dolny"] # 0xeb8b
+ - "": [t: "przedłużenie strzałki w lewo i w prawo"] # 0xeb8c
+ - "": [t: "przedłużenie strzałki północno-wschodniej"]           # 0xeb8d
+ - "": [t: "przedłużenie strzałki północno-zachodniej"]           # 0xeb8e
+ - "": [t: "lewa część dolnego nawiasu klamrowego"]            # 0xec00
+ - "": [t: "środkowa część dolnego nawiasu klamrowego"]             # 0xec01
+ - "": [t: "prawa część dolnego nawiasu klamrowego"]           # 0xec02
+ - "": [t: "poziome przedłużenie nawiasu klamrowego"]           # 0xec03
+ - "": [t: "lewa część górnego nawiasu klamrowego"]              # 0xec04
+ - "": [t: "środkowa część górnego nawiasu klamrowego"]               # 0xec05
+ - "": [t: "prawa część górnego nawiasu klamrowego"]             # 0xec06
+ - "": [t: "lewa pionowa kreska"]                   # 0xec07
+ - "": [t: "prawa pionowa kreska"]                  # 0xec08
+ - "": [t: "lewa podwójna pionowa kreska"]            # 0xec09
+ - "": [t: "prawa podwójna pionowa kreska"]           # 0xec0a
+ - "": [t: "poziome przedłużenie nawiasu kwadratowego"]         # 0xec0b
+ - "": [t: "dolny nawias kwadratowy"]                # 0xec0c
+ - "⎵": [t: "dolny nawias kwadratowy"]                # 0x23b5
+ - "": [t: "górny nawias kwadratowy"]                 # 0xec0d
+ - "⎴": [t: "górny nawias kwadratowy"]                 # 0x23b4
+ - "": [t: "pod nawias kwadratowy lewy"]                  # 0xec0e
+ - "": [t: "pod nawias kwadratowy prawy"]                 # 0xec0f
+ - "": [t: "przez nawias kwadratowy lewy"]                   # 0xec10
+ - "": [t: "przez nawias kwadratowy prawy"]                  # 0xec11
+ - "": [t: "lewy nawias okrągły 1"]                       # 0xec12
+ - "": [t: "lewy nawias okrągły 2"]                       # 0xec13
+ - "": [t: "lewy nawias okrągły 3"]                       # 0xec14
+ - "": [t: "lewy nawias okrągły 4"]                       # 0xec15
+ - "": [t: "prawy nawias okrągły 1"]                      # 0xec16
+ - "": [t: "prawy nawias okrągły 2"]                      # 0xec17
+ - "": [t: "prawy nawias okrągły 3"]                      # 0xec18
+ - "": [t: "prawy nawias okrągły 4"]                      # 0xec19
+ - "": [t: "znak pierwiastka 1"]                           # 0xec1a
+ - "": [t: "znak pierwiastka 2"]                           # 0xec1b
+ - "": [t: "znak pierwiastka 3"]                           # 0xec1c
+ - "": [t: "znak pierwiastka 4"]                           # 0xec1d
+ - "": [t: "znak pierwiastka 5"]                           # 0xec1e
+ - "": [t: "dolna część znaku pierwiastka"]                      # 0xec1f
+ - "": [t: "pionowe przedłużenie znaku pierwiastka"]           # 0xec20
+ - "": [t: "górna część znaku pierwiastka"]                         # 0xec21
+ - "": [t: "lewy biały nawias kwadratowy górny"]              # 0xec22
+ - "": [t: "przedłużenie lewego białego nawiasu kwadratowego"]         # 0xec23
+ - "": [t: "lewy biały nawias kwadratowy dolny"]           # 0xec24
+ - "": [t: "prawy biały nawias kwadratowy górny"]             # 0xec25
+ - "": [t: "przedłużenie prawego białego nawiasu kwadratowego"]        # 0xec26
+ - "": [t: "prawy biały nawias kwadratowy dolny"]          # 0xec27
+ - "": [t: "lewy biały zakrzywiony nawias kwadratowy"]            # 0xec30
+ - "": [t: "prawy biały zakrzywiony nawias kwadratowy"]           # 0xec31
+ - "": [t: "znak dzielenia pisemnego"]                  # 0xec32
+ - "": [t: "przedłużenie znaku dzielenia pisemnego"]         # 0xec33
+ - "": [t: "krótkie dzielenie"]                      # 0xec34
+ - "": [t: "podwójne wiązanie em od południowego zachodu do północnego wschodu"] # 0xec40
+ - "": [t: "podwójne wiązanie em od północnego zachodu do południowego wschodu"] # 0xec41
+ - "": [t: "pojedyncze poziome wiązanie em"]           # 0xec42
+ - "": [t: "podwójne poziome wiązanie em"]           # 0xec43
+ - "": [t: "potrójne poziome wiązanie em"]           # 0xec44
+ - "": [t: "pojedyncze pionowe wiązanie em"]             # 0xec45
+ - "": [t: "podwójne pionowe wiązanie em"]             # 0xec46
+ - "": [t: "potrójne pionowe wiązanie em"]             # 0xec47
+ - "": [t: "wiązanie em mniejsze niż"]                   # 0xec48
+ - "": [t: "wiązanie em większe niż"]                # 0xec49
+ - "": [t: "pojedyncze poziome wiązanie en"]           # 0xec4a
+ - "": [t: "podwójne poziome wiązanie en"]           # 0xec4b
+ - "": [t: "potrójne poziome wiązanie en"]           # 0xec4c
+ - "": [t: "górny lewy prostokąt"]                  # 0xec80
+ - "": [t: "dolny lewy prostokąt"]               # 0xec81
+ - "": [t: "górny prawy prostokąt"]                 # 0xec90
+ - "": [t: "dolny prawy prostokąt"]              # 0xec91
+ - "": [t: "narożnik dzielenia syntetycznego"]           # 0xec92
+ - "": [t: "poziome przedłużenie dzielenia syntetycznego"] # 0xec93
+ - "": [t: "pionowe przedłużenie dzielenia syntetycznego"] # 0xec94
+ - "": [t: "lewy przedłużacz sufitu i podłogi"]         # 0xec95
+ - "": [t: "prawy przedłużacz sufitu i podłogi"]        # 0xec96
+ - "": [t: "przedłużenie przez nawias kwadratowy"]               # 0xec97
+ - "": [t: "pionowe przedłużenie kreski"]               # 0xec98
+ - "": [t: "lewy podwójny pionowe przedłużenie kreski"]   # 0xec99
+ - "": [t: "poziome przedłużenie kreski"]             # 0xec9a
+ - "": [t: "przedłużenie pod nawiasem kwadratowym"]              # 0xec9c
+ - "": [t: "prawa część dolnego nawiasu"]           # 0xec9d
+ - "": [t: "przedłużenie dolnego nawiasu"]        # 0xec9e
+ - "": [t: "lewa część dolnego nawiasu"]            # 0xec9f
+ - "": [t: "przedłużenie górnego nawiasu klamrowego"]          # 0xeca0
+ - "": [t: "lewa część górnego nawiasu"]              # 0xeca1
+ - "": [t: "przedłużenie górnego nawiasu"]          # 0xeca2
+ - "": [t: "prawa część górnego nawiasu"]             # 0xeca3
+ - "": [t: "przedłużenie dolnego nawiasu klamrowego"]        # 0xeca4
+ - "": [t: "stała Plancka przez dwa pi kreska"]     # 0xed00
+ - "": [t: "lustrzane g"]                            # 0xed01
+ - "": [t: "j bez kropki"]                           # 0xed02
+ - "": [t: "digamma"]                             # 0xed03
+ - "ϝ": [t: "digamma"]                             # 0x3dd
+ - "": [t: "d"]                                   # 0xed10
+ - "ⅆ": [t: "d"]                                   # 0x2146
+ - "": [t: "e"]                                   # 0xed11
+ - "ⅇ": [t: "e"]                                   # 0x2147
+ - "": [t: "i"]                                   # 0xed12
+ - "ⅈ": [t: "i"]                                   # 0x2148
+ - "": [t: "j"]                                   # 0xed13
+ - "ⅅ":
+    - spell: "translate('.', 'ⅅ', 'DD')"                                         # 0xed16, 0x2145
+
+# The private use chars are from MathType
+ - "": [t: "całka krzywoliniowa z pętlą przeciwnie do ruchu wskazówek zegara"] # 0xee00
+ - "": [t: "całka krzywoliniowa z pętlą zgodnie z ruchem wskazówek zegara"]     # 0xee01
+ - "": [t: ""]                                  # 0xee04
+ - "": [t: ""]                                  # 0xee05
+ - "": [t: ""]                                  # 0xee06
+ - "": [t: ""]                                  # 0xee07
+ - "": [t: ""]                                  # 0xee08
+ - "": [t: ""]                                  # 0xee09
+ - "": [t: ""]                                  # 0xee0a
+ - "": [t: ""]                                  # 0xee0b
+ - "": [t: ""]                                  # 0xee0c
+ - "": [t: "ozdobnik statusu połączenia"]          # 0xee0d
+ - "": [t: "lewy ozdobnik statusu połączenia"]     # 0xee0e
+ - "": [t: "prawy ozdobnik statusu połączenia"]    # 0xee0f
+ - "": [t: "przedłużenie ozdobnika statusu połączenia"] # 0xee10
+ - "": [t: "całka z pętlą"]                       # 0xee11
+ - "": [t: "podwójna całka z pętlą"]                # 0xee12
+ - "": [t: "potrójna całka z pętlą"]                # 0xee13
+ - "": [t: "rozszerzająca się podwójna całka z pętlą"]      # 0xee15
+ - "": [t: "rozszerzająca się potrójna całka z pętlą"]      # 0xee16
+ - "": [T: "akcent asymptotycznie równy"]      # 0xee17
+ - "": [t: "akcent znaku równości"]                   # 0xee18
+ - "": [t: "poczwórny prim"]                     # 0xee19
+ - "": [t: "kreska akcent z otwartym okręgiem po lewej"]    # 0xee1a
+ - "": [t: "kreska akcent z zamkniętym okręgiem po lewej"]  # 0xee1b
+ - "": [t: "kreska akcent z otwartym okręgiem po prawej"]   # 0xee1c
+ - "": [t: "kreska akcent z przekreśloną kropką"]            # 0xee1d
+ - "": [t: "kreska akcent z kropką pod spodem"]           # 0xee1e
+ - "": [t: "kreska akcent z podwójnie przekreśloną kropką"]     # 0xee1f
+ - "": [t: "kreska akcent z podwójną kropką pod spodem"]    # 0xee20
+ - "": [t: "kreska akcent z daszkiem"]               # 0xee21
+ - "": [t: "gruby akcent kreski dolnej"]              # 0xee22
+ - "": [t: "kreska akcent z zamkniętym okręgiem po prawej"] # 0xee23
+ - "": [t: "duży kropka nad"]                     # 0xee24
+ - "": [t: "znak wyrównania"]                      # 0xef00
+ - "": [t: ""]                                  # 0xef01
+ - "​": [t: ""]                                  # 0x200b
+ - "": [t: ""]                                  # 0xef02
+ - " ": [t: ""]                                  # 0x2009
+ - "": [t: ""]                                  # 0xef03
+ - " ": [t: ""]                                  # 0x205f
+ - "": [t: ""]                                  # 0xef04
+ - "": [t: ""]                                  # 0xef05
+ - "": [t: ""]                                  # 0xef06
+ - "": [t: ""]                                  # 0xef07
+ - "": [t: ""]                                  # 0xef08
+ - "": [t: ""]                                  # 0xef09
+ - "": [t: ""]                                  # 0xef0a
+ - " ": [t: ""]                                  # 0x200a
+ - "": [t: ""]                                  # 0xef22
+ - "": [t: ""]                                  # 0xef23
+ - "": [t: ""]                                  # 0xef24
+ - "": [t: ""]                                  # 0xef29
+ - "": [t: "brakujący składnik"]                        # 0xef41
+ - "": [t: "całka krzywoliniowa zgodna z ruchem wskazówek zegara ze strzałką po lewej"] # 0xef80
+ - "": [t: "całka z kwadrat"]                # 0xef81
+ - "": [t: "całka z ukośnikiem"]                 # 0xef82
+ - "": [t: "odwrócony całka"]                   # 0xef83
+ - "": [t: "podwójny zero przez podwójny zero"]        # 0xef90
+ - "": [t: "zero z ukośnikiem"]                     # 0xef91
+
+ # fraktur chars in math alphabetic block and also MathType private use area
+ # Some of these are reserved because they were used in Plane 0 -- that shouldn't be an issue other than causing the other chars to not display
+ - "𝔄-𝔜":    # 0x1d504 - 0x1d51d ('z' version is reserved)
+    - t: "fraktura"
+    - spell: "translate('.', '𝔄𝔅𝔆𝔇𝔈𝔉𝔊𝔋𝔌𝔍𝔎𝔏𝔐𝔑𝔒𝔓𝔔𝔕𝔖𝔗𝔘𝔙𝔚𝔛𝔜', 'ABCDEFGHIJKLMNOPQRSTUVWXY')"
+
+ - "-":                                          # 0xf000 - 0xf018
+    - t: "fraktura"
+    - spell: "translate('.', '', 'ABCDEFGHIJKLMNOPQRSTUVWXY')"
+
+ - "𝔞-𝔷":    # 0x1d51e - 0x1d537
+    - t: "fraktura"
+    - spell: "translate('.', '𝔞𝔟𝔠𝔡𝔢𝔣𝔤𝔥𝔦𝔧𝔨𝔩𝔪𝔫𝔬𝔭𝔮𝔯𝔰𝔱𝔲𝔳𝔴𝔵𝔶𝔷', 'abcdefghijklmnopqrstuvwxyz')"
+ - "-":    # 0xf01a - 0xf033
+    - t: "fraktura"
+    - spell: "translate('.', '', 'abcdefghijklmnopqrstuvwxyz')"
+    
+ - "𝕬-𝖅":    # 0x1D56C - 0x1D585
+    - t: "fraktura"
+    - t: "pogrubione"
+    - spell: "translate('.', '𝕬𝕭𝕮𝕯𝕰𝕱𝕲𝕳𝕴𝕵𝕶𝕷𝕸𝕹𝕺𝕻𝕼𝕽𝕾𝕿𝖀𝖁𝖂𝖃𝖄𝖅', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ')"
+
+ - "-":                                          # 0xf040 - 0xf059
+    - t: "fraktura"
+    - t: "pogrubione"
+    - spell: "translate('.', '', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ')"
+
+ - "𝖆-𝖟":    # 0x1d586 - 0x1d59f
+    - t: "fraktura"
+    - t: "pogrubione"
+    - spell: "translate('.', '𝖆𝖇𝖈𝖉𝖊𝖋𝖌𝖍𝖎𝖏𝖐𝖑𝖒𝖓𝖔𝖕𝖖𝖗𝖘𝖙𝖚𝖛𝖜𝖝𝖞𝖟', 'abcdefghijklmnopqrstuvwxyz')"
+ - "-":    # 0xf05a - 0xf073
+    - t: "fraktura"
+    - t: "pogrubione"
+    - spell: "translate('.', '', 'abcdefghijklmnopqrstuvwxyz')"
+
+ # double struck (blackboard bold) chars in math alphabetic block and also MathType private use area
+ # Some of these are reserved because they were used in Plane 0 -- that shouldn't be an issue other than causing the other chars to not display
+ - "𝔸-𝕐":    # 0x1d504 - 0x1d51d ('z' version is reserved)
+    - t: "dwukreskowe"
+    - spell: "translate('.', '𝔸𝔹𝔺𝔻𝔼𝔽𝔾𝔿𝕀𝕁𝕂𝕃𝕄𝕅𝕆𝕇𝕈𝕉𝕊𝕋𝕌𝕍𝕎𝕏𝕐', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ')"
+
+ - "-":                                          # 0xf080 - 0xf098
+    - t: "dwukreskowe"
+    - spell: "translate('.', '', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ')"
+
+ - "𝕒-𝕫":    # 0x1d552 - 0x1d56b
+    - t: "dwukreskowe"
+    - spell: "translate('.', '𝕒𝕓𝕔𝕕𝕖𝕗𝕘𝕙𝕚𝕛𝕜𝕝𝕞𝕟𝕠𝕡𝕢𝕣𝕤𝕥𝕦𝕧𝕨𝕩𝕪𝕫', 'abcdefghijklmnopqrstuvwxyz')"
+ - "-":    # 0xf09a - 0xf0b3
+    - t: "dwukreskowe"
+    - spell: "translate('.', '', 'abcdefghijklmnopqrstuvwxyz')"
+ - "𝟘-𝟡":    # 0x1d7d8 - 0x1d7e1
+    - t: "dwukreskowe"
+    - spell: "translate('.', '𝟘𝟙𝟚𝟛𝟜𝟝𝟞𝟟𝟠𝟡', '0123456789')"
+ - "-":    # 0xf0c0 - 0xf0c9
+    - t: "dwukreskowe"
+    - spell: "translate('.', '', '0123456789')"
+
+ - "": [t: "dwukreskowe nabla"]                 # 0xf0ca
+ - "": [t: "dwukreskowa stała Eulera"]        # 0xf0cb
+ 
+ # script chars in math alphabetic block and also MathType private use area
+ - "𝒜-𝒵":    # 0x1d49c - 0x1d4b5
+    - t: "pisane"
+    - spell: "translate('.', '𝒜𝒝𝒞𝒟𝒠𝒡𝒢𝒣𝒤𝒥𝒦𝒧𝒨𝒩𝒪𝒫𝒬𝒭𝒮𝒯𝒰𝒱𝒲𝒳𝒴𝒵', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ')"
+
+ - "-":                                          # 0xf100 - 0xf119
+    - t: "pisane"
+    - spell: "translate('.', '', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ')"
+
+ - "𝒶-𝓏":    # 0x1d4b6 - 0x1d4cf
+    - t: "pisane"
+    - spell: "translate('.', '𝒶𝒷𝒸𝒹𝒺𝒻𝒼𝒽𝒾𝒿𝓀𝓁𝓂𝓃𝓄𝓅𝓆𝓇𝓈𝓉𝓊𝓋𝓌𝓍𝓎𝓏', 'abcdefghijklmnopqrstuvwxyz')"
+ - "-":    # 0xf11a - 0xf133
+    - t: "pisane"
+    - spell: "translate('.', '', 'abcdefghijklmnopqrstuvwxyz')"
+
+ # bold script chars in math alphabetic block and also MathType private use area
+ - "𝓐-𝓩":    # 0x1d4d0 - 0x1d4e9
+    - t: "pisane"
+    - t: "pogrubione"
+    - spell: "translate('.', '𝓐𝓑𝓒𝓓𝓔𝓕𝓖𝓗𝓘𝓙𝓚𝓛𝓜𝓝𝓞𝓟𝓠𝓡𝓢𝓣𝓤𝓥𝓦𝓧𝓨𝓩', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ')"
+
+ - "-":                                          # 0xf140 - 0xf159
+    - t: "pisane"
+    - t: "pogrubione"
+    - spell: "translate('.', '', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ')"
+
+ - "𝓪-𝔃":    # 0x1d4ea - 0x1d503
+    - t: "pisane"
+    - t: "pogrubione"
+    - spell: "translate('.', '𝓪𝓫𝓬𝓭𝓮𝓯𝓰𝓱𝓲𝓳𝓴𝓵𝓶𝓷𝓸𝓹𝓺𝓻𝓼𝓽𝓾𝓿𝔀𝔁𝔂𝔃', 'abcdefghijklmnopqrstuvwxyz')"
+ - "-":    # 0xf15a - 0xf173
+    - t: "pisane"
+    - t: "pogrubione"
+    - spell: "translate('.', '', 'abcdefghijklmnopqrstuvwxyz')"
+
+ - "-":                                          # 0xf180 - 0xf199
+    - spell: "translate('.', '', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ')" 
+
+ - "":                                          # 0xf19a
+    - test: 
+        if: "$CapitalLetters_Beep"
+        then:
+        - audio:
+            value: "beep.mp4"
+            replace: []
+    - test: 
+        if: "$CapitalLetters_UseWord"
+        then_test:
+          if: "$SpeechOverrides_CapitalLetters = ''"
+          then_test:
+            if: "$Impairment = 'Blindness'"
+            then: [t: "wielka"]
+          else: [x: "$SpeechOverrides_CapitalLetters"] 
+    - pitch:
+        value: "$CapitalLetters_Pitch"
+        replace: [t: "ligatura ae"]
+ - "":                                          # 0xf19b
+    - test: 
+        if: "$CapitalLetters_Beep"
+        then:
+        - audio:
+            value: "beep.mp4"
+            replace: []
+    - test: 
+        if: "$CapitalLetters_UseWord"
+        then_test:
+          if: "$SpeechOverrides_CapitalLetters = ''"
+          then_test:
+            if: "$Impairment = 'Blindness'"
+            then: [t: "wielka"]
+          else: [x: "$SpeechOverrides_CapitalLetters"] 
+    - pitch:
+        value: "$CapitalLetters_Pitch"
+        replace: [t: "eszett"]
+ - "":                                          # 0xf19c
+    - test: 
+        if: "$CapitalLetters_Beep"
+        then:
+        - audio:
+            value: "beep.mp4"
+            replace: []
+    - test: 
+        if: "$CapitalLetters_UseWord"
+        then_test:
+          if: "$SpeechOverrides_CapitalLetters = ''"
+          then_test:
+            if: "$Impairment = 'Blindness'"
+            then: [t: "wielka"]
+          else: [x: "$SpeechOverrides_CapitalLetters"] 
+    - pitch:
+        value: "$CapitalLetters_Pitch"
+        replace: [t: "o z kreską"]
+
+ # MathType only has a few of the cap Greek letters in PUA
+ - "":                                          # 0xf201 - 0xf209
+    - t: "dwukreskowe"
+    - spell: "translate('.', '', 'ΔΨΛΠΣΘΓΩΥ')"
+
+ - "-":    # 0xf220 - 0xf236
+    - t: "dwukreskowe"
+    - spell: "translate('.', '', 'ΑΒΓΔΕΖΗΘΙΚΛΜΝΞΟΠΡ΢ΣΤΥΦΧΨΩ')"
+
+ - "": [t: "dwukreskowe sigma końcowa"]           # 0xf237
+ - "": [t: "dwukreskowe ro"]                   # 0xf250
+ - "": [t: "dwukreskowe fi"]                   # 0xf251
+ - "𝐀-𝐙":    # 0x1d400 - 0x1d419
+    - t: "pogrubione"
+    - spell: "translate('.', '𝐀𝐁𝐂𝐃𝐄𝐅𝐆𝐇𝐈𝐉𝐊𝐋𝐌𝐍𝐎𝐏𝐐𝐑𝐒𝐓𝐔𝐕𝐖𝐗𝐘𝐙', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ')"
+
+ - "-":    # 0xf260 - 0xf279
+    - t: "pogrubione"
+    - spell: "translate('.', '', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ')"
+
+ - "𝐚-𝐳":    # 0x1d41a - 0x1d433
+    - t: "pogrubione"
+    - spell: "translate('.', '𝐚𝐛𝐜𝐝𝐞𝐟𝐠𝐡𝐢𝐣𝐤𝐥𝐦𝐧𝐨𝐩𝐪𝐫𝐬𝐭𝐮𝐯𝐰𝐱𝐲𝐳', 'abcdefghijklmnopqrstuvwxyz')"
+
+ - "-":    # 0xf27a - 0xf293
+    - t: "pogrubione"
+    - spell: "translate('.', '', 'abcdefghijklmnopqrstuvwxyz')"
+
+ - "𝐴-𝑍":    # 0x1d434 - 0x1d44d
+    - spell: "translate('.', '𝐴𝐵𝐶𝐷𝐸𝐹𝐺𝐻𝐼𝐽𝐾𝐿𝑀𝑁𝑂𝑃𝑄𝑅𝑆𝑇𝑈𝑉𝑊𝑋𝑌𝑍', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ')"
+
+ - "-":    # 0xf294 - 0xf2ad
+    - spell: "translate('.', '', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ')"
+
+ - "𝑎-𝑧":    # 0x1d44e - 0x1d467
+    - spell: "translate('.', '𝑎𝑏𝑐𝑑𝑒𝑓𝑔𝑕𝑖𝑗𝑘𝑙𝑚𝑛𝑜𝑝𝑞𝑟𝑠𝑡𝑢𝑣𝑤𝑥𝑦𝑧', 'abcdefghijklmnopqrstuvwxyz')"
+
+ - "-":    # 0xf2ae - 0xf2c7
+    - spell: "translate('.', '', 'abcdefghijklmnopqrstuvwxyz')"
+
+ - "𝑨-𝒁":    # 0x1d468 - 0x1d481
+    # - t: "pogrubiona kursywa"
+    - t: "pogrubione"
+    - spell: "translate('.', '𝑨𝑩𝑪𝑫𝑬𝑭𝑮𝑯𝑰𝑱𝑲𝑳𝑴𝑵𝑶𝑷𝑸𝑹𝑺𝑻𝑼𝑽𝑾𝑿𝒀𝒁', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ')"
+
+ - "-":    # 0xf2c8 - 0xf2e1
+    # - t: "pogrubiona kursywa"
+    - t: "pogrubione"
+    - spell: "translate('.', '', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ')"
+
+ - "𝒂-𝒛":    # 0x1d482 - 0x1d49b
+    # - t: "pogrubiona kursywa"
+    - t: "pogrubione"
+    - spell: "translate('.', '𝒂𝒃𝒄𝒅𝒆𝒇𝒈𝒉𝒊𝒋𝒌𝒍𝒎𝒏𝒐𝒑𝒒𝒓𝒔𝒕𝒖𝒗𝒘𝒙𝒚𝒛', 'abcdefghijklmnopqrstuvwxyz')"
+
+ - "-":    # 0xf2e2 - 0xf2fb
+    # - t: "pogrubiona kursywa"
+    - t: "pogrubione"
+    - spell: "translate('.', '', 'abcdefghijklmnopqrstuvwxyz')"
+
+ - "𝖠-𝖹":    # 0x1d5a0 - 0x1d5b9
+    - spell: "translate('.', '𝖠𝖡𝖢𝖣𝖤𝖥𝖦𝖧𝖨𝖩𝖪𝖫𝖬𝖭𝖮𝖯𝖰𝖱𝖲𝖳𝖴𝖵𝖶𝖷𝖸𝖹', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ')"
+
+ - "-":    # 0xf300 - 0xf319
+    - spell: "translate('.', '', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ')"
+
+ - "𝖺-𝗓":    # 0x1d5ba - 0x1d5d3
+    - spell: "translate('.', '𝖺𝖻𝖼𝖽𝖾𝖿𝗀𝗁𝗂𝗃𝗄𝗅𝗆𝗇𝗈𝗉𝗊𝗋𝗌𝗍𝗎𝗏𝗐𝗑𝗒𝗓', 'abcdefghijklmnopqrstuvwxyz')"
+
+ - "-":    # 0xf31a - 0xf333
+    - spell: "translate('.', '', 'abcdefghijklmnopqrstuvwxyz')"
+ 
+ - "𝗔-𝗭":    # 0x1d5d4 - 0x1d5ed
+    - t: "pogrubione"
+    - spell: "translate('.', '𝗔𝗕𝗖𝗗𝗘𝗙𝗚𝗛𝗜𝗝𝗞𝗟𝗠𝗡𝗢𝗣𝗤𝗥𝗦𝗧𝗨𝗩𝗪𝗫𝗬𝗭', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ')"
+
+ - "-":    # 0xf334 - 0xf34d
+    - t: "pogrubione"
+    - spell: "translate('.', '', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ')"
+
+ - "𝗮-𝘇":    # 0x1d5ee - 0x1d607
+    - t: "pogrubione"
+    - spell: "translate('.', '𝗮𝗯𝗰𝗱𝗲𝗳𝗴𝗵𝗶𝗷𝗸𝗹𝗺𝗻𝗼𝗽𝗾𝗿𝘀𝘁𝘂𝘃𝘄𝘅𝘆𝘇', 'abcdefghijklmnopqrstuvwxyz')"
+
+ - "-":    # 0xf34e - 0xf367
+    - t: "pogrubione"
+    - spell: "translate('.', '', 'abcdefghijklmnopqrstuvwxyz')"
+ - "𝘈-𝘡":    # 0x1d608 - 0x1d621
+    # - t: "kursywa"
+    - spell: "translate('.', '𝘈𝘉𝘊𝘋𝘌𝘍𝘎𝘏𝘐𝘑𝘒𝘓𝘔𝘕𝘖𝘗𝘘𝘙𝘚𝘛𝘜𝘝𝘞𝘟𝘠𝘡', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ')"
+ - "-":    # 0xf368 - 0xf381
+      # - t: "kursywa"
+    - spell: "translate('.', '', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ')"
+
+ - "𝘢-𝘻":    # 0x1d622 - 0x1d63b
+      # - t: "kursywa"
+    - spell: "translate('.', '𝘢𝘣𝘤𝘥𝘦𝘧𝘨𝘩𝘪𝘫𝘬𝘭𝘮𝘯𝘰𝘱𝘲𝘳𝘴𝘵𝘶𝘷𝘸𝘹𝘺𝘻', 'abcdefghijklmnopqrstuvwxyz')"
+
+ - "-":    # 0xf382 - 0xf39b
+      # - t: "kursywa"
+    - spell: "translate('.', '', 'abcdefghijklmnopqrstuvwxyz')"
+
+ - "𝘼-𝙕":    # 0x1d63c - 0x1d655
+    # - t: "pogrubiona kursywa"
+    - t: "pogrubione"
+    - spell: "translate('.', '𝘼𝘽𝘾𝘿𝙀𝙁𝙂𝙃𝙄𝙅𝙆𝙇𝙈𝙉𝙊𝙋𝙌𝙍𝙎𝙏𝙐𝙑𝙒𝙓𝙔𝙕', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ')"
+
+ - "-":    # 0xf39c - 0xf3b5
+    # - t: "pogrubiona kursywa"
+    - t: "pogrubione"
+    - spell: "translate('.', '', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ')"
+
+ - "𝙖-𝙯":    # 0x1d656 - 0x1d66f
+    # - t: "pogrubiona kursywa"
+    - t: "pogrubione"
+    - spell: "translate('.', '𝙖𝙗𝙘𝙙𝙚𝙛𝙜𝙝𝙞𝙟𝙠𝙡𝙢𝙣𝙤𝙥𝙦𝙧𝙨𝙩𝙪𝙫𝙬𝙭𝙮𝙯', 'abcdefghijklmnopqrstuvwxyz')"
+
+ - "-":    # 0xf3b6 - 0xf3cf
+    # - t: "pogrubiona kursywa"
+    - t: "pogrubione"
+    - spell: "translate('.', '', 'abcdefghijklmnopqrstuvwxyz')"
+
+ - "𝙰-𝚉":    # 0x1d670 - 0x1d689
+    - spell: "translate('.', '𝙰𝙱𝙲𝙳𝙴𝙵𝙶𝙷𝙸𝙹𝙺𝙻𝙼𝙽𝙾𝙿𝚀𝚁𝚂𝚃𝚄𝚅𝚆𝚇𝚈𝚉', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ')"
+
+ - "-":    # 0xf3d0 - 0xf3e9
+    - spell: "translate('.', '', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ')"
+
+ - "𝚊-𝚣":    # 0x1d68a - 0x1d6a3
+    - spell: "translate('.', '𝚊𝚋𝚌𝚍𝚎𝚏𝚐𝚑𝚒𝚓𝚔𝚕𝚖𝚗𝚘𝚙𝚚𝚛𝚜𝚝𝚞𝚟𝚠𝚡𝚢𝚣', 'abcdefghijklmnopqrstuvwxyz')"
+
+ - "-":    # 0xf3ea - 0xf403
+    - spell: "translate('.', '', 'abcdefghijklmnopqrstuvwxyz')"
+
+ - "": [t: "bez kropki I"]                           # 0xf404
+ - "𝚤": [t: "bez kropki I"]                           # 0x1d6a4
+ - "𝚥": [t: "j bez kropki"]                           # 0x1d6a5
+
+ - "𝚨-𝛀":    # 0x1d6a8 - 0x1d6c0
+    - t: "pogrubione"
+    - spell: "translate('.', '𝚨𝚩𝚪𝚫𝚬𝚭𝚮𝚯𝚰𝚱𝚲𝚳𝚴𝚵𝚶𝚷𝚸𝚹𝚺𝚻𝚼𝚽𝚾𝚿𝛀', 'ΑΒΓΔΕΖΗΘΙΚΛΜΝΞΟΠΡ΢ΣΤΥΦΧΨΩ')"
+
+ - "-":    # 0xf408 - 0xf420
+    - t: "pogrubione"
+    - spell: "translate('.', '', 'ΑΒΓΔΕΖΗΘΙΚΛΜΝΞΟΠΡ΢ΣΤΥΦΧΨΩ')"
+
+ - "𝛂-𝛚":    # 0x1d6c2 - 0x1d6da
+    - t: "pogrubione"
+    - spell: "translate('.', '𝛂𝛃𝛄𝛅𝛆𝛇𝛈𝛉𝛊𝛋𝛌𝛍𝛎𝛏𝛐𝛑𝛒𝛓𝛔𝛕𝛖𝛗𝛘𝛙𝛚', 'αβγδεζηθικλμνξοπρςστυφχψω')"
+
+ - "-":    # 0xf422 - 0xf43a
+    - t: "pogrubione"
+    - spell: "translate('.', '', 'αβγδεζηθικλμνξοπρςστυφχψω')"
+
+ - "": [t: "pogrubiona nabla"]                          # 0xf421
+ - "𝛁": [t: "pogrubiona nabla"]                          # 0x1d6c1
+
+ - "𝛛𝛜𝛝𝛞𝛟𝛠𝛡":    # 0x1D6DB - 0x1D6E1
+    - t: "pogrubione"
+    - spell: "translate('.', '𝛛𝛜𝛝𝛞𝛟𝛠𝛡', '∂εθκφρπ')"
+
+ - "":    # 0xF43C - 0xF441
+    - t: "pogrubione"
+    - spell: "translate('.', '', '∂εθκφρπ')"
+
+ - "𝛢-𝛺":    # 0x1d6e2 - 0x1d6fa
+      # - t: "kursywa"
+    - spell: "translate('.', '𝛢𝛣𝛤𝛥𝛦𝛧𝛨𝛩𝛪𝛫𝛬𝛭𝛮𝛯𝛰𝛱𝛲𝛳𝛴𝛵𝛶𝛷𝛸𝛹𝛺', 'ΑΒΓΔΕΖΗΘΙΚΛΜΝΞΟΠΡ΢ΣΤΥΦΧΨΩ')"
+
+ - "-":    # 0xf442 - 0xf45a
+      # - t: "kursywa"
+    - spell: "translate('.', '', 'ΑΒΓΔΕΖΗΘΙΚΛΜΝΞΟΠΡ΢ΣΤΥΦΧΨΩ')"
+
+ - "𝛼-𝜔":    # 0x1d6fc - 0x1d714
+      # - t: "kursywa"
+    - spell: "translate('.', '𝛼𝛽𝛾𝛿𝜀𝜁𝜂𝜃𝜄𝜅𝜆𝜇𝜈𝜉𝜊𝜋𝜌𝜍𝜎𝜏𝜐𝜑𝜒𝜓𝜔', 'αβγδεζηθικλμνξοπρςστυφχψω')"
+
+ - "-":    # 0xf45c - 0xf474
+      # - t: "kursywa"
+    - spell: "translate('.', '', 'αβγδεζηθικλμνξοπρςστυφχψω')"
+
+ - "": [t: "kursywa nabla"]                          # 0xf45b
+ - "𝛻": [t: "kursywa nabla"]                          # 0x1d6fb
+
+ - "𝜕𝜖𝜗𝜘𝜙𝜚𝜛":    # 0x1d715 - 0x1d71b
+      # - t: "kursywa"
+    - spell: "translate('.', '𝜕𝜖𝜗𝜘𝜙𝜚𝜛', '∂εθκφρπ')"
+
+ - "":    # 0xf475  - 0xf47b
+      # - t: "kursywa"
+    - spell: "translate('.', '', '∂εθκφρπ')"
+
+ - "𝜜-𝜴":    # 0x1d71c - 0x1d734
+    # - t: "pogrubiona kursywa"
+    - t: "pogrubione"
+    - spell: "translate('.', '𝜜𝜝𝜞𝜟𝜠𝜡𝜢𝜣𝜤𝜥𝜦𝜧𝜨𝜩𝜪𝜫𝜬𝜭𝜮𝜯𝜰𝜱𝜲𝜳𝜴', 'ΑΒΓΔΕΖΗΘΙΚΛΜΝΞΟΠΡ΢ΣΤΥΦΧΨΩ')"
+
+ - "-":    # 0xf47c - 0xf494
+    # - t: "pogrubiona kursywa"
+    - t: "pogrubione"
+    - spell: "translate('.', '', 'ΑΒΓΔΕΖΗΘΙΚΛΜΝΞΟΠΡ΢ΣΤΥΦΧΨΩ')"
+
+ - "𝜶-𝝎":    # 0x1d736 - 0x1d74e
+    # - t: "pogrubiona kursywa"
+    - t: "pogrubione"
+    - spell: "translate('.', '𝜶𝜷𝜸𝜹𝜺𝜻𝜼𝜽𝜾𝜿𝝀𝝁𝝂𝝃𝝄𝝅𝝆𝝇𝝈𝝉𝝊𝝋𝝌𝝍𝝎', 'αβγδεζηθικλμνξοπρςστυφχψω')"
+
+ - "-":    # 0xf496 - 0xf4ae
+    # - t: "pogrubiona kursywa"
+    - t: "pogrubione"
+    - spell: "translate('.', '', 'αβγδεζηθικλμνξοπρςστυφχψω')"
+
+ - "𝝏𝝐𝝑𝝒𝝓𝝔𝝕":    # 0x1d74f - 0x1d755
+    # - t: "pogrubiona kursywa"
+    - t: "pogrubione"
+    - spell: "translate('.', '𝝏𝝐𝝑𝝒𝝓𝝔𝝕', '∂εθκφρπ')"
+
+ - "":    # 0xf422 - 0xf43a
+    # - t: "pogrubiona kursywa"
+    - t: "pogrubione"
+    - spell: "translate('.', '', '∂εθκφρπ')"
+
+ - "𝜵": [t: "pogrubiona pochylona nabla"]                  # 0x1d735
+ - "": [t: "pogrubiona pochylona nabla"]                  # 0xf495
+
+ - "𝝖-𝝮":    # 0x1d756 - 0x1d76e
+    - t: "pogrubione"
+    - spell: "translate('.', '𝝖𝝗𝝘𝝙𝝚𝝛𝝜𝝝𝝞𝝟𝝠𝝡𝝢𝝣𝝤𝝥𝝦𝝧𝝨𝝩𝝪𝝫𝝬𝝭𝝮', 'ΑΒΓΔΕΖΗΘΙΚΛΜΝΞΟΠΡ΢ΣΤΥΦΧΨΩ')"
+ - "-":    # 0xf4b6 - 0xf4ce
+    - t: "pogrubione"
+    - spell: "translate('.', '', 'ΑΒΓΔΕΖΗΘΙΚΛΜΝΞΟΠΡ΢ΣΤΥΦΧΨΩ')"
+
+ - "𝝰-𝞈":    # 0x1d770 - 0x1d788
+    - t: "pogrubione"
+    - spell: "translate('.', '𝝰𝝱𝝲𝝳𝝴𝝵𝝶𝝷𝝸𝝹𝝺𝝻𝝼𝝽𝝾𝝿𝞀𝞁𝞂𝞃𝞄𝞅𝞆𝞇𝞈', 'αβγδεζηθικλμνξοπρςστυφχψω')"
+
+ - "-":    # 0xf4d0 - 0xf4e8
+    - t: "pogrubione"
+    - spell: "translate('.', '', 'αβγδεζηθικλμνξοπρςστυφχψω')"
+
+ - "𝞉𝞊𝞋𝞌𝞍𝞎𝞏":    # 0x1d789 - 0x1d78f
+    - t: "pogrubione"
+    - spell: "translate('.', '𝞉𝞊𝞋𝞌𝞍𝞎𝞏', '∂εθκφρπ')"
+
+ - "":    # 0xf4e9 - 0xf4ef
+    - t: "pogrubione"
+    - spell: "translate('.', '', '∂εθκφρπ')"
+
+ - "": [t: "pogrubiona nabla"]                          # 0xf4cf
+ - "𝝯": [t: "pogrubiona nabla"]                          # 0x1d76f
+
+ - "𝞐-𝞨":    # 0x1d790 - 0x1d7a8
+    # - t: "pogrubiona kursywa"
+    - t: "pogrubione"
+    - spell: "translate('.', '𝞐𝞑𝞒𝞓𝞔𝞕𝞖𝞗𝞘𝞙𝞚𝞛𝞜𝞝𝞞𝞟𝞠𝞡𝞢𝞣𝞤𝞥𝞦𝞧𝞨', 'ΑΒΓΔΕΖΗΘΙΚΛΜΝΞΟΠΡ΢ΣΤΥΦΧΨΩ')"
+
+ - "-":    # 0xf4f0 - 0xf508
+    # - t: "pogrubiona kursywa"
+    - t: "pogrubione"
+    - spell: "translate('.', '', 'ΑΒΓΔΕΖΗΘΙΚΛΜΝΞΟΠΡ΢ΣΤΥΦΧΨΩ')"
+
+ - "𝞪-𝟂":    # 0x1d7aa - 0x1d7c2
+    # - t: "pogrubiona kursywa"
+    - t: "pogrubione"
+    - spell: "translate('.', '𝞪𝞫𝞬𝞭𝞮𝞯𝞰𝞱𝞲𝞳𝞴𝞵𝞶𝞷𝞸𝞹𝞺𝞻𝞼𝞽𝞾𝞿𝟀𝟁𝟂', 'αβγδεζηθικλμνξοπρςστυφχψω')"
+
+ - "-":    # 0xf50a - 0xf522
+    # - t: "pogrubiona kursywa"
+    - t: "pogrubione"
+    - spell: "translate('.', '', 'αβγδεζηθικλμνξοπρςστυφχψω')"
+
+ - "𝟃𝟄𝟅𝟆𝟇𝟈𝟉":    # 0x1d7c3 - 0x1d7c9
+    # - t: "pogrubiona kursywa"
+    - t: "pogrubione"
+    - spell: "translate('.', '𝟃𝟄𝟅𝟆𝟇𝟈𝟉', '∂εθκφρπ')"
+
+ - "":    # 0xf523 - 0xf529
+    # - t: "pogrubiona kursywa"
+    - t: "pogrubione"
+    - spell: "translate('.', '', '∂εθκφρπ')"
+
+ - "": [t: "pogrubiona nabla"]                          # 0xf509
+ - "𝞩": [t: "pogrubiona nabla"]                          # 0x1d7a9
+
+ - "-":    # 0xf52e - 0xf537  (old MathType)
+    - t: "pogrubione"
+    - spell: "translate('.', '', '0123456789')"
+
+ - "𝟎-𝟗":    # 0x1d7ce - 0x1d7d7  
+    - t: "pogrubione"
+    - spell: "translate('.', '𝟎𝟏𝟐𝟑𝟒𝟓𝟔𝟕𝟖𝟗', '0123456789')"
+
+ - "-":    # 0xf52e - 0xf537  (old MathType)
+    - t: "pogrubione"
+    - spell: "translate('.', '', '0123456789')"
+
+ - "𝟬-𝟵":    # 0x1D7EC - 0x1D7F5  
+    - t: "pogrubione"
+    - spell: "translate('.', '𝟬𝟭𝟮𝟯𝟰𝟱𝟲𝟳𝟴𝟵', '0123456789')"
+
+ - "-":    # 0xf556 - 0xf55f  (old MathType)
+    - spell: "translate('.', '', '0123456789')"
+
+ - "𝟢-𝟫":    # 0x1d7e2 - 0x1d7eb  
+    - spell: "translate('.', '𝟢𝟣𝟤𝟥𝟦𝟧𝟨𝟩𝟪𝟫', '0123456789')"
+
+
+ - "𝟶-𝟿":    # 0x1d7f6 - 0x1d7ff  
+    - spell: "translate('.', '𝟶𝟷𝟸𝟹𝟺𝟻𝟼𝟽𝟾𝟿', '0123456789')"
+
+
+ - "": [t: "nieznany znak"]                   # 0xf700
+ - "": [t: "dolny prawy i dolny lewy trójkąt"] # 0xf726
+ - "": [t: "poziome przedłużenie wielokropka"]        # 0xf72d
+ - "": [t: "poziome przedłużenie wielokropka w linii środkowej"] # 0xf72e
+ - "": [t: "przedłużenie znaku pierwiastka"]                    # 0xf8e5
+ - "": [t: "pionowy strzałka przedłużenie"]             # 0xf8e6
+ - "": [t: "poziomy strzałka przedłużenie"]           # 0xf8e7
+ - "": [t: "bezszeryfowy znak zastrzeżony"]          # 0xf8e8
+ - "": [t: "znak praw autorskich znak bezszeryfowe"]           # 0xf8e9
+ - "": [t: "bezszeryfowy znak towarowy"]          # 0xf8ea
+ - "": [t: "lewy nawias górny"]                      # 0xf8eb
+ - "": [t: "lewy nawias przedłużenie"]                 # 0xf8ec
+ - "": [t: "lewy nawias dolny"]                   # 0xf8ed
+ - "": [t: "lewy nawias kwadratowy górny"]                    # 0xf8ee
+ - "": [t: "lewy nawias kwadratowy przedłużenie"]               # 0xf8ef
+ - "": [t: "lewy nawias kwadratowy dolny"]                 # 0xf8f0
+ - "": [t: "lewy nawias klamrowy górny"]                      # 0xf8f1
+ - "": [t: "lewy nawias klamrowy środkowy"]                      # 0xf8f2
+ - "": [t: "lewy nawias klamrowy dolny"]                   # 0xf8f3
+ - "": [t: "nawias klamrowy przedłużenie"]                      # 0xf8f4
+ - "": [t: "całka przedłużenie"]                   # 0xf8f5
+ - "": [t: "prawy nawias górny"]                     # 0xf8f6
+ - "": [t: "prawy nawias przedłużenie"]                # 0xf8f7
+ - "": [t: "prawy nawias dolny"]                  # 0xf8f8
+ - "": [t: "prawy nawias kwadratowy górny"]                   # 0xf8f9
+ - "": [t: "prawy nawias kwadratowy przedłużenie"]              # 0xf8fa
+ - "": [t: "prawy nawias kwadratowy dolny"]                # 0xf8fb
+ - "": [t: "prawy nawias klamrowy górny"]                     # 0xf8fc
+ - "": [t: "prawy nawias klamrowy środkowy"]                     # 0xf8fd
+ - "": [t: "prawy nawias klamrowy dolny"]                  # 0xf8fe
+ - "": [t: "logo jabłka"]                          # 0xf8ff
+ - "ﬀ": [t: "ff"]                                  # 0xfb00
+ - "ﬁ": [t: "fi"]                                  # 0xfb01
+ - "ﬂ": [t: "fl"]                                  # 0xfb02
+ - "ﬃ": [t: "ffi"]                                 # 0xfb03
+ - "ﬄ": [t: "ffl"]                                 # 0xfb04
+ - "ﬅ": [t: "ft"]                                  # 0xfb05
+ - "ﬆ": [t: "st"]                                  # 0xfb06
+ - "﬩": [t: "hebrajska litera alternatywny znak plus"]      # 0xfb29
+ - "︠": [t: "lewa połowa ligatury, ozdobnik"]     # 0xfe20
+ - "︡": [t: "prawa połowa ligatury, ozdobnik"]    # 0xfe21
+ - "︢": [t: "podwójny tylda lewa połowa ozdobnik"] # 0xfe22
+ - "︣": [t: "podwójny tylda prawa połowa ozdobnik"] # 0xfe23
+ - "︤": [t: "makron lewa połowa ozdobnik"]      # 0xfe24
+ - "︥": [t: "makron prawa połowa ozdobnik"]     # 0xfe25
+ - "︦": [t: "łączący ozdobnik makronu"]     # 0xfe26
+ - "︵": [t: "przez nawias"]                          # 0xfe35
+ - "︶": [t: "pod nawias"]                         # 0xfe36
+ - "︷": [t: "przez nawias klamrowy"]                          # 0xfe37
+ - "︸": [t: "pod nawias klamrowy"]                         # 0xfe38
+ - "︿": [t: "przez kąt nawias kwadratowy"]                  # 0xfe3f
+ - "﹀": [t: "pod kąt nawias kwadratowy"]                 # 0xfe40
+ - "﹡": [t: "mały gwiazdka"]                      # 0xfe61
+ - "﹢": [t: "mały plus"]                          # 0xfe62
+ - "﹣": [t: "mały minus"]                         # 0xfe63
+ - "﹤": [t: "mały mniejsze niż"]                     # 0xfe64
+ - "﹥": [t: "mały większe niż"]                  # 0xfe65
+ - "﹦": [t: "mały równa się"]                        # 0xfe66
+ - "＋": [t: "pełnoszeroki znak plus"]                 # 0xff0b
+ - "＜": [T: "mniejsze niż"]                           # 0xff1c
+ - "＝": [T: "równa się"]                              # 0xff1d
+ - "＞": [T: "większe niż"]                        # 0xff1e
+ - "＼": [t: "ukośnik odwrotny"]                           # 0xff3c
+ - "＾": [T: "daszek"]                                 # 0xff3e
+ - "｜":                                            # 0xff5c
+    # note: for ClearSpeak and SimpleSpeak, "|" inside of sets is handled at the mrow level, same for 'sets'
+     - with:
+        variables: [DefaultToGiven: "count(preceding-sibling::*)=1 and count(following-sibling::*)=1 and ../../../*[1][.='P']"] # P(A|B)
+        replace:
+        - test:
+            - if: "$SpeechStyle != 'ClearSpeak'"
+              then_test:
+                  if: "$DefaultToGiven"
+                  then: [T: "pod warunkiem"]
+                  else: [T: "kreska pionowa"]
+            - else_if: "not(preceding-sibling::*) or not(following-sibling::*)"
+              then: [T: "kreska pionowa"]
+            - else_if: "$ClearSpeak_VerticalLine = 'SuchThat'"
+              then: [T: "takich że"]
+            - else_if: "$ClearSpeak_VerticalLine = 'Given' or $DefaultToGiven"
+              then: [T: "pod warunkiem"] 
+            - else: [T: "dzieli"]                   
+ - "～": [T: "tylda"]                               # 0xff5e
+ - "￢": [T: "nie"]                                 # 0xffe2
+ - "￩": [t: "strzałka w lewo"]                           # 0xffe9
+ - "￪": [t: "strzałka w górę"]                             # 0xffea
+ - "￫": [t: "strzałka w prawo"]                          # 0xffeb
+ - "￬": [t: "strzałka w dół"]                           # 0xffec
+ - "￼": [t: "nieznany lub brakujący obiekt"]            # 0xfffc
+ - "�": [t: "nieznany lub brakujący znak"]        # 0xfffd
+
+ - "🣑": [t: "jest w równowadze z"]                      # 0x1F8D1
+ - "🣒": [t: "jest w równowadze przesuniętej w prawo z"]  # 0x1F8D2
+ - "🣓": [t: "jest w równowadze przesuniętej w lewo z"]   # 0x1F8D3
+
+# MathJax v4 has adopted these PUA values for some partial chem bonds that aren't in Unicode
+ - "\uE410": [t: "wiązanie cząstkowe"]                          # 0xe410 
+ - "\uE411": [t: "podwójne wiązanie cząstkowe"]                          # 0xe411 
+ - "\uE412": [t: "potrójne wiązanie cząstkowe"]                          # 0xe412 
+
+# MathJax v4 also adopted these PUA values for some arrows thar are in Unicode
+# Hopefully these will be exported properly in future versions of MathJax
+ - "\uE428": [spell: "'⟵'"]                      # 0xe428  defer to def of arrow
+ - "\uE429": [spell: "'⟶'"]                      # 0xe429  defer to def of arrow 
+ - "\uE42A": [spell: "'⟷'"]                      # 0xe42a  defer to def of arrow 
+ - "\uE408": [spell: "'🣑'"]                       # 0xe408  defer to def of arrow 
+ - "\uE409": [spell: "'🣒'"]                       # 0xe409  defer to def of arrow 
+ - "\uE40A": [spell: "'🣓'"]                       # 0xe40a  defer to def of arrow 
+ - "\uE42B": [spell: "'⇄'"]                       # 0xe42b  defer to def of arrow 
+ - "\uE42C": [spell: "'←'"]                       # 0xe42c  defer to def of arrow 
+ - "\uE42D": [spell: "'→'"]                       # 0xe42d  defer to def of arrow 
+ - "\uE42E": [spell: "'⇄'"]                       # 0xe42e  defer to def of arrow 

--- a/Rules/Languages/pl/unicode.yaml
+++ b/Rules/Languages/pl/unicode.yaml
@@ -1,0 +1,585 @@
+---
+ # Note to translators:
+ #   most languages don't have two ways to pronounce 'a' -- if not need, remove the rules and change "B-z" to "A-z"
+ #   some languages say the word for "uppercase" after the letter. Make sure to change that where appropriate by moving some code around
+ - "a": 
+    - test: 
+        if: "$TTS='none'"
+        then: [t: "a"]                         # long "a" sound in all speech engines I tested (espeak, MS SAPI, eloquence,
+        else: [spell: "'a'"]                         #    AWS Polly, ReadSpeaker, NaturalReader, google cloud, nuance, ibm watson)
+ - "b-z": 
+    - test: 
+        if: "$TTS='none'"
+        then: [t: "."]                          
+        else: [spell: "'.'"]                       
+
+ # Capital letters are a little tricky: users can pick their favorite word (something that was requested) and 
+ # screen readers have options to use pitch changes or beeps instead of or in addition to say "cap"
+ # Also, if a user can see the screen, they probably don't need to hear "cap", but if they specified an override, they must want to hear the override.
+
+ - "A":
+    - test: 
+        if: "$CapitalLetters_Beep"
+        then:
+        - audio:
+            value: "beep.mp4"
+            replace: []
+    - test: 
+        if: "$CapitalLetters_UseWord"
+        then_test:
+          if: "$SpeechOverrides_CapitalLetters = ''"
+          then_test:
+            if: "$Impairment = 'Blindness'"
+            then: [t: "wielka"]
+          else: [x: "$SpeechOverrides_CapitalLetters"]
+    - pitch:
+        value: "$CapitalLetters_Pitch"
+        replace:
+        - test:
+            if: "$TTS='none'"
+            then: [t: "a"]
+            else: [spell: "'a'"]
+            
+ - "B-Z":
+    - test: 
+        if: "$CapitalLetters_Beep"
+        then:
+        - audio:
+            value: "beep.mp4"
+            replace: []
+    - test: 
+        if: "$CapitalLetters_UseWord"
+        then_test:
+          if: "$SpeechOverrides_CapitalLetters = ''"
+          then_test:
+            if: "$Impairment = 'Blindness'"
+            then: [t: "wielka"]
+          else: [x: "$SpeechOverrides_CapitalLetters"] 
+    - pitch:
+        value: "$CapitalLetters_Pitch"
+        # note: processing of ranges converts '.' into the character, so it needs to be in quotes below
+        replace: [spell: "translate('.', 'BCDEFGHIJKLMNOPQRSTUVWXYZ', 'bcdefghijklmnopqrstuvwxyz')"]
+
+ - "0-9": [t: "."]
+
+ - " ": [t: " "]                     # 0x20
+
+ - "!":                                            # 0x21
+    - test:
+        if: "ancestor-or-self::*[contains(@data-intent-property, ':literal:')]"
+        then_test:
+            if: "$Verbosity = 'Terse'"
+            then: [T: "wykrzyknik"]                      # 0x21
+            else: [T: "wykrzyknik"]          # 0x21
+        else: [T: "silnia"]                     # 0x21
+          
+ - "\"": [t: "cudzysłów"]                     # 0x22
+ - "#": [t: "numer"]                              # 0x23
+ - "$": [t: "dolary"]                             # 0x24
+ - "%": [T: "procent"]                             # 0x25
+ - "&": [t: "znak et"]                           # 0x26
+ - "'": [t: "apostrof"]                          # 0x27
+ - "(":                                            # 0x28
+    - test:
+        if: $SpeechStyle = 'ClearSpeak' or $SpeechStyle = 'SimpleSpeak'
+        then_test:
+            if: "$Verbosity='Terse'"
+            then: [T: "otwórz"]                     # 0x28
+            else: [T: "nawias otwierający"]               # 0x28
+        else: [T: "lewy nawias"]                   # 0x28                         
+ - ")":                                          # 0x29
+    - test:
+        if: $SpeechStyle = 'ClearSpeak' or $SpeechStyle = 'SimpleSpeak'
+        then_test:
+            if: "$Verbosity='Terse'"
+            then: [T: "zamknij"]                   # 0x29
+            else: [T: "nawias zamykający"]             # 0x29
+        else: [T: "prawy nawias"]                 # 0x29                 
+
+ - "*":                                          # 0x2a
+    test:
+        if:
+          - "parent::*[name(.)='subscripted-norm'] or "
+          - "parent::*[(name(.)='indexed-by' or name(.)='msub') and *[1][self::m:mo and .='∥']] or "
+          - "parent::*[name(.)='msubsup' and *[1][self::m:mo and .='∥']] and count(preceding-sibling::*)=1"
+        then: [T: "gwiazdkowa"]                  # 0x2a (norma 'gwiazdkowa' - * jako indeks normy)
+        else_test:
+            if: "parent::*[name(.)='msup' or name(.)='msubsup' or name(.)='skip-super']"
+            then: [t: "gwiazda"]                 # 0x2a
+            else: [T: "razy"]                    # 0x2a
+ - "+": [T: "plus"]                              # 0x2b
+ - ",":                                          # 0x2c
+    # the following deals with the interaction of "," with "…" which sometimes wants the ',' to be silent
+    # that this test is here and not with "…" is not ideal, but seems simplest
+     test:
+        if:
+            - "$SpeechStyle != 'ClearSpeak' or $ClearSpeak_Ellipses = 'Auto' or "
+               # must be ClearSpeak and $ClearSpeak_Ellipses = 'AndSoOn'
+               # speak "comma" when not adjacent to '…'
+            - "( following-sibling::*[1][text()!= '…'] and preceding-sibling::*[1][text()!='…']  ) or "
+               # except if expression starts with '…'
+            - "../*[1][.='…'] "
+        then:
+        - T: "przecinek"                         # 	(en: 'comma', google translation)
+        - test:
+            if: "$Verbosity != Terse"
+            then: [pause: short]
+        # else silent
+
+ - "-": [T: "minus"]                               # 0x2d
+ - ".":                                          # 0x2e
+    - test:
+        if: "parent::*[1][self::m:mn]"
+        then: [T: "przecinek"]
+        else: [T: "kropka"]
+ - "/":                                           # 0x2f
+    - test:
+        if: "ancestor-or-self::*[contains(@data-intent-property, ':literal:')]"
+        then: [T: "ukośnik"]                        # 0x2f
+        else: [T: "podzielone przez"]                   # 0x2f
+
+ - ":": [T: "dwukropek"]                               # 0x3a
+ - ";": [T: "średnik"]                           # 0x3b
+ - "<":                                          # 0x3c
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [T: "jest"]
+     - T: "mniejsze niż"
+ - "=":                                           # 0x3d
+    - test: 
+        if: "$Verbosity!='Terse'"
+        then: [T: "równa się"]
+        else: [T: "równa się"]
+
+ - ">":                                          # 0x3e
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [T: "jest"]
+     - T: "większe niż"
+ - "?": [T: "znak zapytania"]                       # 0x3f
+ - "@": [t: "małpa"]                             # 0x40
+ - "[":                                          # 0x5b
+    - test:
+        if: $SpeechStyle = 'ClearSpeak' or $SpeechStyle = 'SimpleSpeak'
+        then: [T: "nawias kwadratowy otwierający"]
+        else: [T: "lewy nawias kwadratowy"]                            
+ - "\\": [T: "ukośnik odwrotny"]                         # 0x5c
+ - "]":                                          # 0x5d
+    - test:
+        if: $SpeechStyle = 'ClearSpeak' or $SpeechStyle = 'SimpleSpeak'
+        then: [T: "nawias kwadratowy zamykający"]
+        else: [T: "prawy nawias kwadratowy"]
+ - "^":                                           # 0x5e
+    - test:
+        if: "parent::m:modified-variable or parent::m:mover"
+        then: [T: "daszek"]
+        else: [t: "daszek"]
+ - "_": [t: "pod kreska"]                          # 0x5f
+ - "`": [t: "grawis"]                              # 0x60
+ - "{":                                         # 0x7b
+    - test:
+        if: $SpeechStyle = 'ClearSpeak' or $SpeechStyle = 'SimpleSpeak'
+        then: [T: "nawias klamrowy otwierający"]
+        else: [T: "lewy nawias klamrowy"]                            
+ - "|":                                          # 0x7c
+    # note: for ClearSpeak and SimpleSpeak, "|" inside of sets is handled at the mrow level, same for 'sets'
+     - with:
+        variables: [DefaultToGiven: "count(preceding-sibling::*)=1 and count(following-sibling::*)=1 and ../../../*[1][.='P']"] # P(A|B)
+        replace:
+        - test:
+            - if: "ancestor-or-self::*[contains(@data-intent-property, ':literal:')]"
+              then: [T: "kreska pionowa"]
+            - else_if: "$SpeechStyle != 'ClearSpeak'"
+              then_test:
+                - if: "$DefaultToGiven"
+                  then: [T: "pod warunkiem"]
+                - else_if: "preceding-sibling::*[1][self::m:mn and not(contains(., $DecimalSeparators))] and 
+                            following-sibling::*[1][self::m:mn and not(contains(., $DecimalSeparators))]"
+                  then: [T: "dzieli"]
+                  else: [T: "kreska pionowa"]
+            - else_if: "not(preceding-sibling::*) or not(following-sibling::*)"
+              then: [T: "kreska pionowa"]
+            - else_if: "$ClearSpeak_VerticalLine = 'SuchThat'"
+              then: [T: "takich że"]
+            - else_if: "$ClearSpeak_VerticalLine = 'Given' or $DefaultToGiven"
+              then: [T: "pod warunkiem"] 
+            - else: [T: "dzieli"]                   
+
+ - "}":                                          # 0x7d
+    - test:
+        if: $SpeechStyle = 'ClearSpeak' or $SpeechStyle = 'SimpleSpeak'
+        then: [T: "nawias klamrowy zamykający"]
+        else: [T: "prawy nawias klamrowy"]                            
+
+ - "~": [T: "tylda"]                               # 0x7e
+ - " ":                                            # 0xa0
+    - test:
+        # could be mtext in mtd or mtext in an mrow that is a concatenation of mtd's. Is there a better solution?
+        if: "@data-empty-in-2D and not(ancestor::*[self::m:piecewise or self::m:system-of-equations or self::m:lines])"
+        then: [T: "pusty"]                         # want to say something for fraction (etc) with empty child
+        else: [t: ""]                            
+
+ - "¬": [T: "nie"]                                 # 0xac
+ - "°":                                          # 0xb0
+    - test:
+        if: "parent::*[name(.)='msup' or name(.)='msubsup' or name(.)='skip-super' or name(.)='say-super']"
+        then: [T: "stopni"]
+        else: [T: "stopień"]
+ - "±": [T: "plus minus"]                       # 0xb1
+ - "´": [t: "akut"]                            # 0xb4
+ - "·":                                            # 0xB7
+    - test:
+        if: "ancestor-or-self::*[contains(@data-intent-property, ':literal:')] or not($SpeechStyle = 'ClearSpeak' and $ClearSpeak_MultSymbolDot = 'Auto')"
+        then: [T: "kropka"]
+        else: [T: "razy"]
+ - "×":                                          # 0xd7
+    - test:
+        if: "$SpeechStyle = 'ClearSpeak'"
+        then_test:
+        - if: "$ClearSpeak_MultSymbolX = 'Auto'"
+          then: [T: "razy"]
+        - else_if: "$ClearSpeak_MultSymbolX = 'By'"
+          then: [T: "na"]
+          else: [t: "krzyż"]
+        else_test:
+            if: "ancestor-or-self::*[contains(@data-intent-property, ':literal:')]"
+            then: [t: "krzyż"]
+            else: [T: "razy"]
+
+ - "÷": [T: "podzielone przez"]                          # 0xf7
+ - "̀": [t: "ozdobnik akcentu grawis"]          # 0x300
+ - "́": [t: "ozdobnik akcentu ostrego"]          # 0x301
+ - "̂": [t: "ozdobnik daszka"]     # 0x302
+ - "̃": [t: "ozdobnik tyldy"]                 # 0x303
+ - "̄": [t: "ozdobnik makronu"]                # 0x304
+ - "̅": [t: "ozdobnik kreski górnej"]               # 0x305
+ - "̆": [t: "znak krótkości"]                     # 0x306
+ - "̇": [t: "ozdobnik kropki nad"]             # 0x307
+
+   # Note: ClearSpeak has pref TriangleSymbol for "Δ", but that is wrong
+ - "Α-Ω": 
+    - test: 
+        if: "$CapitalLetters_Beep"
+        then:
+        - audio:
+            value: "beep.mp4"
+            replace: []
+    - test: 
+        if: "$CapitalLetters_UseWord"
+        then_test:
+          if: "$SpeechOverrides_CapitalLetters = ''"
+          then_test:
+            if: "$Impairment = 'Blindness'"
+            then: [t: "wielka"]
+          else: [x: "$SpeechOverrides_CapitalLetters"] 
+    - pitch:
+        value: "$CapitalLetters_Pitch"
+        # note: processing of ranges converts '.' into the character, so it needs to be in quotes below
+        replace: [spell: "translate('.', 'ΑΒΓΔΕΖΗΘΙΚΛΜΝΞΟΠΡ΢ΣΤΥΦΧΨΩ', 'αβγδεζηθικλμνξοπρςστυφχψω')"]
+
+ - "α": [t: "alfa"]                               # 0x3b1
+ - "β": [t: "beta"]                                # 0x3b2
+ - "γ": [t: "gamma"]                               # 0x3b3
+ - "δ": [t: "delta"]                               # 0x3b4
+ - "ε": [t: "epsilon"]                             # 0x3b5
+ - "ζ": [t: "dzeta"]                                # 0x3b6
+ - "η": [t: "eta"]                                 # 0x3b7
+ - "θ": [t: "theta"]                               # 0x3b8
+ - "ι": [t: "jota"]                                # 0x3b9
+ - "κ": [t: "kappa"]                               # 0x3ba
+ - "λ": [t: "lambda"]                               # 0x3bb
+ - "μ": [t: "mi"]                                  # 0x3bc
+ - "ν": [t: "ni"]                                  # 0x3bd
+ - "ξ": [t: "ksi"]                                 # 0x3be
+ - "ο": [t: "omikron"]                             # 0x3bf
+ - "π": [t: "pi"]                                  # 0x3c0
+ - "ρ": [t: "ro"]                                 # 0x3c1
+ - "ς": [t: "sigma końcowa"]                         # 0x3c2
+ - "σ": [t: "sigma"]                               # 0x3c3
+ - "τ": [t: "tau"]                                 # 0x3c4
+ - "υ": [t: "ypsilon"]                             # 0x3c5
+ - "φ": [t: "fi"]                                 # 0x3c6
+ - "χ": [t: "chi"]                                 # 0x3c7
+ - "ψ": [t: "psi"]                                 # 0x3c8
+ - "ω": [t: "omega"]                               # 0x3c9
+ - "ϕ": [t: "fi"]                                 # 0x3d5
+ - "ϖ": [t: "pi"]                                  # 0x3d6
+ - "ϵ": [t: "epsilon"]                             # 0x3f5
+ - "϶": [t: "odwrócony epsilon"]                    # 0x3f6
+
+ - "–": [t: "półpauza"]                             # 0x2013
+ - "—": [t: "pauza"]                             # 0x2014
+ - "―": [t: "kreska pozioma"]                      # 0x2015
+ - "‖": [t: "podwójna pionowa kreska"]                # 0x2016
+ - "…":                                          # 0x2026
+    test:
+        if:
+            - "$SpeechStyle != 'ClearSpeak' or $ClearSpeak_Ellipses = 'Auto' or"
+               # must be ClearSpeak and $ClearSpeak_Ellipses = 'AndSoOn'
+               # speak '…' as 'and so on...' unless expr starts with '…'
+            - "../*[1][.='…']"
+        then: [t: "trzy kropki"]
+        else_test:  # must have $ClearSpeak_Ellipses = 'AndSoOn'
+            if: "count(following-sibling::*) = 0"
+            then: [t: "i tak dalej"]
+            else: [t: "i tak dalej aż do"]
+
+ - "⁡":                                          # 0x2061
+    - test:
+        # skip saying "of" when Terse and a trig function, when it is a shape (does this happen?), or we are in :literal mode
+        if: "not(
+              ( $Verbosity='Terse' or ($SpeechStyle = 'ClearSpeak' and IsNode(following-sibling::*[1],'simple')) and
+                preceding-sibling::*[1][IfThenElse($SpeechStyle='ClearSpeak',
+                                                   IsInDefinition(., 'ClearSpeakTrigFunctionNames'),
+                                                   IsInDefinition(., 'TrigFunctionNames') )]
+              ) or
+              preceding-sibling::*[1][IsInDefinition(., 'GeometryShapes')] or
+              (@data-changed='added' and ancestor-or-self::*[contains(@data-intent-property, ':literal:')])
+            )"
+        then: [T: "z"]
+ - "⁢": [t: ""]                                   # 0x2062
+ - "⁣": [t: ""]                                   # 0x2063
+ - "⁤": [T: "i"]                                # 0x2064
+ - "′": [t: "prim"]                               # 0x2032
+ - "″": [t: "podwójny prim"]                        # 0x2033
+ - "‴": [t: "potrójny prim"]                        # 0x2034
+
+ - "ℂℕℚℝℤ":     # here we rely on this running through the table again to speak "cap xxx"
+    - t: "dwukreskowe"
+    - spell: "translate('.', 'ℂℕℚℝℤ', 'CNQRZ')"
+
+ - "℃": [t: "stopnie Celsjusza"]                     # 0x2103
+ - "℉": [t: "stopnie Fahrenheita"]                  # 0x2109
+ - "ℋℛℓ":                                          # 0x210b
+    - t: "pisane"
+    - spell: "translate('.', 'ℋℛℓ', 'HRl')"
+ - "ℎ": [t: "stała Plancka"]                     # 0x210e
+ - "ℜ":                                          # 0x211c
+    - t: "fraktura"
+    - spell: "'R'"
+
+ - "Ω": [t: "omy"]                                # 0x2126
+ - "K": [t: "kelwin"]                              # 0x212a
+ - "Å": [t: "angstremy"]                           # 0x212b
+ - "ⅆⅇⅈⅉ":                                          # 0x2146-9
+    - t: "dwukreskowa kursywa"
+    - spell: "translate('.', 'ⅆⅇⅈⅉ', 'deij')"
+
+ - "←": [t: "strzałka w lewo"]                     # 0x2190
+ - "↑": [t: "strzałka w górę"]                       # 0x2191
+ - "→":                                          # 0x2192
+     - test:
+        if: "ancestor::*[2][self::m:limit or self::m:limit-sup or self::m:limit-inf]"
+        then: [t: "dąży do"]
+        else_test:
+          if: "parent::*[self::m:mrow]/parent::*[self::m:subscripted-norm]"
+          then: [t: "do"]      # indeks normy operatorowej ‖·‖_{p→q}: → czyta sie "do"
+          else: [t: "strzałka w prawo"]
+
+ - "↓": [t: "strzałka w dół"]                     # 0x2193
+ - "⇒": [T: "implikuje"]             # 0x21d2
+ - "∀": [t: "dla każdego"]                             # 0x2200
+ - "∂":                                          # 0x2202
+     - test: 
+         if: "$Verbosity='Terse'"
+         then: [t: "cząstkowe"]
+         else: [t: "pochodna cząstkowa"]
+ - "∃": [t: "istnieje"]                        # 0x2203
+ - "∄": [t: "nie istnieje"]                # 0x2204
+ - "∅": [T: "zbiór pusty"]                           # 0x2205
+ - "∆":                                          # 0x2206
+     - t: "laplasjan"
+ - "∈":                                          # 0x2208
+     - test:
+        if: "$SpeechStyle != 'ClearSpeak'"
+        then:
+        - test:
+            if: "$Verbosity!='Terse' and not(ancestor::*[self::m:set])"    # "the set x is an element of ..." sounds bad"
+            then: [T: "jest"]
+        - t: "elementem zbioru"
+        # Several options for speaking elements in ClearSpeak -- they split between being inside a set or not and then the option
+        else_test:
+            if: "../../self::m:set or ../../../self::m:set" # inside a set
+            then_test:
+              - if: $ClearSpeak_SetMemberSymbol = 'Auto' or $ClearSpeak_SetMemberSymbol = 'In'
+                then: [T: "do"]
+              - else_if: $ClearSpeak_SetMemberSymbol = 'Member'
+                then: [t: "element zbioru"]
+              - else_if: $ClearSpeak_SetMemberSymbol = 'Element'
+                then: [t: "należy do"]
+              - else: [t: "należące do"]             # $ClearSpeak_SetMemberSymbol = 'Belongs'
+            else_test:
+              - if: $ClearSpeak_SetMemberSymbol = 'Auto' or $ClearSpeak_SetMemberSymbol = 'Member'
+                then: [t: "jest elementem zbioru"]
+              - else_if: $ClearSpeak_SetMemberSymbol = 'Element'
+                then: [t: "jest elementem zbioru"]
+              - else_if: $ClearSpeak_SetMemberSymbol = 'In'
+                then: [t: "należy do"]
+              - else: [t: "należy do"]              # $ClearSpeak_SetMemberSymbol = 'Belongs'
+ - "∉":                                          # 0x2209
+    # rule is identical to 0x2208
+     - test:
+        if: "$SpeechStyle != 'ClearSpeak'"
+        then:
+        - t: "nie jest elementem zbioru"
+        # Several options for speaking elements in ClearSpeak -- they split between being inside a set or not and then the option
+        else_test:
+            if: "../../self::m:set or ../../../self::m:set" # inside a set
+            then_test:
+              - if: $ClearSpeak_SetMemberSymbol = 'Auto' or $ClearSpeak_SetMemberSymbol = 'In'
+                then: [t: "nie należy do"]
+              - else_if: $ClearSpeak_SetMemberSymbol = 'Member'
+                then: [t: "nie jest elementem zbioru"]
+              - else_if: $ClearSpeak_SetMemberSymbol = 'Element'
+                then: [t: "nie jest elementem zbioru"]
+              - else: [t: "nienależące do"]             # $ClearSpeak_SetMemberSymbol = 'Belongs'
+            else_test:
+              - if: $ClearSpeak_SetMemberSymbol = 'Auto' or $ClearSpeak_SetMemberSymbol = 'Member'
+                then: [t: "nie jest elementem zbioru"]
+              - else_if: $ClearSpeak_SetMemberSymbol = 'Element'
+                then: [t: "nie jest elementem zbioru"]
+              - else_if: $ClearSpeak_SetMemberSymbol = 'In'
+                then: [t: "nie należy do"]
+              - else: [t: "nie należy do"]              # $ClearSpeak_SetMemberSymbol = 'Belongs'
+ - "∊":                                          # 0x220a
+     - test:
+        if: "$SpeechStyle != 'ClearSpeak'"
+        then:
+        - test: 
+            if: "$Verbosity!='Terse' and not(ancestor::*[self::m:set])"    # "the set x is an element of ..." sounds bad"
+            then: [T: "jest"]
+        - t: "element zbioru"
+        # Several options for speaking elements in ClearSpeak -- they split between being inside a set or not and then the option
+        else_test:
+            if: "../../self::m:set or ../../../self::m:set" # inside a set
+            then_test:
+              - if: $ClearSpeak_SetMemberSymbol = 'Auto' or $ClearSpeak_SetMemberSymbol = 'In'
+                then: [T: "do"]
+              - else_if: $ClearSpeak_SetMemberSymbol = 'Member'
+                then: [t: "element zbioru"]
+              - else_if: $ClearSpeak_SetMemberSymbol = 'Element'
+                then: [t: "należy do"]
+              - else: [t: "należące do"]             # $ClearSpeak_SetMemberSymbol = 'Belongs'
+            else_test:
+              - if: $ClearSpeak_SetMemberSymbol = 'Auto' or $ClearSpeak_SetMemberSymbol = 'Member'
+                then: [t: "jest elementem zbioru"]
+              - else_if: $ClearSpeak_SetMemberSymbol = 'Element'
+                then: [t: "jest elementem zbioru"]
+              - else_if: $ClearSpeak_SetMemberSymbol = 'In'
+                then: [t: "należy do"]
+              - else: [t: "należy do"]              # $ClearSpeak_SetMemberSymbol = 'Belongs'
+ - "∏": [T: "iloczyn"]                             # 0x220f
+ - "∐": [t: "koprodukt"]                          # 0x2210
+ - "∑": [T: "suma"]                                 # 0x2211
+ - "−": [T: "minus"]                               # 0x2212
+ - "∓": [T: "minus plus"]                       # 0x2213
+ - "∗":                                          # 0x2217
+    test:
+        if:
+          - "parent::*[name(.)='subscripted-norm'] or "
+          - "parent::*[(name(.)='indexed-by' or name(.)='msub') and *[1][self::m:mo and .='∥']] or "
+          - "parent::*[name(.)='msubsup' and *[1][self::m:mo and .='∥']] and count(preceding-sibling::*)=1"
+        then: [T: "gwiazdkowa"]                   # norma ‖·‖_* -> "norma gwiazdkowa"
+        else: [T: "razy"]                        # 0x2217
+ - "∘": [t: "złożone z"]                       # 0x2218
+ - "√":                                          # 0x221a
+     - t: "pierwiastek kwadratowy z"
+ - "∝":                                          # 0x221d
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [T: "jest"]
+     - t: "proporcjonalne do"
+ - "∞":
+    - test:
+        if: "ancestor::*[self::m:limit or self::m:limit-sup or self::m:limit-inf or self::m:large-op] or parent::*[self::m:subscripted-norm] or parent::*[self::m:mrow]/parent::*[self::m:subscripted-norm]"
+        then: [T: "nieskończoności"]
+        else: [T: "nieskończoność"]                          # 0x221e
+ - "∟": [t: "kąt prosty"]                         # 0x221f
+ - "∠": [t: "kąt"]                               # 0x2220
+ - "∡": [t: "kąt mierzony"]                      # 0x2221
+ - "∣": [T: "dzieli"]                              # 0x2223
+ - "∤": [t: "nie dzieli"]                      # 0x2224
+ - "∥":                                           # 0x2225
+     - test:
+         if: "ancestor-or-self::*[contains(@data-intent-property, ':literal:')]"
+         then: [t: "podwójna pionowa kreska"]
+         else:
+         - test:
+              if: "$Verbosity!='Terse'"
+              then: [T: "jest"]
+         - t: "równoległe do"
+ - "∦":                                           # 0x2226
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [T: "jest"]
+     - t: "nierównoległe do"
+ - "∧": [T: "i"]                                 # 0x2227
+ - "∨": [T: "lub"]                                  # 0x2228
+ - "∩": [T: "przecięcie"]                        # 0x2229
+ - "∪": [T: "suma zbiorów"]                               # 0x222a
+ - "∫": [T: "całka"]                            # 0x222b
+ - "∬": [t: "całka podwójna"]                     # 0x222c
+ - "∭": [t: "całka potrójna"]                     # 0x222d
+ - "∮": [t: "całka krzywoliniowa"]                    # 0x222e
+ - "∶":                                          # 0x2236
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [T: "jest"]
+     - T: "do"
+ - "∷": [t: "jako"]                                  # 0x2237
+ - "∼": [t: "tylda"]                            # 0x223c
+ - "∽": [t: "odwrócona tylda"]                      # 0x223d
+ - "∾":                                          # 0x223e
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [T: "jest"]
+     - t: "most dodatnie"
+ - "∿": [t: "fala sinusoidalna"]                           # 0x223f
+ - "≠":                                          # 0x2260
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [T: "jest"]
+     - T: "nie równa się"
+ - "≡":                                          # 0x2261
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [T: "jest"]
+     - t: "identyczne z"
+ - "≤":                                          # 0x2264
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [T: "jest"]
+     - T: "mniejsze lub równe"
+ - "≥":                                          # 0x2265
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [T: "jest"]
+     - T: "większe lub równe"
+ - "≦": [t: "mniejsze nad równe"]             # 0x2266
+ - "≧": [t: "większe nad równe"]          # 0x2267
+ - "≺": [t: "poprzedza"]                            # 0x227a
+ - "≻": [t: "następuje po"]                            # 0x227b
+ - "⊂":                                          # 0x2282
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [t: "jest"]
+     - t: "podzbiorem"
+ - "⊃":                                          # 0x2283
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [t: "jest"]
+     - t: "nadzbiorem"
+ - "⊄":                                          # 0x2284
+     - t: "nie jest podzbiorem"
+ - "⊅":                                          # 0x2285
+     - t: "nie jest nadzbiorem"
+ - "⊆":                                          # 0x2286
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [t: "jest"]
+     - t: "podzbiorem lub równym"
+ - "⊇":                                          # 0x2287
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [t: "jest"]
+     - t: "nadzbiorem lub równym"

--- a/tests/Languages/pl.rs
+++ b/tests/Languages/pl.rs
@@ -1,0 +1,1257 @@
+#![allow(non_snake_case)]
+
+use crate::common::*;
+use anyhow::Result;
+
+#[test]
+fn binomial_theorem_simple_speak() -> Result<()> {
+    let expr = r#"
+        <math xmlns="http://www.w3.org/1998/Math/MathML" display="block">
+            <msup>
+                <mrow><mo>(</mo><mi>x</mi><mo>+</mo><mi>a</mi><mo>)</mo></mrow>
+                <mi>n</mi>
+            </msup>
+            <mo>=</mo>
+            <munderover>
+                <mo stretchy="false">&#x2211;</mo>
+                <mrow><mi>k</mi><mo>=</mo><mn>0</mn></mrow>
+                <mi>n</mi>
+            </munderover>
+            <mrow>
+                <mo>(</mo>
+                <mfrac linethickness="0"><mi>n</mi><mi>k</mi></mfrac>
+                <mo>)</mo>
+                <msup><mi>x</mi><mi>k</mi></msup>
+                <msup><mi>a</mi><mrow><mi>n</mi><mo>&#x2212;</mo><mi>k</mi></mrow></msup>
+            </mrow>
+        </math>
+    "#;
+    test(
+        "pl",
+        "SimpleSpeak",
+        expr,
+        "nawias otwierający, x plus a, nawias zamykający do potęgi n; równa się; suma od k równa się 0, do n; n po k razy x do potęgi k razy a do potęgi n minus k",
+    )?;
+    Ok(())
+}
+
+#[test]
+fn variable_power_simple_speak() -> Result<()> {
+    let expr = "<math><msup><mi>x</mi><mi>n</mi></msup></math>";
+    test("pl", "SimpleSpeak", expr, "x do potęgi n")?;
+    Ok(())
+}
+
+#[test]
+fn binomial_simple_speak() -> Result<()> {
+    let expr = r#"
+        <math>
+            <mo>(</mo>
+            <mfrac linethickness="0"><mi>n</mi><mi>k</mi></mfrac>
+            <mo>)</mo>
+        </math>
+    "#;
+    test("pl", "SimpleSpeak", expr, "n po k")?;
+    Ok(())
+}
+
+#[test]
+fn clearspeak_absolute_value_and_equivalence() -> Result<()> {
+    let expr = r#"
+        <math>
+            <mrow><mo>|</mo><mi>x</mi><mo>&#x2212;</mo><mn>3</mn><mo>|</mo></mrow>
+            <mo>&#x21d4;</mo>
+            <mn>1</mn><mo>&lt;</mo><mi>x</mi><mo>&lt;</mo><mn>5</mn>
+        </math>
+    "#;
+    test(
+        "pl",
+        "ClearSpeak",
+        expr,
+        "wartość bezwzględna z x minus 3; wtedy i tylko wtedy 1; jest mniejsze niż x jest mniejsze niż 5",
+    )?;
+    Ok(())
+}
+
+#[test]
+fn clearspeak_closed_interval() -> Result<()> {
+    let expr = r#"
+        <math>
+            <mi>x</mi><mo>&#x2208;</mo>
+            <mrow><mo>[</mo><mi>a</mi><mo>,</mo><mi>b</mi><mo>]</mo></mrow>
+        </math>
+    "#;
+    test(
+        "pl",
+        "ClearSpeak",
+        expr,
+        "x jest elementem zbioru, przedział domknięty od a do b",
+    )?;
+    Ok(())
+}
+
+#[test]
+fn clearspeak_limit_arrow() -> Result<()> {
+    let expr = r#"
+        <math>
+            <munder>
+                <mo>lim</mo>
+                <mrow><mi>x</mi><mo>&#x2192;</mo><mi>a</mi></mrow>
+            </munder>
+            <mfrac>
+                <mrow><mi>f</mi><mo>&#x2061;</mo><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow>
+                <mrow><mi>g</mi><mo>&#x2061;</mo><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow>
+            </mfrac>
+        </math>
+    "#;
+    test(
+        "pl",
+        "ClearSpeak",
+        expr,
+        "granica gdy x dąży do a, z f z x przez g z x",
+    )?;
+    Ok(())
+}
+
+#[test]
+fn clearspeak_multiline_plural() -> Result<()> {
+    let expr = r#"
+        <math>
+            <mi>f</mi>
+            <mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow>
+            <mo>=</mo>
+            <mrow>
+                <mo stretchy="true">{</mo>
+                <mtable>
+                    <mtr><mtd><mo>-</mo><mn>1</mn></mtd><mtd><mtext>dla</mtext></mtd><mtd><mi>x</mi><mo>&lt;</mo><mn>0</mn></mtd></mtr>
+                    <mtr><mtd><mn>0</mn></mtd><mtd><mtext>dla</mtext></mtd><mtd><mi>x</mi><mo>=</mo><mn>0</mn></mtd></mtr>
+                    <mtr><mtd><mn>1</mn></mtd><mtd><mtext>dla</mtext></mtd><mtd><mi>x</mi><mo>&gt;</mo><mn>0</mn></mtd></mtr>
+                </mtable>
+            </mrow>
+        </math>
+    "#;
+    test(
+        "pl",
+        "ClearSpeak",
+        expr,
+        "f z x równa się; 3 przypadki; przypadek 1; minus 1 dla x jest mniejsze niż 0; przypadek 2; 0 dla x równa się 0; przypadek 3; 1 dla x jest większe niż 0",
+    )?;
+    Ok(())
+}
+
+#[test]
+fn clearspeak_vector_product_names() -> Result<()> {
+    let expr = r#"
+        <math>
+            <mover><mi>a</mi><mo>&#x2192;</mo></mover>
+            <mo>&#x22c5;</mo>
+            <mover><mi>b</mi><mo>&#x2192;</mo></mover>
+            <mo>=</mo>
+            <mover><mi>a</mi><mo>&#x2192;</mo></mover>
+            <mo>&#xd7;</mo>
+            <mover><mi>b</mi><mo>&#x2192;</mo></mover>
+        </math>
+    "#;
+    test(
+        "pl",
+        "ClearSpeak",
+        expr,
+        "wektor a, iloczyn skalarny wektor b; równa się, wektor a, iloczyn wektorowy wektor b",
+    )?;
+    Ok(())
+}
+
+#[test]
+fn clearspeak_limsup_and_tilde() -> Result<()> {
+    let expr = r#"
+        <math>
+            <munder>
+                <mi>limsup</mi>
+                <mrow><mi>n</mi><mo>&#x2192;</mo><mi>&#x221e;</mi></mrow>
+            </munder>
+            <msub><mi>a</mi><mi>n</mi></msub>
+            <mo>&#x223c;</mo>
+            <mn>0</mn>
+        </math>
+    "#;
+    test(
+        "pl",
+        "ClearSpeak",
+        expr,
+        "granica górna gdy n dąży do nieskończoności, z a indeks dolny n; tylda 0",
+    )?;
+    Ok(())
+}
+
+#[test]
+fn clearspeak_max_min_and_infinity_norm_are_polish() -> Result<()> {
+    let expr = r#"
+        <math>
+            <mrow intent="max($x)">
+                <mi arg="x">x</mi>
+            </mrow>
+            <mo>,</mo>
+            <mrow intent="min($x)">
+                <mi arg="x">x</mi>
+            </mrow>
+            <mo>,</mo>
+            <mrow>
+                <mo>∥</mo><mi>x</mi><msub><mo>∥</mo><mi>∞</mi></msub>
+            </mrow>
+            <mo>,</mo>
+            <mrow>
+                <mo>∥</mo><mi>x</mi><msubsup><mo>∥</mo><mi>∞</mi><mn>2</mn></msubsup>
+            </mrow>
+        </math>
+    "#;
+    test(
+        "pl",
+        "ClearSpeak",
+        expr,
+        "maksimum z x, przecinek, minimum z x, przecinek; norma nieskończoności z x, przecinek; norma nieskończoności z x do potęgi 2",
+    )?;
+    test(
+        "pl",
+        "SimpleSpeak",
+        expr,
+        "maksimum z x, przecinek, minimum z x, przecinek; norma nieskończoności z x, przecinek; norma nieskończoności z x do kwadratu",
+    )?;
+    Ok(())
+}
+
+#[test]
+fn clearspeak_named_functions_without_intent_are_polish() -> Result<()> {
+    let expr = r#"
+        <math>
+            <mi>max</mi><mo>&#x2061;</mo><mi>x</mi>
+            <mo>,</mo>
+            <mi>min</mi><mo>&#x2061;</mo><mi>x</mi>
+            <mo>,</mo>
+            <mi>sup</mi><mo>&#x2061;</mo><mi>x</mi>
+            <mo>,</mo>
+            <mi>inf</mi><mo>&#x2061;</mo><mi>x</mi>
+        </math>
+    "#;
+    test(
+        "pl",
+        "ClearSpeak",
+        expr,
+        "maksimum z x, przecinek, minimum z x, przecinek; supremum z x, przecinek, infimum z x",
+    )?;
+    test(
+        "pl",
+        "SimpleSpeak",
+        expr,
+        "maksimum z x, przecinek, minimum z x, przecinek; supremum z x, przecinek, infimum z x",
+    )?;
+    Ok(())
+}
+
+#[test]
+fn clearspeak_under_named_functions_from_pandoc_are_polish() -> Result<()> {
+    let expr = r#"
+        <math>
+            <munder><mo>max</mo><mi>i</mi></munder>
+            <mrow><mo>|</mo><msub><mi>x</mi><mi>i</mi></msub><mo>|</mo></mrow>
+            <mo>=</mo>
+            <msup>
+                <mrow>
+                    <mo>(</mo>
+                    <munder><mo>min</mo><mi>i</mi></munder>
+                    <mrow><mo>|</mo><msub><mi>x</mi><mi>i</mi></msub><mo>|</mo></mrow>
+                    <mo>)</mo>
+                </mrow>
+                <mn>2</mn>
+            </msup>
+        </math>
+    "#;
+    test(
+        "pl",
+        "ClearSpeak",
+        expr,
+        "maksimum z i pod z, wartość bezwzględna z x indeks dolny i; równa się; nawias otwierający minimum z i pod z, wartość bezwzględna z x indeks dolny i; nawias zamykający do kwadratu",
+    )?;
+    Ok(())
+}
+
+#[test]
+fn clearspeak_under_compound_operators_are_polish() -> Result<()> {
+    let expr = r#"
+        <math>
+            <munder>
+                <mrow><mi>arg</mi><mi>max</mi></mrow>
+                <mrow><mi>x</mi><mo>∈</mo><mi>X</mi></mrow>
+            </munder>
+            <mi>f</mi><mo>&#x2061;</mo><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow>
+            <mo>,</mo>
+            <munder>
+                <mrow><mi>arg</mi><mi>min</mi></mrow>
+                <mrow><mi>y</mi><mo>∈</mo><mi>Y</mi></mrow>
+            </munder>
+            <mi>g</mi><mo>&#x2061;</mo><mrow><mo>(</mo><mi>y</mi><mo>)</mo></mrow>
+            <mo>,</mo>
+            <munder>
+                <mrow><mi>ess</mi><mi>sup</mi></mrow>
+                <mrow><mi>x</mi><mo>∈</mo><mi>Ω</mi></mrow>
+            </munder>
+            <mrow><mo>|</mo><mi>f</mi><mo>|</mo></mrow>
+        </math>
+    "#;
+    test(
+        "pl",
+        "ClearSpeak",
+        expr,
+        "arg maksimum z x jest elementem zbioru, wielka x pod; f z x; przecinek; arg minimum z y jest elementem zbioru, wielka y pod; g z y; przecinek; supremum istotne z x jest elementem zbioru, wielka omega pod; wartość bezwzględna z f",
+    )?;
+    Ok(())
+}
+
+#[test]
+fn clearspeak_infinity_after_to_uses_genitive() -> Result<()> {
+    let expr = r#"
+        <math>
+            <munder>
+                <mo>lim</mo>
+                <mrow>
+                    <mi>x</mi><mo>&#x2192;</mo>
+                    <mrow><mo>-</mo><mi>&#x221e;</mi></mrow>
+                </mrow>
+            </munder>
+            <mi>f</mi><mo>&#x2061;</mo><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow>
+            <mo>,</mo>
+            <munderover>
+                <mo>&#x2211;</mo>
+                <mrow><mi>n</mi><mo>=</mo><mn>1</mn></mrow>
+                <mi>&#x221e;</mi>
+            </munderover>
+            <msup><mn>2</mn><mrow><mo>-</mo><mi>n</mi></mrow></msup>
+            <mo>,</mo>
+            <munderover>
+                <mo>&#x222b;</mo>
+                <mn>0</mn>
+                <mi>&#x221e;</mi>
+            </munderover>
+            <msup><mi>e</mi><mrow><mo>-</mo><mi>x</mi></mrow></msup>
+        </math>
+    "#;
+    test(
+        "pl",
+        "ClearSpeak",
+        expr,
+        "granica gdy x dąży do minus nieskończoności, z f z x; przecinek; suma od n równa się 1, do nieskończoności; 2 do potęgi minus n; przecinek; całka od 0, do nieskończoności; e do potęgi minus x",
+    )?;
+    Ok(())
+}
+
+#[test]
+fn common_fraction_numerators_use_polish_feminine_forms() -> Result<()> {
+    let expr = r#"
+        <math>
+            <mfrac><mn>1</mn><mn>2</mn></mfrac>
+            <mo>+</mo>
+            <mfrac><mn>2</mn><mn>3</mn></mfrac>
+            <mo>+</mo>
+            <mfrac><mn>3</mn><mn>4</mn></mfrac>
+            <mo>+</mo>
+            <mfrac><mn>1</mn><mn>10</mn></mfrac>
+            <mo>+</mo>
+            <mfrac><mn>2</mn><mn>10</mn></mfrac>
+        </math>
+    "#;
+    test(
+        "pl",
+        "ClearSpeak",
+        expr,
+        "jedna druga plus dwie trzecie plus 3 czwarte plus jedna dziesiąta plus dwie dziesiąte",
+    )?;
+    test(
+        "pl",
+        "SimpleSpeak",
+        expr,
+        "jedna druga plus dwie trzecie plus 3 czwarte plus jedna dziesiąta plus dwie dziesiąte",
+    )?;
+    Ok(())
+}
+
+#[test]
+fn clearspeak_approximation_relations() -> Result<()> {
+    let expr = r#"
+        <math>
+            <mi>x</mi><mo>&#x2248;</mo><mi>y</mi><mo>,</mo>
+            <mi>y</mi><mo>&#x2243;</mo><mi>z</mi><mo>,</mo>
+            <mi>z</mi><mo>&#x2245;</mo><mi>w</mi>
+        </math>
+    "#;
+    test(
+        "pl",
+        "ClearSpeak",
+        expr,
+        "x jest w przybliżeniu równe y; przecinek; y jest asymptotycznie równe z; przecinek; z jest przystające do w",
+    )?;
+    Ok(())
+}
+
+#[test]
+fn clearspeak_precedence_relation_implies() -> Result<()> {
+    let expr = r#"
+        <math>
+            <mi>a</mi><mo>&#x227c;</mo><mi>b</mi>
+            <mo>&#x2227;</mo>
+            <mi>b</mi><mo>&#x227c;</mo><mi>c</mi>
+            <mo>&#x21d2;</mo>
+            <mi>a</mi><mo>&#x227c;</mo><mi>c</mi>
+        </math>
+    "#;
+    test(
+        "pl",
+        "ClearSpeak",
+        expr,
+        "a poprzedza lub jest równe, b i b, poprzedza lub jest równe, c implikuje a, poprzedza lub jest równe c",
+    )?;
+    Ok(())
+}
+
+#[test]
+fn clearspeak_square_relations_and_negated_implication() -> Result<()> {
+    let expr = r#"
+        <math>
+            <mi>x</mi><mo>&#x2291;</mo><mi>y</mi><mo>&#x228f;</mo><mi>z</mi>
+            <mo>,</mo>
+            <mi>u</mi><mo>&#x2280;</mo><mi>v</mi>
+            <mo>,</mo>
+            <mi>P</mi><mo>&#x21cf;</mo><mi>Q</mi>
+        </math>
+    "#;
+    test(
+        "pl",
+        "ClearSpeak",
+        expr,
+        "x kwadratowo poprzedza lub jest równe; y kwadratowo poprzedza z; przecinek; u nie poprzedza v, przecinek; wielka p nie implikuje wielka q",
+    )?;
+    Ok(())
+}
+
+#[test]
+fn clearspeak_much_less_greater_relations() -> Result<()> {
+    let expr = r#"
+        <math>
+            <mi>x</mi><mo>&#x226a;</mo><mi>y</mi>
+            <mo>,</mo>
+            <mi>y</mi><mo>&#x226b;</mo><mi>z</mi>
+            <mo>,</mo>
+            <mi>a</mi><mo>&#x22d8;</mo><mi>b</mi>
+            <mo>,</mo>
+            <mi>c</mi><mo>&#x22d9;</mo><mi>d</mi>
+        </math>
+    "#;
+    test(
+        "pl",
+        "ClearSpeak",
+        expr,
+        "x jest znacznie mniejsze niż y; przecinek; y jest znacznie większe niż z; przecinek; a jest bardzo znacznie mniejsze niż b; przecinek; c jest bardzo znacznie większe niż d",
+    )?;
+    Ok(())
+}
+
+#[test]
+fn clearspeak_two_headed_arrow() -> Result<()> {
+    let expr = r#"
+        <math>
+            <mi>A</mi><mo>&#x21a0;</mo><mi>B</mi>
+        </math>
+    "#;
+    test(
+        "pl",
+        "ClearSpeak",
+        expr,
+        "wielka a, strzałka w prawo z dwoma grotami, wielka b",
+    )?;
+    Ok(())
+}
+
+#[test]
+fn clearspeak_negated_unicode_relations() -> Result<()> {
+    let expr = r#"
+        <math>
+            <mi>x</mi><mo>&#x2270;</mo><mi>y</mi>
+            <mo>,</mo>
+            <mi>a</mi><mo>&#x22e0;</mo><mi>b</mi>
+            <mo>,</mo>
+            <mi>c</mi><mo>&#x22e2;</mo><mi>d</mi>
+            <mo>,</mo>
+            <mi>A</mi><mo>&#x220c;</mo><mi>x</mi>
+        </math>
+    "#;
+    test(
+        "pl",
+        "ClearSpeak",
+        expr,
+        "x nie jest mniejsze ani równe y; przecinek; a nie poprzedza ani nie jest równe b; przecinek; c nie poprzedza kwadratowo ani nie jest równe d; przecinek; wielka a nie zawiera elementu x",
+    )?;
+    Ok(())
+}
+
+#[test]
+fn clearspeak_series3_symbol_words() -> Result<()> {
+    let expr = r#"
+        <math>
+            <mi>p</mi><mo>&#x2234;</mo><mi>q</mi>
+            <mo>,</mo>
+            <mi>r</mi><mo>&#x2235;</mo><mi>s</mi>
+            <mo>,</mo>
+            <mi>u</mi><mo>&#x223d;</mo><mi>v</mi>
+            <mo>,</mo>
+            <mi>g</mi><mo>&#x2240;</mo><mi>h</mi>
+        </math>
+    "#;
+    test(
+        "pl",
+        "ClearSpeak",
+        expr,
+        "p zatem q, przecinek; r ponieważ s, przecinek; u odwrócona tylda v, przecinek; g iloczyn wieńcowy h",
+    )?;
+    Ok(())
+}
+
+#[test]
+fn clearspeak_series3_arrows() -> Result<()> {
+    let expr = r#"
+        <math>
+            <mi>a</mi><mo>&#x219a;</mo><mi>b</mi>
+            <mo>,</mo>
+            <mi>c</mi><mo>&#x21ae;</mo><mi>d</mi>
+            <mo>,</mo>
+            <mi>e</mi><mo>&#x21c7;</mo><mi>f</mi>
+        </math>
+    "#;
+    test(
+        "pl",
+        "ClearSpeak",
+        expr,
+        "a przekreślona strzałka w lewo b; przecinek; c przekreślona strzałka w lewo i w prawo d; przecinek; e podwójne strzałki w lewo f",
+    )?;
+    Ok(())
+}
+
+#[test]
+fn clearspeak_series3_delimiters() -> Result<()> {
+    let expr = r#"
+        <math>
+            <mo>&#x298d;</mo><mi>x</mi><mo>&#x2990;</mo>
+            <mo>,</mo>
+            <mo>&#x3010;</mo><mi>A</mi><mo>&#x3011;</mo>
+            <mo>,</mo>
+            <mo>&#x3014;</mo><mi>C</mi><mo>&#x3015;</mo>
+        </math>
+    "#;
+    test(
+        "pl",
+        "ClearSpeak",
+        expr,
+        "lewy nawias kwadratowy z haczykiem w górnym rogu x, prawy nawias kwadratowy z haczykiem w górnym rogu; przecinek; lewy czarny nawias soczewkowy; wielka a, prawy czarny nawias soczewkowy; przecinek; lewy nawias skorupowy, wielka c prawy nawias skorupowy",
+    )?;
+    Ok(())
+}
+
+#[test]
+fn clearspeak_series4_bold_math_alphabet() -> Result<()> {
+    let expr = r#"
+        <math>
+            <mi>&#x1d431;</mi><mo>&#x22c5;</mo><mi>&#x1d432;</mi>
+        </math>
+    "#;
+    test(
+        "pl",
+        "ClearSpeak",
+        expr,
+        "pogrubione x iloczyn skalarny pogrubione y",
+    )?;
+    Ok(())
+}
+
+#[test]
+fn clearspeak_series4_arrow_words() -> Result<()> {
+    let expr = r#"
+        <math>
+            <mi>a</mi><mo>&#x21dc;</mo><mi>b</mi>
+            <mo>,</mo>
+            <mi>c</mi><mo>&#x27ff;</mo><mi>d</mi>
+            <mo>,</mo>
+            <mi>e</mi><mo>&#x21fb;</mo><mi>f</mi>
+        </math>
+    "#;
+    test(
+        "pl",
+        "ClearSpeak",
+        expr,
+        "a falista strzałka w lewo b, przecinek; c długa falista strzałka w prawo d; przecinek; e, strzałka w prawo z podwójną pionową kreską f",
+    )?;
+    Ok(())
+}
+
+#[test]
+fn clearspeak_series4_relation_words() -> Result<()> {
+    let expr = r#"
+        <math>
+            <mi>x</mi><mo>&#x22eb;</mo><mi>y</mi>
+            <mo>,</mo>
+            <mi>a</mi><mo>&#x2a7d;</mo><mi>b</mi>
+            <mo>,</mo>
+            <mi>c</mi><mo>&#x2aaf;</mo><mi>d</mi>
+            <mo>,</mo>
+            <mi>e</mi><mo>&#x2ac5;</mo><mi>f</mi>
+        </math>
+    "#;
+    test(
+        "pl",
+        "ClearSpeak",
+        expr,
+        "x nie zawiera jako normalnej podgrupy y; przecinek; a mniejsze niż lub ukośnie równe b; przecinek; c poprzedza nad pojedynczą linią równości d; przecinek; e podzbiór nad znakiem równości f",
+    )?;
+    Ok(())
+}
+
+#[test]
+fn clearspeak_series4_logic_operator_words() -> Result<()> {
+    let expr = r#"
+        <math>
+            <mi>A</mi><mo>&#x228d;</mo><mi>B</mi>
+            <mo>,</mo>
+            <mi>C</mi><mo>&#x22a2;</mo><mi>D</mi>
+            <mo>,</mo>
+            <mi>E</mi><mo>&#x22a7;</mo><mi>F</mi>
+            <mo>,</mo>
+            <mi>G</mi><mo>&#x27d7;</mo><mi>H</mi>
+            <mo>,</mo>
+            <mi>I</mi><mo>&#x2a3f;</mo><mi>J</mi>
+        </math>
+    "#;
+    test(
+        "pl",
+        "ClearSpeak",
+        expr,
+        "wielka a mnożenie wielozbiorów, wielka b; przecinek; wielka c dowodzi wielka d; przecinek; wielka e modeluje wielka f; przecinek; wielka g, pełne złączenie zewnętrzne, wielka h; przecinek; wielka i amalgamacja lub koprodukt, wielka j",
+    )?;
+    Ok(())
+}
+
+#[test]
+fn clearspeak_series5_arrow_symbol_words() -> Result<()> {
+    let expr = r#"
+        <math>
+            <mi>a</mi><mo>&#x2911;</mo><mi>b</mi>
+            <mo>,</mo>
+            <mi>c</mi><mo>&#x291d;</mo><mi>d</mi>
+            <mo>,</mo>
+            <mi>e</mi><mo>&#x2938;</mo><mi>f</mi>
+        </math>
+    "#;
+    test(
+        "pl",
+        "ClearSpeak",
+        expr,
+        "a strzałka w prawo z kropkowanym trzonem b; przecinek; c strzałka w lewo do wypełnionego rombu d; przecinek; e, prawostronna strzałka łukowa zgodna z ruchem wskazówek zegara f",
+    )?;
+    Ok(())
+}
+
+#[test]
+fn clearspeak_series5_angle_and_operator_words() -> Result<()> {
+    let expr = r#"
+        <math>
+            <mi>u</mi><mo>&#x29a8;</mo><mi>v</mi>
+            <mo>,</mo>
+            <mi>x</mi><mo>&#x2a11;</mo><mi>y</mi>
+            <mo>,</mo>
+            <mi>p</mi><mo>&#x2a3d;</mo><mi>q</mi>
+        </math>
+    "#;
+    test(
+        "pl",
+        "ClearSpeak",
+        expr,
+        "u; kąt mierzony z otwartym ramieniem zakończonym strzałką skierowaną w górę i w prawo v; przecinek; x, całka przeciwna do ruchu wskazówek zegara, y; przecinek; p prawostronny iloczyn wewnętrzny q",
+    )?;
+    Ok(())
+}
+
+#[test]
+fn clearspeak_series5_pua_mathjax_words() -> Result<()> {
+    let expr = r#"
+        <math>
+            <mi>p</mi><mo>&#xe916;</mo><mi>q</mi>
+            <mo>,</mo>
+            <mi>r</mi><mo>&#xe925;</mo><mi>s</mi>
+            <mo>,</mo>
+            <mi>t</mi><mo>&#xe97a;</mo><mi>u</mi>
+        </math>
+    "#;
+    test(
+        "pl",
+        "ClearSpeak",
+        expr,
+        "p, nadzbiór z kropką zawiera jako relację indeksu dolnego q; przecinek; r tylda z dwiema kropkami s, przecinek; t sparowane poczwórne pionowe kropki u",
+    )?;
+    Ok(())
+}
+
+#[test]
+fn clearspeak_series6_unicode_symbol_words() -> Result<()> {
+    let expr = r#"
+        <math>
+            <mi>a</mi><mo>&#x2975;</mo><mi>b</mi>
+            <mo>,</mo>
+            <mi>c</mi><mo>&#x29bc;</mo><mi>d</mi>
+            <mo>,</mo>
+            <mi>e</mi><mo>&#x29d8;</mo><mi>f</mi>
+            <mo>,</mo>
+            <mi>g</mi><mo>&#x29ee;</mo><mi>h</mi>
+            <mo>,</mo>
+            <mi>i</mi><mo>&#x2a5a;</mo><mi>j</mi>
+            <mo>,</mo>
+            <mi>k</mi><mo>&#x2a6f;</mo><mi>l</mi>
+        </math>
+    "#;
+    test(
+        "pl",
+        "ClearSpeak",
+        expr,
+        "a, strzałka w prawo nad znakiem przybliżonej równości b; przecinek; c, znak dzielenia w kółku obrócony przeciwnie do ruchu wskazówek zegara d; przecinek; e; lewy falisty ogranicznik; f przecinek; g biały kwadrat z przekreśleniem błędu h; przecinek; i logiczne i ze środkowym trzonem j; przecinek; k w przybliżeniu równe z daszkiem l",
+    )?;
+    Ok(())
+}
+
+#[test]
+fn clearspeak_series7_unicode_symbol_words() -> Result<()> {
+    let expr = r#"
+        <math>
+            <mi>a</mi><mo>&#x2ab7;</mo><mi>b</mi>
+            <mo>,</mo>
+            <mi>c</mi><mo>&#x2af7;</mo><mi>d</mi>
+            <mo>,</mo>
+            <mi>e</mi><mo>&#x2b3f;</mo><mi>f</mi>
+            <mo>,</mo>
+            <mi>g</mi><mo>&#xe980;</mo><mi>h</mi>
+            <mo>,</mo>
+            <mi>i</mi><mo>&#xea09;</mo><mi>j</mi>
+            <mo>,</mo>
+            <mi>k</mi><mo>&#xeb08;</mo><mi>l</mi>
+        </math>
+    "#;
+    test(
+        "pl",
+        "ClearSpeak",
+        expr,
+            "a, poprzedza nad znakiem przybliżonej równości b; przecinek; c potrójnie zagnieżdżone mniejsze niż d; przecinek; e, falista strzałka skierowana bezpośrednio w lewo f; przecinek; g kąt sferyczny otwarty w górę h; przecinek; i ani równe, ani mniejsze niż j; przecinek; k, łuk ze strzałką w lewo przeciwnie do ruchu wskazówek zegara l",
+    )?;
+    Ok(())
+}
+
+#[test]
+fn clearspeak_ac_current_symbol() -> Result<()> {
+    let expr = r#"
+        <math>
+            <mi>q</mi><mo>&#x23e6;</mo><mi>q</mi>
+        </math>
+    "#;
+    test("pl", "ClearSpeak", expr, "q prąd przemienny q")?;
+    Ok(())
+}
+
+#[test]
+fn clearspeak_prescript_words_are_polish() -> Result<()> {
+    let expr = r#"
+        <math>
+            <mmultiscripts>
+                <mi>x</mi>
+                <none/><none/>
+                <mprescripts/>
+                <none/><mo>&#x2032;</mo>
+            </mmultiscripts>
+        </math>
+    "#;
+    test("pl", "ClearSpeak", expr, "x lewy indeks górny prim")?;
+    Ok(())
+}
+
+#[test]
+fn clearspeak_degree_prescript_uses_nominative() -> Result<()> {
+    let expr = r#"
+        <math>
+            <mmultiscripts>
+                <mi>x</mi>
+                <none/><none/>
+                <mprescripts/>
+                <none/><mo>&#xb0;</mo>
+            </mmultiscripts>
+        </math>
+    "#;
+    test("pl", "ClearSpeak", expr, "x lewy indeks górny stopień")?;
+    Ok(())
+}
+
+#[test]
+fn clearspeak_degree_after_number_stays_plural() -> Result<()> {
+    let expr = r#"
+        <math>
+            <msup><mn>30</mn><mo>&#xb0;</mo></msup>
+        </math>
+    "#;
+    test("pl", "ClearSpeak", expr, "30 stopni")?;
+    Ok(())
+}
+
+#[test]
+fn simplespeak_degree_unit_plural() -> Result<()> {
+    let expr = r#"
+        <math>
+            <mn>1</mn><mi intent=":unit">&#xb0;</mi><mo>,</mo>
+            <mn>2</mn><mi intent=":unit">&#xb0;</mi>
+        </math>
+    "#;
+    test("pl", "SimpleSpeak", expr, "1 stopień, przecinek; 2 stopnie")?;
+    Ok(())
+}
+
+#[test]
+fn clearspeak_word_degree_celsius_prescript_is_polish() -> Result<()> {
+    let expr = r#"
+        <math>
+            <mrow><mi>T</mi><mo>=</mo><mn>1</mn><msup><mtext> </mtext><mo>∘</mo></msup><mi>C</mi></mrow>
+            <mo>,</mo>
+            <mrow><mi>T</mi><mo>=</mo><mn>2</mn><msup><mtext> </mtext><mo>∘</mo></msup><mi>C</mi></mrow>
+            <mo>,</mo>
+            <mrow><mi>T</mi><mo>=</mo><mn>20</mn><msup><mtext> </mtext><mo>∘</mo></msup><mi>C</mi></mrow>
+        </math>
+    "#;
+    test(
+        "pl",
+        "ClearSpeak",
+        expr,
+        "wielka t równa się 1 stopień Celsjusza; przecinek; wielka t równa się 2 stopnie Celsjusza; przecinek; wielka t równa się 20 stopni Celsjusza",
+    )?;
+    Ok(())
+}
+
+#[test]
+fn clearspeak_vector_calculus_intents_are_polish() -> Result<()> {
+    let expr = r#"
+        <math>
+            <mrow intent="gradient($f)"><mi arg="f">f</mi></mrow>
+            <mo>,</mo>
+            <mrow intent="divergence($g)"><mi arg="g">g</mi></mrow>
+            <mo>,</mo>
+            <mrow intent="curl($h)"><mi arg="h">h</mi></mrow>
+        </math>
+    "#;
+    test(
+        "pl",
+        "ClearSpeak",
+        expr,
+        "gradient z f, przecinek; dywergencja z g, przecinek, rotacja z h",
+    )?;
+    Ok(())
+}
+
+#[test]
+fn clearspeak_array_intent_is_polish() -> Result<()> {
+    let expr = r#"
+        <math>
+            <mtable intent=":array">
+                <mtr><mtd><mi>a</mi></mtd><mtd><mi>b</mi></mtd></mtr>
+                <mtr><mtd><mi>c</mi></mtd><mtd><mi>d</mi></mtd></mtr>
+            </mtable>
+        </math>
+    "#;
+    test(
+        "pl",
+        "ClearSpeak",
+        expr,
+        "tablica z; wiersz 1; kolumna 1; a, kolumna 2; b; przecinek; wiersz 2; kolumna 1; c, kolumna 2; d",
+    )?;
+    Ok(())
+}
+
+#[test]
+fn clearspeak_covariance_and_subscripted_norm_are_polish() -> Result<()> {
+    let expr = r#"
+        <math>
+            <mi>Cov</mi>
+            <mo>,</mo>
+            <mrow intent="subscripted-norm($x,$p)">
+                <mi arg="x">x</mi>
+                <mi arg="p">p</mi>
+            </mrow>
+        </math>
+    "#;
+    test(
+        "pl",
+        "ClearSpeak",
+        expr,
+        "kowariancja przecinek, norma p z x",
+    )?;
+    Ok(())
+}
+
+#[test]
+fn clearspeak_word_subscripted_norm_is_polish() -> Result<()> {
+    let expr = r#"
+        <math>
+            <mrow>
+                <mo>∥</mo>
+                <mi>x</mi>
+                <msub><mo>∥</mo><mi>p</mi></msub>
+            </mrow>
+        </math>
+    "#;
+    test("pl", "ClearSpeak", expr, "norma p z x")?;
+    Ok(())
+}
+
+#[test]
+fn clearspeak_star_subscripted_norm_is_polish() -> Result<()> {
+    let expr = r#"
+        <math>
+            <mrow>
+                <mo>∥</mo><mi>a</mi><msub><mo>∥</mo><mo>*</mo></msub>
+            </mrow>
+            <mo>,</mo>
+            <mrow>
+                <mo>∥</mo><mi>a</mi><msub><mo>∥</mo><mo>*</mo></msub><mo>=</mo><mn>1</mn>
+            </mrow>
+            <mo>,</mo>
+            <mrow>
+                <mo>∥</mo><mi>a</mi><msubsup><mo>∥</mo><mo>*</mo><mn>2</mn></msubsup>
+            </mrow>
+            <mo>,</mo>
+            <mrow>
+                <mo>∥</mo><mi>b</mi><msub><mo>∥</mo><mo>∗</mo></msub>
+            </mrow>
+            <mo>,</mo>
+            <mrow intent="subscripted-norm($x,$s)">
+                <mi arg="x">a</mi>
+                <mo arg="s">*</mo>
+            </mrow>
+        </math>
+    "#;
+    test(
+        "pl",
+        "ClearSpeak",
+        expr,
+        "norma gwiazdkowa z a, przecinek; norma gwiazdkowa z a, równa się 1; przecinek; norma gwiazdkowa z a do potęgi 2; przecinek; norma gwiazdkowa z b, przecinek; norma gwiazdkowa z a",
+    )?;
+    Ok(())
+}
+
+#[test]
+fn clearspeak_word_leading_norms_are_polish() -> Result<()> {
+    let expr = r#"
+        <math>
+            <mrow>
+                <mo>∥</mo><mi>x</mi><msub><mo>∥</mo><mi>p</mi></msub><mo>=</mo><mn>1</mn>
+            </mrow>
+            <mo>,</mo>
+            <mrow>
+                <mo>∥</mo><mi>x</mi><msub><mo>∥</mo><mn>2</mn></msub>
+                <mo>≤</mo>
+                <mo>∥</mo><mi>y</mi><msub><mo>∥</mo><mn>1</mn></msub>
+            </mrow>
+            <mo>,</mo>
+            <mrow>
+                <mo>∥</mo><mi>z</mi><mo>∥</mo><mo>=</mo><mn>1</mn>
+            </mrow>
+            <mo>,</mo>
+            <mrow>
+                <msqrt><mi>n</mi></msqrt><mo>&#x2062;</mo>
+                <mo>∥</mo><mi>x</mi><msub><mo>∥</mo><mn>2</mn></msub>
+            </mrow>
+            <mo>,</mo>
+            <mrow>
+                <mi>x</mi><mo>+</mo><mo>∥</mo><mi>y</mi><msub><mo>∥</mo><mi>p</mi></msub>
+            </mrow>
+            <mo>,</mo>
+            <mrow>
+                <mi>p</mi><mo>∥</mo><mi>q</mi>
+            </mrow>
+        </math>
+    "#;
+    test(
+        "pl",
+        "ClearSpeak",
+        expr,
+        "norma p z x równa się 1, przecinek; norma 2 z x, jest mniejsze lub równe, norma 1 z y; przecinek; norma z z, równa się 1; przecinek; pierwiastek kwadratowy z n; norma 2 z x; przecinek; x plus norma p z y, przecinek; p jest równoległe do q",
+    )?;
+    Ok(())
+}
+
+#[test]
+fn clearspeak_complex_norm_indices_are_polish() -> Result<()> {
+    let expr = r#"
+        <math>
+            <mrow>
+                <mo>∥</mo><mi>a</mi>
+                <msub>
+                    <mo>∥</mo>
+                    <mrow><mn>1</mn><mo>→</mo><mi>∞</mi></mrow>
+                </msub>
+            </mrow>
+            <mo>,</mo>
+            <mrow intent="subscripted-norm($x,$p)">
+                <mi arg="x">a</mi>
+                <mrow arg="p"><mn>1</mn><mo>→</mo><mi>∞</mi></mrow>
+            </mrow>
+            <mo>,</mo>
+            <mrow>
+                <mo>∥</mo><mi>f</mi>
+                <msub>
+                    <mo>∥</mo>
+                    <mrow>
+                        <msup><mi>L</mi><mi>∞</mi></msup>
+                        <mrow><mo>(</mo><mi>Ω</mi><mo>)</mo></mrow>
+                    </mrow>
+                </msub>
+            </mrow>
+            <mo>,</mo>
+            <mrow>
+                <mo>∥</mo><mi>u</mi>
+                <msub>
+                    <mo>∥</mo>
+                    <mrow>
+                        <msup><mi>W</mi><mrow><mn>1</mn><mo>,</mo><mi>∞</mi></mrow></msup>
+                        <mrow><mo>(</mo><mi>Ω</mi><mo>)</mo></mrow>
+                    </mrow>
+                </msub>
+            </mrow>
+            <mo>,</mo>
+            <mrow>
+                <mo>∥</mo><mi>a</mi><msubsup><mo>∥</mo><mi>F</mi><mn>2</mn></msubsup>
+            </mrow>
+        </math>
+    "#;
+    test(
+        "pl",
+        "ClearSpeak",
+        expr,
+        "norma od 1 do nieskończoności z a, przecinek; norma od 1 do nieskończoności z a, przecinek; norma wielka l do potęgi nieskończoność, z wielka omega z f; przecinek; norma wielka w do potęgi 1 przecinek, nieskończoność, z wielka omega z u; przecinek; norma Frobeniusa z a do potęgi 2",
+    )?;
+    Ok(())
+}
+
+#[test]
+fn clearspeak_powered_word_norms_are_polish() -> Result<()> {
+    let expr = r#"
+        <math>
+            <mrow>
+                <mfrac><mn>1</mn><mn>2</mn></mfrac>
+                <mo>&#x2062;</mo>
+                <mo>∥</mo><mi>a</mi><mi>x</mi><mo>-</mo><mi>b</mi>
+                <msubsup><mo>∥</mo><mn>2</mn><mn>2</mn></msubsup>
+                <mo>+</mo>
+                <mi>λ</mi><mo>&#x2062;</mo>
+                <mo>∥</mo><mi>w</mi><msub><mo>∥</mo><mn>1</mn></msub>
+            </mrow>
+            <mo>,</mo>
+            <mrow>
+                <mi>p</mi><mo>∥</mo><mi>q</mi>
+            </mrow>
+        </math>
+    "#;
+    test(
+        "pl",
+        "ClearSpeak",
+        expr,
+        "jedna druga norma 2 z, a x minus b, do kwadratu plus lambda norma 1 z w; przecinek; p jest równoległe do q",
+    )?;
+    Ok(())
+}
+
+#[test]
+fn simplespeak_powered_word_norms_are_polish() -> Result<()> {
+    let expr = r#"
+        <math>
+            <mrow>
+                <mfrac><mn>1</mn><mn>2</mn></mfrac>
+                <mo>&#x2062;</mo>
+                <mo>∥</mo><mi>a</mi><mi>x</mi><mo>-</mo><mi>b</mi>
+                <msubsup><mo>∥</mo><mn>2</mn><mn>2</mn></msubsup>
+                <mo>+</mo>
+                <mi>λ</mi><mo>&#x2062;</mo>
+                <mo>∥</mo><mi>w</mi><msub><mo>∥</mo><mn>1</mn></msub>
+            </mrow>
+            <mo>,</mo>
+            <mrow>
+                <mi>p</mi><mo>∥</mo><mi>q</mi>
+            </mrow>
+        </math>
+    "#;
+    test(
+        "pl",
+        "SimpleSpeak",
+        expr,
+        "jedna druga norma 2 z, a x minus b, do kwadratu plus lambda norma 1 z w; przecinek; p jest równoległe do q",
+    )?;
+    Ok(())
+}
+
+#[test]
+fn clearspeak_named_math_words() -> Result<()> {
+    let expr = r#"
+        <math>
+            <mi>rank</mi><mo>&#x2061;</mo><mrow><mo>(</mo><mi>a</mi><mo>)</mo></mrow>
+            <mo>+</mo>
+            <mi>nullity</mi><mo>&#x2061;</mo><mrow><mo>(</mo><mi>a</mi><mo>)</mo></mrow>
+            <mo>=</mo>
+            <mrow><mi>p</mi><mtext> prime</mtext></mrow>
+        </math>
+    "#;
+    test(
+        "pl",
+        "ClearSpeak",
+        expr,
+        "rząd z a plus wymiar jądra z a; równa się p pierwsze",
+    )?;
+    Ok(())
+}
+
+#[test]
+fn subscripted_function_application_with_invisible_times_is_polish() -> Result<()> {
+    let expr = r#"
+        <math>
+            <mrow>
+                <msub><mi>σ</mi><mi>i</mi></msub>
+                <mo>&#x2062;</mo>
+                <mrow><mo>(</mo><mi>A</mi><mo>)</mo></mrow>
+            </mrow>
+            <mo>,</mo>
+            <mrow>
+                <mn>2</mn>
+                <mo>&#x2062;</mo>
+                <mrow><mo>(</mo><mi>x</mi><mo>+</mo><mn>1</mn><mo>)</mo></mrow>
+            </mrow>
+            <mo>,</mo>
+            <mrow>
+                <msub><mi>σ</mi><mi>i</mi></msub>
+                <mo>&#x2061;</mo>
+                <mi>A</mi>
+            </mrow>
+            <mo>,</mo>
+            <mrow>
+                <munderover>
+                    <mo>∑</mo>
+                    <mi>i</mi>
+                    <mrow><msub><mi>σ</mi><mi>i</mi></msub></mrow>
+                </munderover>
+                <mo>&#x2062;</mo>
+                <mrow><mo>(</mo><mi>A</mi><mo>)</mo></mrow>
+            </mrow>
+        </math>
+    "#;
+    test(
+        "pl",
+        "ClearSpeak",
+        expr,
+        "sigma indeks dolny i, z wielka a; przecinek; 2 razy, nawias otwierający, x plus 1, nawias zamykający; przecinek; sigma indeks dolny i, z wielka a; przecinek; suma od i, do sigma indeks dolny i; z wielka a",
+    )?;
+    test_ClearSpeak_prefs(
+        "pl",
+        vec![("ClearSpeak_Functions", "None")],
+        expr,
+        "sigma indeks dolny i, z wielka a; przecinek; 2 razy, nawias otwierający, x plus 1, nawias zamykający; przecinek; sigma indeks dolny i, z wielka a; przecinek; suma od i, do sigma indeks dolny i; z wielka a",
+    )?;
+    test(
+        "pl",
+        "SimpleSpeak",
+        expr,
+        "sigma indeks dolny i, z wielka a; przecinek; 2 razy, nawias otwierający, x plus 1, nawias zamykający; przecinek; sigma indeks dolny i, z wielka a; przecinek; suma od i, do sigma indeks dolny i; z wielka a",
+    )?;
+    Ok(())
+}
+
+#[test]
+fn clearspeak_determinant_with_vertical_bars() -> Result<()> {
+    let expr = r#"
+        <math>
+            <mrow>
+                <mo>|</mo>
+                <mtable>
+                    <mtr><mtd><mi>a</mi></mtd><mtd><mi>b</mi></mtd></mtr>
+                    <mtr><mtd><mi>c</mi></mtd><mtd><mi>d</mi></mtd></mtr>
+                </mtable>
+                <mo>|</mo>
+            </mrow>
+        </math>
+    "#;
+    test_prefs(
+        "pl",
+        "ClearSpeak",
+        vec![("Verbosity", "Verbose")],
+        expr,
+        "2 na 2 wyznacznik; wiersz 1; a, b; wiersz 2; c, d; koniec wyznacznika",
+    )?;
+    Ok(())
+}
+
+
+// =====================================================================
+// Testy regresji: normy z podwojna kreska U+2225 generowane przez pandoc
+// (oba ograniczniki ∥ jako form="postfix"). Poprawka: ∥ dostal warianty
+// LEFT/RIGHT_FENCE w operator-info.in, dzieki czemu norma paruje sie i
+// staje sie nawigowalnym intentem 'norm'/'subscripted-norm'. Patrz tez
+// usuniecie pustych 'ot: ""' (psuly nawigacje zagniezdzonych wezlow).
+// =====================================================================
+
+#[test]
+fn norma_pandoc_prosta() -> Result<()> {
+    // \|x\| -> oba ∥ jako postfix (jak generuje pandoc)
+    let expr = r#"<math><mrow>
+        <mo stretchy="false" form="postfix">&#x2225;</mo>
+        <mi>x</mi>
+        <mo stretchy="false" form="postfix">&#x2225;</mo>
+    </mrow></math>"#;
+    test("pl", "ClearSpeak", expr, "norma z x")?;
+    Ok(())
+}
+
+#[test]
+fn norma_pandoc_z_indeksem() -> Result<()> {
+    // \|x\|_p
+    let expr = r#"<math><mrow>
+        <mo stretchy="false" form="postfix">&#x2225;</mo>
+        <mi>x</mi>
+        <msub><mo stretchy="false" form="postfix">&#x2225;</mo><mi>p</mi></msub>
+    </mrow></math>"#;
+    test("pl", "ClearSpeak", expr, "norma p z x")?;
+    Ok(())
+}
+
+#[test]
+fn norma_pandoc_frobeniusa() -> Result<()> {
+    // \|A\|_F
+    let expr = r#"<math><mrow>
+        <mo stretchy="false" form="postfix">&#x2225;</mo>
+        <mi>A</mi>
+        <msub><mo stretchy="false" form="postfix">&#x2225;</mo><mi>F</mi></msub>
+    </mrow></math>"#;
+    test("pl", "ClearSpeak", expr, "norma Frobeniusa z wielka a")?;
+    Ok(())
+}
+
+#[test]
+fn norma_pandoc_gwiazdkowa() -> Result<()> {
+    // \|A\|_*
+    let expr = r#"<math><mrow>
+        <mo stretchy="false" form="postfix">&#x2225;</mo>
+        <mi>A</mi>
+        <msub><mo stretchy="false" form="postfix">&#x2225;</mo><mo>*</mo></msub>
+    </mrow></math>"#;
+    test("pl", "ClearSpeak", expr, "norma gwiazdkowa z wielka a")?;
+    Ok(())
+}
+
+#[test]
+fn rownoleglosc_nie_jest_norma() -> Result<()> {
+    // TEST NEGATYWNY: a ∥ b (pojedynczy ∥ jako relacja) NIE moze byc norma
+    let expr = r#"<math><mrow><mi>a</mi><mo>&#x2225;</mo><mi>b</mi></mrow></math>"#;
+    test("pl", "ClearSpeak", expr, "a jest równoległe do b")?;
+    Ok(())
+}

--- a/tests/languages.rs
+++ b/tests/languages.rs
@@ -8,6 +8,7 @@ mod Languages {
     mod en;
         mod ru;
     mod fi;
+    mod pl;
     mod sv;
     mod nb;
     mod de;


### PR DESCRIPTION
This PR adds a Polish localization for MathCAT's speech and navigation rules.

What's included (all under `Rules/Languages/pl/`, 13 rule files):
- ClearSpeak_Rules.yaml, SimpleSpeak_Rules.yaml
- SharedRules/ (default, general, geometry, linear-algebra, calculus)
- definitions.yaml, unicode.yaml, unicode-full.yaml, intent.yaml, navigate.yaml, overview.yaml

Plus regression tests:
- tests/Languages/pl.rs -- Polish rule regression tests
- tests/languages.rs -- registers the pl test module

Notes:
- No changes to the engine core (src/ untouched).
- Written against the crate version currently on main (0.7.6-beta.5).
- The rules have been extensively tested against corpora generated via pandoc and against real-world MathML from Wikipedia (Mathoid). Continuous reading is correct across all tested domains; the remaining known navigation limitations for a handful of nested-norm (U+2225) and degree (degC) cases are language-independent core-navigation behaviors (see e.g. #415), not specific to these rules.

Happy to adjust anything based on your review.