### PR TITLE
fix: distinguish principal value Log in speech

### DIFF
--- a/Rules/Languages/en/SharedRules/general.yaml
+++ b/Rules/Languages/en/SharedRules/general.yaml
@@ -465,9 +465,9 @@
       else: [t: "covariance"]      # phrase('covariance' function)
 
 -
-  name: log    # handle both log and ln (if in an mrow, 'intents' are used)
+  name: log    # handle log, principal Log, and ln (if in an mrow, 'intents' are used)
   tag: mi
-  match: ".='log' or .='ln'"
+  match: ".='log' or .='Log' or .='ln'"
   replace:
   - bookmark: "@id"
   - test:
@@ -476,6 +476,8 @@
   - test:
     - if: ".= 'log'"
       then: [t: "log"]      # phrase(the 'log' function is used in mathematics)
+    - else_if: ".= 'Log'"
+      then: [t: "principal value log"]
     - else_if: "$Verbosity='Terse'"
       then: [spell: "'ln'"]
       else: [t: "natural log"]      # phrase(the 'natural log' function is used in mathematics)

--- a/tests/Languages/en/ClearSpeak/functions.rs
+++ b/tests/Languages/en/ClearSpeak/functions.rs
@@ -110,6 +110,14 @@ fn simple_log() -> Result<()> {
 }
 
 #[test]
+fn principal_value_log() -> Result<()> {
+    let expr = "<math><mrow><mi>Log</mi><mi>z</mi></mrow></math>";
+    test("en", "ClearSpeak", expr, "the principal value log of z")?;
+    return Ok(());
+
+}
+
+#[test]
 fn normal_log() -> Result<()> {
     let expr = "<math><mrow><mi>log</mi><mrow><mo>(</mo><mrow><mi>x</mi><mo>+</mo><mi>y</mi></mrow><mo>)</mo></mrow></mrow></math>";
     test("en", "ClearSpeak", expr, "the log of, open paren x plus y, close paren")?;

--- a/tests/Languages/en/SimpleSpeak/functions.rs
+++ b/tests/Languages/en/SimpleSpeak/functions.rs
@@ -92,6 +92,14 @@ fn simple_log() -> Result<()> {
 }
 
 #[test]
+fn principal_value_log() -> Result<()> {
+    let expr = "<math><mrow><mi>Log</mi><mi>z</mi></mrow></math>";
+    test("en", "SimpleSpeak", expr, "the principal value log of z")?;
+    return Ok(());
+
+}
+
+#[test]
 fn normal_log() -> Result<()> {
     let expr = "<math><mrow><mi>log</mi><mrow><mo>(</mo><mrow><mi>x</mi><mo>+</mo><mi>y</mi></mrow><mo>)</mo></mrow></mrow></math>";
     test("en", "SimpleSpeak", expr, "the log of, open paren x plus y, close paren")?;


### PR DESCRIPTION
## Summary

- I added English speech handling for uppercase `Log` as the principal-value logarithm.
- I added regression coverage for both SimpleSpeak and ClearSpeak.
- Lowercase `log` behavior remains unchanged.

## Validation

- `cargo test Languages::en::SimpleSpeak::functions -- --nocapture` (35 passed)
- `cargo test Languages::en::ClearSpeak::functions -- --nocapture` (49 passed)
- `git diff --check upstream/main...HEAD`

I left the full repository build and test suite to CI to keep local validation focused on the changed English speech path.

Fixes #637
