### PR TITLE
Expand Polish test suite (56 -> 605) and fix plural declension in multi-line equations

### DIFF
--- a/Rules/Languages/pl/ClearSpeak_Rules.yaml
+++ b/Rules/Languages/pl/ClearSpeak_Rules.yaml
@@ -631,36 +631,59 @@
   - LineCount: "count(*[not(contains(@data-intent-property, ':continued-row:'))])"
   - NextLineIsContinuedRow: "false()"   # default value
   - IsColumnSilent: true()
+  # Polish plural declension category of $LineCount: singular (1), paucal (2-4
+  # except 12-14 -> nominative plural), otherwise genitive plural.
+  - Paucal: "($LineCount mod 10 = 2 or $LineCount mod 10 = 3 or $LineCount mod 10 = 4) and not($LineCount mod 100 = 12 or $LineCount mod 100 = 13 or $LineCount mod 100 = 14)"
+  - IsCase: "($ClearSpeak_MultiLineLabel = 'Auto' and self::m:piecewise) or $ClearSpeak_MultiLineLabel = 'Case'"
+  - IsLine: "not($IsCase) and ($ClearSpeak_MultiLineLabel = 'Auto' or $ClearSpeak_MultiLineLabel = 'Line' or $ClearSpeak_MultiLineLabel = 'None')"
   replace:
   - test:
     - if: "$ClearSpeak_MultiLineOverview = 'Auto'"
       then:
       - x: "$LineCount"
       - test:
-        - if: "$LineCount != 1 and (($ClearSpeak_MultiLineLabel = 'Auto' and self::m:piecewise) or $ClearSpeak_MultiLineLabel = 'Case')"
-          then: [t: "przypadki"]      # phrase(this is the first 'case' of three cases)
-        - else_if: "$LineCount != 1 and ($ClearSpeak_MultiLineLabel = 'Auto' or $ClearSpeak_MultiLineLabel = 'Line' or $ClearSpeak_MultiLineLabel = 'None')"
-          then: [t: "linie"]      # phrase(this is the first 'line' of three lines)
-        - else_if: "$LineCount != 1 and $ClearSpeak_MultiLineLabel = 'Constraint'"
-          then: [t: "warunki"]      # phrase(this is the first 'constraint' of three constraints)
-        - else_if: "$LineCount != 1 and $ClearSpeak_MultiLineLabel = 'Equation'"
-          then: [t: "równania"]      # phrase(this is the first 'equation' of three equations)
-        - else_if: "$LineCount != 1 and $ClearSpeak_MultiLineLabel = 'Row'"
-          then: [T: "wiersze"]      # phrase(this is the first 'row' of three rows)
-        - else_if: "$LineCount != 1 and $ClearSpeak_MultiLineLabel = 'Step'"
-          then: [t: "kroki"]      # phrase(this is the first 'step' of three steps)
-        - else_if: "($ClearSpeak_MultiLineLabel = 'Auto' and self::m:piecewise) or $ClearSpeak_MultiLineLabel = 'Case'"
-          then: [t: "przypadek"]      # phrase(this is the first 'case' of three cases)
-        - else_if: "$ClearSpeak_MultiLineLabel = 'Auto' or $ClearSpeak_MultiLineLabel = 'Line' or $ClearSpeak_MultiLineLabel = 'None'" # already dealt with Auto/Case
-          then: [t: "linia"]      # phrase(this is the first 'line' of three lines)
+        - if: "$IsCase"
+          then_test:
+            - if: "$LineCount = 1"
+              then: [t: "przypadek"]      # phrase(this is the first 'case' of three cases)
+            - else_if: "$Paucal"
+              then: [t: "przypadki"]      # phrase(there are 'two cases' to consider)
+              else: [t: "przypadków"]      # phrase(there are 'five cases' to consider)
+        - else_if: "$IsLine"
+          then_test:
+            - if: "$LineCount = 1"
+              then: [t: "linia"]      # phrase(this is the first 'line' of three lines)
+            - else_if: "$Paucal"
+              then: [t: "linie"]      # phrase(there are 'two lines' shown)
+              else: [t: "linii"]      # phrase(there are 'five lines' shown)
         - else_if: "$ClearSpeak_MultiLineLabel = 'Constraint'"
-          then: [t: "warunek"]      # phrase(this is the first 'constraint' of three constraints)
+          then_test:
+            - if: "$LineCount = 1"
+              then: [t: "warunek"]      # phrase(this is the first 'constraint' of three constraints)
+            - else_if: "$Paucal"
+              then: [t: "warunki"]      # phrase(there are 'two constraints' to satisfy)
+              else: [t: "warunków"]      # phrase(there are 'five constraints' to satisfy)
         - else_if: "$ClearSpeak_MultiLineLabel = 'Equation'"
-          then: [t: "równanie"]      # phrase(this is the first 'equation' of three equations)
+          then_test:
+            - if: "$LineCount = 1"
+              then: [t: "równanie"]      # phrase(this is the first 'equation' of three equations)
+            - else_if: "$Paucal"
+              then: [t: "równania"]      # phrase(there are 'two equations' to solve)
+              else: [t: "równań"]      # phrase(there are 'five equations' to solve)
         - else_if: "$ClearSpeak_MultiLineLabel = 'Row'"
-          then: [T: "wiersz"]      # phrase(this is the first 'row' of three rows)
+          then_test:
+            - if: "$LineCount = 1"
+              then: [T: "wiersz"]      # phrase(this is the first 'row' of three rows)
+            - else_if: "$Paucal"
+              then: [T: "wiersze"]      # phrase(there are 'two rows' shown)
+              else: [T: "wierszy"]      # phrase(there are 'five rows' shown)
         - else_if: "$ClearSpeak_MultiLineLabel = 'Step'"
-          then: [t: "krok"]      # phrase(this is the first 'step' of three steps)
+          then_test:
+            - if: "$LineCount = 1"
+              then: [t: "krok"]      # phrase(this is the first 'step' of three steps)
+            - else_if: "$Paucal"
+              then: [t: "kroki"]      # phrase(there are 'two steps' to follow)
+              else: [t: "kroków"]      # phrase(there are 'five steps' to follow)
           # else 'None -- don't say anything'
       - pause: short
   - x: "*"

--- a/Rules/Languages/pl/SharedRules/general.yaml
+++ b/Rules/Languages/pl/SharedRules/general.yaml
@@ -544,15 +544,32 @@
   - IsColumnSilent: true()
   replace:
   - x: "$LineCount"
+  # Polish plural declension of the counted noun: 1 -> singular; 2-4 (but not
+  # 12-14) -> paucal; otherwise genitive plural. Applied per row-type.
   - test:
-    - if: "self::m:piecewise"
-      then: [t: "przypadek"]      # phrase(this is the first 'case' of three cases)
-    - else_if: "self::m:system-of-equations"
-      then: [t: "równanie"]      # phrase(this is the first 'equation' of three equations)
-      else: [t: "linia"]      # phrase(this is the first 'line' of three lines)
-  - test:
-    - if: "$LineCount != 1"
-      then: [ct: "s"] # plural
+    - if: "$LineCount = 1"
+      then:
+      - test:
+        - if: "self::m:piecewise"
+          then: [t: "przypadek"]      # phrase(this is the first 'case' of three cases)
+        - else_if: "self::m:system-of-equations"
+          then: [t: "równanie"]      # phrase(this is the first 'equation' of three equations)
+          else: [t: "linia"]      # phrase(this is the first 'line' of three lines)
+    - else_if: "($LineCount mod 10 = 2 or $LineCount mod 10 = 3 or $LineCount mod 10 = 4) and not($LineCount mod 100 = 12 or $LineCount mod 100 = 13 or $LineCount mod 100 = 14)"
+      then:
+      - test:
+        - if: "self::m:piecewise"
+          then: [t: "przypadki"]      # phrase(there are 'two cases' to consider)
+        - else_if: "self::m:system-of-equations"
+          then: [t: "równania"]      # phrase(there are 'two equations' to solve)
+          else: [t: "linie"]      # phrase(there are 'two lines' shown)
+    - else:
+      - test:
+        - if: "self::m:piecewise"
+          then: [t: "przypadków"]      # phrase(there are 'five cases' to consider)
+        - else_if: "self::m:system-of-equations"
+          then: [t: "równań"]      # phrase(there are 'five equations' to solve)
+          else: [t: "linii"]      # phrase(there are 'five lines' shown)
   - pause: short
   - x: "*"
   - pause: long

--- a/tests/Languages/pl.rs
+++ b/tests/Languages/pl.rs
@@ -1,3 +1,35 @@
 #![allow(non_snake_case)]
 
+// Existing hand-written Polish tests (norms, degrees, relations, etc.)
 mod pl;
+
+// Tests mirrored from the English suite, with expected speech localized to Polish.
+mod ClearSpeak {
+    mod functions;
+    mod large_ops;
+    mod menclose;
+    mod mfrac;
+    mod mroot;
+    mod msup;
+    mod sets;
+    mod symbols_and_adornments;
+    mod multiline;
+}
+
+mod SimpleSpeak {
+    mod functions;
+    mod large_ops;
+    mod mfrac;
+    mod msup;
+    mod sets;
+    mod geometry;
+    mod linear_algebra;
+    mod multiline;
+    mod subscripts;
+}
+mod shared;
+mod units;
+mod chemistry;
+mod alphabets;
+mod definitions;
+mod mtable;

--- a/tests/Languages/pl/ClearSpeak/functions.rs
+++ b/tests/Languages/pl/ClearSpeak/functions.rs
@@ -1,0 +1,569 @@
+/// Tests for:
+/// *  functions including trig functions, logs, and functions to powers
+/// *  implied times/functional call and explicit times/function call
+/// *  parens
+/// These are all intertwined, so they are in one file
+use crate::common::*;
+use anyhow::Result;
+
+#[test]
+fn trig_names() -> Result<()> {
+    let expr = "<math><mrow>
+    <mi>sin</mi><mi>x</mi><mo>+</mo>
+    <mi>cos</mi><mi>y</mi><mo>+</mo>
+    <mi>tan</mi><mi>z</mi><mo>+</mo>
+    <mi>sec</mi><mi>&#x03B1;</mi><mo>+</mo>
+    <mi>csc</mi><mi>&#x03D5;</mi><mo>+</mo>
+    <mi>cot</mi><mi>&#x03C6;</mi>
+    </mrow></math>";
+    test("pl", "ClearSpeak", expr, "sinus x plus cosinus y plus tangens z plus sekans alfa, plus kosekans fi, plus cotangens fi")?;
+    return Ok(());
+
+}
+
+#[test]
+fn hyperbolic_trig_names() -> Result<()> {
+    let expr = "<math><mrow>
+    <mi>sinh</mi><mi>x</mi><mo>+</mo>
+    <mi>cosh</mi><mi>y</mi><mo>+</mo>
+    <mi>tanh</mi><mi>z</mi><mo>+</mo>
+    <mi>sech</mi><mi>&#x03B1;</mi><mo>+</mo>
+    <mi>csch</mi><mi>&#x03D5;</mi><mo>+</mo>
+    <mi>coth</mi><mi>&#x03C6;</mi>
+    </mrow></math>";
+    test("pl", "ClearSpeak", expr, "sinus hiperboliczny z x, plus cosinus hiperboliczny z y, plus tangens hiperboliczny z z, plus sekans hiperboliczny z alfa, plus kosekans hiperboliczny z fi, plus cotangens hiperboliczny z fi")?;
+                                return Ok(());
+
+}
+
+
+#[test]
+fn inverse_trig() -> Result<()> {
+    let expr = "<math><msup><mi>sin</mi><mrow><mo>-</mo><mn>1</mn></mrow></msup><mi>x</mi></math>";
+    test("pl", "ClearSpeak", expr, "odwrotność sinus z x")?;
+    return Ok(());
+
+}
+
+#[test]
+fn inverse_trig_trig_inverse() -> Result<()> {
+    let expr = "<math><msup><mi>tan</mi><mrow><mo>-</mo><mn>1</mn></mrow></msup><mi>x</mi></math>";
+    test_ClearSpeak("pl", "ClearSpeak_Trig", "TrigInverse",expr,
+        "tangens odwrotność z x")?;
+        return Ok(());
+
+}
+
+#[test]
+fn inverse_trig_arc() -> Result<()> {
+    let expr = "<math><msup><mi>cosh</mi><mrow><mo>-</mo><mn>1</mn></mrow></msup><mi>x</mi></math>";
+    test_ClearSpeak("pl", "ClearSpeak_Trig", "ArcTrig",expr,
+        "łuk cosinus hiperboliczny z x")?;
+        return Ok(());
+
+}
+
+#[test]
+fn trig_squared() -> Result<()> {
+    let expr = "<math><msup><mi>sin</mi><mn>2</mn></msup><mi>x</mi></math>";
+    test("pl", "ClearSpeak", expr, "sinus do kwadratu z x")?;
+    return Ok(());
+
+}
+
+#[test]
+fn trig_cubed() -> Result<()> {
+    let expr = "<math><msup><mi>tan</mi><mn>3</mn></msup><mi>x</mi></math>";
+    test("pl", "ClearSpeak", expr, "tangens do sześcianu z x")?;
+    return Ok(());
+
+}
+
+#[test]
+fn trig_fourth() -> Result<()> {
+    let expr = "<math><msup><mi>sec</mi><mn>4</mn></msup><mi>x</mi></math>";
+    test("pl", "ClearSpeak", expr, "sekans do potęgi czwartej, z x")?;
+    return Ok(());
+
+}
+
+
+#[test]
+fn trig_power_other() -> Result<()> {
+    let expr = "<math><msup><mi>sinh</mi><mrow>><mi>n</mi><mo>-</mo><mn>1</mn></mrow></msup><mi>x</mi></math>";
+    test("pl", "ClearSpeak", expr, "sinus hiperboliczny do potęgi n minus 1, z x")?;
+    return Ok(());
+
+}
+
+#[test]
+fn simple_log() -> Result<()> {
+    let expr = "<math> <mrow>  <mi>log</mi><mi>x</mi></mrow> </math>";
+    test("pl", "ClearSpeak", expr, "logarytm x")?;
+    return Ok(());
+
+}
+
+#[test]
+fn principal_value_log() -> Result<()> {
+    let expr = "<math><mrow><mi>Log</mi><mi>z</mi></mrow></math>";
+    test("pl", "ClearSpeak", expr, "Log z z")?;
+    return Ok(());
+
+}
+
+#[test]
+fn normal_log() -> Result<()> {
+    let expr = "<math><mrow><mi>log</mi><mrow><mo>(</mo><mrow><mi>x</mi><mo>+</mo><mi>y</mi></mrow><mo>)</mo></mrow></mrow></math>";
+    test("pl", "ClearSpeak", expr, "logarytm z, nawias otwierający, x plus y, nawias zamykający")?;
+    return Ok(());
+
+}
+
+#[test]
+fn simple_log_with_base() -> Result<()> {
+    let expr = "<math> <mrow>  <msub><mi>log</mi><mi>b</mi></msub><mi>x</mi></mrow> </math>";
+    test("pl", "ClearSpeak", expr, "logarytm o podstawie b, z x")?;
+    return Ok(());
+
+}
+
+#[test]
+fn normal_log_with_base() -> Result<()> {
+    let expr = "<math><mrow><msub><mi>log</mi><mi>b</mi></msub><mrow><mo>(</mo><mrow><mi>x</mi><mo>+</mo><mi>y</mi></mrow><mo>)</mo></mrow></mrow></math>";
+    test("pl", "ClearSpeak", expr, "logarytm o podstawie b, z, nawias otwierający, x plus y, nawias zamykający")?;
+    return Ok(());
+
+}
+
+#[test]
+fn simple_ln() -> Result<()> {
+    let expr = "<math> <mrow>  <mi>ln</mi><mi>x</mi></mrow> </math>";
+    test("pl", "ClearSpeak", expr, "l n x")?;
+    return Ok(());
+
+}
+
+#[test]
+fn normal_ln() -> Result<()> {
+    let expr = "<math><mrow><mi>ln</mi><mrow><mo>(</mo><mrow><mi>x</mi><mo>+</mo><mi>y</mi></mrow><mo>)</mo></mrow></mrow></math>";
+    test("pl", "ClearSpeak", expr, "l n z, nawias otwierający, x plus y, nawias zamykający")?;
+    return Ok(());
+
+}
+
+    
+#[test]
+fn simple_natural_log() -> Result<()> {
+    let expr = "<math> <mrow>  <mi>ln</mi><mi>x</mi></mrow> </math>";
+    test_ClearSpeak("pl", "ClearSpeak_Log", "LnAsNaturalLog",expr,
+        "logarytm naturalny x")?;
+        return Ok(());
+
+}
+
+    
+#[test]
+fn natural_log() -> Result<()> {
+    let expr = "<math><mi>ln</mi><mo>(</mo><mi>x</mi><mo>+</mo><mi>y</mi><mo>)</mo></math>";
+    test_ClearSpeak("pl", "ClearSpeak_Log", "LnAsNaturalLog",expr,
+        "logarytm naturalny z, nawias otwierający, x plus y, nawias zamykający")?;
+        return Ok(());
+
+}
+
+
+#[test]
+fn explicit_function_call_with_parens() -> Result<()> {
+    let expr = "<math><mrow><mi>t</mi><mo>&#x2061;</mo><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>";
+    test("pl", "ClearSpeak", expr, "t z x")?;
+    return Ok(());
+
+}
+
+
+#[test]
+fn explicit_times_with_parens() -> Result<()> {
+    let expr = "<math><mrow><mi>t</mi><mo>&#x2062;</mo><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>";
+    test("pl", "ClearSpeak", expr, "t razy x")?;
+    return Ok(());
+
+}
+
+#[test]
+fn explicit_function_call() -> Result<()> {
+    let expr = "<math><mrow><mi>t</mi><mo>&#x2061;</mo><mrow><mi>x</mi></mrow></mrow></math>";
+    test("pl", "ClearSpeak", expr, "t z x")?;
+    return Ok(());
+
+}
+
+#[test]
+fn explicit_times() -> Result<()> {
+    let expr = "<math><mrow><mi>t</mi><mo>&#x2062;</mo><mrow><mi>x</mi></mrow></mrow></math>";
+    test("pl", "ClearSpeak", expr, "t x")?;
+    return Ok(());
+
+}
+
+
+#[test]
+fn test_functions_none_pref() -> Result<()> {
+    let expr = "<math>
+    <mi>log</mi><mo>&#x2061;</mo><mrow><mo>(</mo><mrow><mi>x</mi><mo>+</mo><mi>y</mi></mrow><mo>)</mo></mrow>
+    <mo>+</mo>
+    <mi>f</mi><mo>&#x2061;</mo><mrow><mo>(</mo><mrow><mi>x</mi><mo>+</mo><mi>y</mi></mrow><mo>)</mo></mrow>
+    </math>";
+    test_ClearSpeak("pl", "ClearSpeak_Functions", "None",expr,
+        "logarytm z, nawias otwierający, x plus y, nawias zamykający; plus; f razy, nawias otwierający, x plus y, nawias zamykający")?;
+        return Ok(());
+
+}
+
+#[test]
+fn test_functions_none_pref_multiple_args() -> Result<()> {
+    let expr = "<math>
+        <mi>B</mi> <mrow><mo>(</mo> <mrow> <mn>2</mn><mo>,</mo><mn>6</mn></mrow> <mo>)</mo></mrow>
+    </math>";
+    test_ClearSpeak("pl", "ClearSpeak_Functions", "None",expr,
+        "wielka b razy, nawias otwierający, 2 przecinek, 6, nawias zamykający")?;
+        return Ok(());
+
+}
+
+
+/*
+    * Tests for times
+    */
+#[test]
+fn no_times_binomial() -> Result<()> {
+    let expr = "<math><mrow><mi>x</mi> <mo>&#x2062;</mo> <mi>y</mi></mrow></math>";
+    test("pl", "ClearSpeak", expr, "x y")?;
+    return Ok(());
+
+}
+
+#[test]
+fn times_following_paren() -> Result<()> {
+    let expr = "<math><mrow>
+        <mn>2</mn>
+        <mrow>  <mo>(</mo> <mn>3</mn>  <mo>)</mo> </mrow>
+        </mrow></math>";
+    test("pl", "ClearSpeak", expr, "2 razy 3")?;
+    return Ok(());
+
+}
+
+#[test]
+fn times_preceding_paren() -> Result<()> {
+    let expr = "<math><mrow>
+        <mrow>  <mo>(</mo> <mn>2</mn>  <mo>)</mo> </mrow>
+        <mn>3</mn>
+        </mrow></math>";
+    test("pl", "ClearSpeak", expr, "2 razy 3")?;
+    return Ok(());
+
+}
+
+#[test]
+fn times_sqrt() -> Result<()> {
+    let expr = "<math><mrow>
+        <msqrt> <mi>a</mi>  </msqrt>
+        <msqrt> <mi>b</mi>  </msqrt>
+        <mo>=</mo>
+        <msqrt> <mrow>  <mi>a</mi><mi>b</mi></mrow> </msqrt>
+        </mrow></math>";
+    test("pl", "ClearSpeak", expr, "pierwiastek kwadratowy z a; razy pierwiastek kwadratowy z b; równa się, pierwiastek kwadratowy z a b")?;
+    return Ok(());
+
+}
+
+#[test]
+fn more_implied_times() -> Result<()> {
+    let expr = "<math><mrow>
+    <mrow>
+    <msup>
+        <mrow>
+        <mrow><mo>(</mo>
+        <mrow> <mn>2</mn><mi>x</mi></mrow>
+        <mo>)</mo></mrow></mrow>
+        <mn>2</mn>
+    </msup>
+    </mrow>
+    </mrow></math>";
+    test_ClearSpeak("pl", "ClearSpeak_ImpliedTimes", "MoreImpliedTimes",expr,
+        "nawias otwierający, 2 razy x, nawias zamykający do kwadratu")?;
+        return Ok(());
+
+}
+
+#[test]
+fn explicit_times_more_implied_times() -> Result<()> {
+    let expr = "<math><mrow><mi>t</mi><mo>&#x2062;</mo><mrow><mi>x</mi></mrow></mrow></math>";
+    test_ClearSpeak("pl", "ClearSpeak_ImpliedTimes", "MoreImpliedTimes",expr, "t razy x")?;
+    return Ok(());
+
+}
+
+#[test]
+fn explicit_times_none_simple_right() -> Result<()> {
+    let expr = "<math><mn>2</mn><mo>[</mo><mn>3</mn> <mo>]</mo></math>";
+    test_ClearSpeak("pl", "ClearSpeak_ImpliedTimes", "None",
+        expr, "2, nawias kwadratowy otwierający 3 nawias kwadratowy zamykający")?;
+        return Ok(());
+
+}
+
+#[test]
+fn explicit_times_none_simple_left() -> Result<()> {
+    let expr = "<math><mo>(</mo><mn>2</mn><mo>&#x2212;</mo><mn>1</mn><mo>)</mo><mi>x</mi></math>";
+    test_ClearSpeak("pl", "ClearSpeak_ImpliedTimes", "None",
+        expr, "nawias otwierający, 2 minus 1, nawias zamykający; x")?;
+        return Ok(());
+
+}
+
+#[test]
+fn explicit_times_none_superscript() -> Result<()> {
+    let expr = "<math> 
+    <mi>f</mi><mo>(</mo><mi>x</mi><mo>)</mo><mo>=</mo><msup>
+<mi>x</mi>
+<mn>2</mn>
+</msup>
+<mrow><mo>(</mo>
+<mrow>
+<mi>x</mi><mo>+</mo><mn>1</mn></mrow>
+<mo>)</mo></mrow>
+    </math>";
+    test_ClearSpeak_prefs("pl", 
+        vec![("ClearSpeak_ImpliedTimes", "None"), ("ClearSpeak_Functions", "None")],
+        expr, "f, nawias otwierający x nawias zamykający; równa się; x do kwadratu, nawias otwierający, x plus 1, nawias zamykający")?;
+        return Ok(());
+
+}
+
+/*
+    * Tests for parens
+    */
+    #[test]
+    fn no_parens_number() -> Result<()> {
+        let expr = "<math><mrow>
+        <mrow><mo>(</mo>
+        <mn>25</mn>
+        <mo>)</mo></mrow>
+        <mi>x</mi>
+        </mrow></math>";
+        test("pl", "ClearSpeak", expr, "25 razy x")?;
+        return Ok(());
+
+    }
+
+    #[test]
+    fn no_parens_monomial() -> Result<()> {
+        let expr = "<math><mrow>
+        <mi>b</mi>
+        <mrow><mo>(</mo>
+        <mrow><mi>x</mi><mi>y</mi></mrow>
+        <mo>)</mo></mrow>
+        </mrow></math>";
+        test("pl", "ClearSpeak", expr, "b, nawias otwierający, x y nawias zamykający")?;
+        return Ok(());
+
+    }
+
+    #[test]
+    fn no_parens_negative_number() -> Result<()> {
+        let expr = "<math><mrow>
+        <mn>2</mn><mo>+</mo>
+        <mrow><mo>(</mo>
+        <mrow><mo>&#x2212;</mo><mn>2</mn></mrow>
+        <mo>)</mo></mrow>
+        </mrow></math>";
+        test("pl", "ClearSpeak", expr, "2 plus minus 2")?;
+        return Ok(());
+
+    }
+
+
+    #[test]
+    fn no_parens_negative_number_with_var() -> Result<()> {
+        let expr = "<math><mrow>
+        <mrow><mo>(</mo>
+        <mrow><mo>&#x2212;</mo><mn>2</mn></mrow><mi>x</mi>
+        <mo>)</mo>
+        </mrow>
+        <mo>+</mo><mn>1</mn>
+        </mrow></math>";
+        test("pl", "ClearSpeak", expr, "minus 2 x plus 1")?;
+        return Ok(());
+
+    }
+
+    #[test]
+    fn parens_superscript() -> Result<()> {
+        let expr = "<math><mrow>
+        <mrow>
+        <msup>
+        <mrow>
+            <mrow><mo>(</mo>
+            <mrow> <mn>2</mn><mi>x</mi></mrow>
+            <mo>)</mo></mrow></mrow>
+        <mn>2</mn>
+        </msup>
+        </mrow>
+    </mrow></math>";
+        test("pl", "ClearSpeak", expr, "nawias otwierający, 2 x nawias zamykający do kwadratu")?;
+        return Ok(());
+
+    }
+
+    #[test]
+    fn no_parens_fraction() -> Result<()> {
+        let expr = "<math><mrow>
+        <mn>2</mn>
+        <mo>+</mo>
+        <mrow>
+            <mrow><mo>(</mo>
+            <mfrac> <mn>1</mn><mn>2</mn></mfrac>
+            <mo>)</mo></mrow></mrow>
+    </mrow></math>";
+        test("pl", "ClearSpeak", expr, "2 plus jedna druga")?;
+        return Ok(());
+
+    }
+
+
+    // Tests for the ten types of intervals in ClearSpeak
+    #[test]
+    fn parens_interval_open_open() -> Result<()> {
+        let expr = "<math> 
+        <mrow><mo>(</mo>
+        <mrow> <mi>c</mi><mo>,</mo><mi>d</mi></mrow>
+        <mo>)</mo></mrow>
+    </math>";
+    test_ClearSpeak("pl", "ClearSpeak_Paren", "Interval",expr,
+    "przedział otwarty od c do d")?;
+    return Ok(());
+
+}
+
+#[test]
+    fn parens_interval_closed_open() -> Result<()> {
+        let expr = "<math> 
+        <mrow><mo>[</mo>
+        <mrow> <mi>c</mi><mo>,</mo><mi>d</mi></mrow>
+        <mo>)</mo></mrow>
+    </math>";
+    test_ClearSpeak("pl", "ClearSpeak_Paren", "Interval ",expr,
+    "przedział lewostronnie domknięty prawostronnie otwarty od c do d")?;
+    return Ok(());
+
+}
+
+
+#[test]
+fn parens_interval_open_closed() -> Result<()> {
+    let expr = "<math> 
+    <mrow><mo>(</mo>
+        <mrow> <mi>c</mi><mo>,</mo><mi>d</mi></mrow>
+    <mo>]</mo></mrow>
+    </math>";
+    test_ClearSpeak("pl", "ClearSpeak_Paren", "Interval ",expr,
+    "przedział lewostronnie otwarty prawostronnie domknięty od c do d")?;
+    return Ok(());
+
+}
+
+
+#[test]
+fn parens_interval_closed_closed() -> Result<()> {
+    let expr = "<math> 
+    <mrow><mo>[</mo>
+    <mrow> <mi>c</mi><mo>,</mo><mi>d</mi></mrow>
+    <mo>]</mo></mrow>
+</math>";
+test_ClearSpeak("pl", "ClearSpeak_Paren", "Interval ",expr,
+"przedział domknięty od c do d")?;
+return Ok(());
+
+}
+
+    #[test]
+    fn parens_interval_neg_infinity_open_open() -> Result<()> {
+        let expr = "<math> 
+        <mrow><mo>(</mo>
+        <mrow><mo>-</mo> <mi>∞</mi><mo>,</mo><mi>d</mi></mrow>
+        <mo>)</mo></mrow>
+    </math>";
+    test_ClearSpeak("pl", "ClearSpeak_Paren", "Interval ",expr,
+    "przedział otwarty od minus nieskończoność do d")?;
+    return Ok(());
+
+}
+
+    #[test]
+    fn parens_interval_neg_infinity_closed_open() -> Result<()> {
+        let expr = "<math> 
+        <mrow><mo>(</mo>
+        <mrow> <mo>-</mo> <mi>∞</mi><mo>,</mo><mi>d</mi></mrow>
+        <mo>]</mo></mrow>
+    </math>";
+    test_ClearSpeak("pl", "ClearSpeak_Paren", "Interval ",expr,
+    "przedział lewostronnie otwarty prawostronnie domknięty od minus nieskończoność do d")?;
+    return Ok(());
+
+}
+
+
+#[test]
+fn parens_interval_open_open_infinity() -> Result<()> {
+    let expr = "<math> 
+    <mrow><mo>(</mo>
+        <mrow> <mi>c</mi><mo>,</mo><mi>∞</mi></mrow>
+    <mo>)</mo></mrow>
+    </math>";
+    test_ClearSpeak("pl", "ClearSpeak_Paren", "Interval ",expr,
+    "przedział otwarty od c do nieskończoność")?;
+    return Ok(());
+
+}
+
+
+#[test]
+fn parens_interval_closed_open_infinity() -> Result<()> {
+    let expr = "<math> 
+        <mrow><mo>[</mo>
+        <mrow> <mi>c</mi><mo>,</mo><mi>∞</mi></mrow>
+        <mo>)</mo></mrow>
+    </math>";
+    test_ClearSpeak("pl", "ClearSpeak_Paren", "Interval ",expr,
+"przedział lewostronnie domknięty prawostronnie otwarty od c do nieskończoność")?;
+return Ok(());
+
+}
+
+#[test]
+fn parens_interval_neg_infinity_to_infinity() -> Result<()> {
+    let expr = "<math> 
+    <mrow><mo>(</mo>
+        <mrow><mo>-</mo> <mi>∞</mi><mo>,</mo><mi>∞</mi></mrow>
+        <mo>)</mo></mrow>
+    </math>";
+    test_ClearSpeak("pl", "ClearSpeak_Paren", "Interval ",expr,
+    "przedział otwarty od minus nieskończoność do nieskończoność")?;
+    return Ok(());
+
+}
+
+#[test]
+fn parens_interval_neg_infinity_to_pos_infinity() -> Result<()> {
+    let expr = "<math> 
+    <mrow><mo>(</mo>
+        <mrow><mo>-</mo> <mi>∞</mi><mo>,</mo><mo>+</mo><mi>∞</mi></mrow>
+    <mo>)</mo></mrow>
+    </math>";
+    test_ClearSpeak("pl", "ClearSpeak_Paren", "Interval ",expr,
+    "przedział otwarty od minus nieskończoność do plus nieskończoność")?;
+    return Ok(());
+
+}

--- a/tests/Languages/pl/ClearSpeak/large_ops.rs
+++ b/tests/Languages/pl/ClearSpeak/large_ops.rs
@@ -1,0 +1,235 @@
+use crate::common::*;
+use anyhow::Result;
+
+#[test]
+fn sum_both() -> Result<()> {
+    let expr = "<math>
+        <munderover>
+            <mo>∑</mo>
+            <mrow><mi>n</mi><mo>=</mo><mn>1</mn></mrow>
+            <mrow><mn>10</mn></mrow>
+        </munderover>
+        <mi>n</mi>
+    </math>";
+    test("pl", "ClearSpeak", expr, "suma od n równa się 1, do 10; n")?;
+    return Ok(());
+
+}
+
+#[test]
+fn sum_under() -> Result<()> {
+    let expr = "<math>
+        <munder>
+            <mo>∑</mo>
+            <mi>S</mi>
+        </munder>
+        <mi>i</mi>
+    </math>";
+    test("pl", "ClearSpeak", expr, "suma przez wielka s z i")?;
+    return Ok(());
+
+}
+#[test]
+fn sum_both_msubsup() -> Result<()> {
+    let expr = "<math>
+        <msubsup>
+            <mo>∑</mo>
+            <mrow><mi>n</mi><mo>=</mo><mn>1</mn></mrow>
+            <mrow><mn>10</mn></mrow>
+        </msubsup>
+        <mi>n</mi>
+    </math>";
+    test("pl", "ClearSpeak", expr, "suma od n równa się 1, do 10; n")?;
+    return Ok(());
+
+}
+
+#[test]
+fn sum_sub() -> Result<()> {
+    let expr = "<math>
+        <msub>
+            <mo>∑</mo>
+            <mi>S</mi>
+        </msub>
+        <mi>i</mi>
+    </math>";
+    test("pl", "ClearSpeak", expr, "suma przez wielka s z i")?;
+    return Ok(());
+
+}
+
+#[test]
+fn sum() -> Result<()> {
+    let expr = "<math>
+            <mo>∑</mo>
+            <msub><mi>a</mi><mi>i</mi></msub>
+    </math>";
+    test("pl", "ClearSpeak", expr, "suma, a indeks dolny i")?;
+    return Ok(());
+
+}
+
+#[test]
+fn product_both() -> Result<()> {
+    let expr = "<math>
+        <munderover>
+            <mo>∏</mo>
+            <mrow><mi>n</mi><mo>=</mo><mn>1</mn></mrow>
+            <mrow><mn>10</mn></mrow>
+        </munderover>
+        <mi>n</mi>
+    </math>";
+    test("pl", "ClearSpeak", expr, "iloczyn od n równa się 1, do 10; n")?;
+    return Ok(());
+
+}
+
+#[test]
+fn product_under() -> Result<()> {
+    let expr = "<math>
+        <munder>
+            <mo>∏</mo>
+            <mi>S</mi>
+        </munder>
+        <mi>i</mi>
+    </math>";
+    test("pl", "ClearSpeak", expr, "iloczyn przez wielka s z i")?;
+    return Ok(());
+
+}
+
+#[test]
+fn product() -> Result<()> {
+    let expr = "<math>
+            <mo>∏</mo>
+            <msub><mi>a</mi><mi>i</mi></msub>
+    </math>";
+    test("pl", "ClearSpeak", expr, "iloczyn, a indeks dolny i")?;
+    return Ok(());
+
+}
+
+#[test]
+fn intersection_both() -> Result<()> {
+    let expr = "<math>
+        <munderover>
+            <mo>⋂</mo>
+            <mrow><mi>i</mi><mo>=</mo><mn>1</mn> </mrow>
+            <mn>10</mn>
+        </munderover>
+        <msub><mi>S</mi><mi>i</mi></msub>
+    </math>";
+    test("pl", "ClearSpeak", expr, "przecięcie od i równa się 1, do 10; wielka s indeks dolny i")?;
+    return Ok(());
+
+}
+
+#[test]
+fn intersection_under() -> Result<()> {
+    let expr = "<math>
+        <munder>
+            <mo>⋂</mo>
+            <mi>C</mi>
+        </munder>
+        <msub><mi>S</mi><mi>i</mi></msub>
+    </math>";
+    test("pl", "ClearSpeak", expr, "przecięcie przez wielka c z, wielka s indeks dolny i")?;
+    return Ok(());
+
+}
+
+#[test]
+fn intersection() -> Result<()> {
+    let expr = "<math>
+            <mo>⋂</mo>
+            <msub><mi>S</mi><mi>i</mi></msub>
+            </math>";
+    test("pl", "ClearSpeak", expr, "przecięcie, wielka s indeks dolny i")?;
+    return Ok(());
+
+}
+
+#[test]
+fn union_both() -> Result<()> {
+    let expr = "<math>
+        <munderover>
+            <mo>⋃</mo>
+            <mrow><mi>i</mi><mo>=</mo><mn>1</mn> </mrow>
+            <mn>10</mn>
+        </munderover>
+        <msub><mi>S</mi><mi>i</mi></msub>
+    </math>";
+    test("pl", "ClearSpeak", expr, "suma zbiorów od i równa się 1, do 10; wielka s indeks dolny i")?;
+    return Ok(());
+
+}
+
+#[test]
+fn union_under() -> Result<()> {
+    let expr = "<math>
+        <munder>
+            <mo>⋃</mo>
+            <mi>C</mi>
+        </munder>
+        <msub><mi>S</mi><mi>i</mi></msub>
+    </math>";
+    test("pl", "ClearSpeak", expr, "suma zbiorów przez wielka c z, wielka s indeks dolny i")?;
+    return Ok(());
+
+}
+
+#[test]
+fn union() -> Result<()> {
+    let expr = "<math>
+            <mo>⋃</mo>
+            <msub><mi>S</mi><mi>i</mi></msub>
+            </math>";
+    test("pl", "ClearSpeak", expr, "suma zbiorów, wielka s indeks dolny i")?;
+    return Ok(());
+
+}
+
+#[test]
+fn integral_both() -> Result<()> {
+    let expr = "<math>
+            <mrow>
+                <msubsup>
+                    <mo>∫</mo>
+                    <mn>0</mn>
+                    <mn>1</mn>
+                </msubsup>
+                <mrow><mi>f</mi><mrow><mo>(</mo><mi>x</mi> <mo>)</mo></mrow></mrow>
+            </mrow>
+            <mtext>&#x2009;</mtext><mi>d</mi><mi>x</mi>
+        </math>";
+    test("pl", "ClearSpeak", expr, "całka od 0, do 1; f z x; d x")?;
+    return Ok(());
+
+}
+
+#[test]
+fn integral_under() -> Result<()> {
+    let expr = "<math>
+        <munder>
+            <mo>∫</mo>
+            <mi>ℝ</mi>
+        </munder>
+        <mrow><mi>f</mi><mrow><mo>(</mo><mi>x</mi> <mo>)</mo></mrow></mrow>
+        <mi>d</mi><mi>x</mi>
+        </math>";
+    test("pl", "ClearSpeak", expr, "całka przez liczby rzeczywiste z; f z x d x")?;
+    return Ok(());
+
+}
+
+#[test]
+fn integral() -> Result<()> {
+    let expr = "<math>
+            <mo>∫</mo>
+            <mrow><mi>f</mi><mrow><mo>(</mo><mi>x</mi> <mo>)</mo></mrow></mrow>
+            <mi>d</mi><mi>x</mi>
+            </math>";
+    test("pl", "ClearSpeak", expr, "całka, f z x d x")?;
+    return Ok(());
+
+}

--- a/tests/Languages/pl/ClearSpeak/menclose.rs
+++ b/tests/Languages/pl/ClearSpeak/menclose.rs
@@ -1,0 +1,242 @@
+use crate::common::*;
+use anyhow::Result;
+
+#[test]
+fn menclose_actuarial() -> Result<()> {
+    let expr = "<math>
+                    <menclose notation='actuarial'>  <mn>3</mn><mo>+</mo><mn>2</mn><mi>i</mi> </menclose>
+                </math>";
+    test("pl", "ClearSpeak", expr, "symbol aktuarialny, obejmujący 3 plus 2 i koniec obramowania")?;
+    return Ok(());
+
+}
+
+#[test]
+fn menclose_box() -> Result<()> {
+    let expr = "<math>
+                    <menclose notation='box circle'>  <mn>3</mn><mo>+</mo><mn>2</mn><mi>i</mi> </menclose>
+                </math>";
+    test("pl", "ClearSpeak", expr, "ramka, okrąg, obejmujący 3 plus 2 i koniec obramowania")?;
+    return Ok(());
+
+}
+
+#[test]
+fn menclose_left() -> Result<()> {
+    let expr = "<math>
+                    <menclose notation='left'>  <mfrac><mn>3</mn><mn>2</mn></mfrac> </menclose>
+                </math>";
+    test("pl", "ClearSpeak", expr, "linia na lewo, obejmujący 3 drugie koniec obramowania")?;
+    return Ok(());
+
+}
+
+#[test]
+fn menclose_right() -> Result<()> {
+    let expr = "<math>
+                    <menclose notation='right'>  <mfrac><mn>3</mn><mn>2</mn></mfrac> </menclose>
+                </math>";
+    test("pl", "ClearSpeak", expr, "linia na prawo, obejmujący 3 drugie koniec obramowania")?;
+    return Ok(());
+
+}
+
+#[test]
+fn menclose_top_bottom() -> Result<()> {
+    let expr = "<math>
+                    <menclose notation='top bottom'>  <mfrac><mn>3</mn><mn>2</mn></mfrac> </menclose>
+                </math>";
+    test("pl", "ClearSpeak", expr, "linia na góra, dół, obejmujący 3 drugie koniec obramowania")?;
+    return Ok(());
+
+}
+
+#[test]
+fn menclose_updiagonalstrike() -> Result<()> {
+    let expr = "<math>
+                    <menclose notation='updiagonalstrike'>  <mfrac><mn>3</mn><mn>2</mn></mfrac> </menclose>
+                </math>";
+    test("pl", "ClearSpeak", expr, "ukośnie w górę, krzyż na zewnątrz, obejmujący 3 drugie koniec obramowania")?;
+    return Ok(());
+
+}
+
+#[test]
+fn menclose_downdiagonalstrike() -> Result<()> {
+    let expr = "<math>
+                    <menclose notation='downdiagonalstrike'>  <mfrac><mn>3</mn><mn>2</mn></mfrac> </menclose>
+                </math>";
+    test("pl", "ClearSpeak", expr, "ukośnie w dół, krzyż na zewnątrz, obejmujący 3 drugie koniec obramowania")?;
+    return Ok(());
+
+}
+
+#[test]
+fn menclose_cross_out() -> Result<()> {
+    let expr = "<math>
+                    <menclose notation='updiagonalstrike downdiagonalstrike'>  <mfrac><mn>3</mn><mn>2</mn></mfrac> </menclose>
+                </math>";
+    test("pl", "ClearSpeak", expr, "x, krzyż na zewnątrz, obejmujący 3 drugie koniec obramowania")?;
+    return Ok(());
+
+}
+
+#[test]
+fn menclose_vertical_horizontal_strike() -> Result<()> {
+    let expr = "<math>
+                    <menclose notation='verticalstrike horizontalstrike'>  <mfrac><mn>3</mn><mn>2</mn></mfrac> </menclose>
+                </math>";
+    test("pl", "ClearSpeak", expr, "pionowy, poziomy, krzyż na zewnątrz, obejmujący 3 drugie koniec obramowania")?;
+    return Ok(());
+
+}
+
+#[test]
+fn menclose_leftarrow() -> Result<()> {
+    let expr = "<math>
+                    <menclose notation='leftarrow'> <mfrac><mn>3</mn><mn>2</mn></mfrac> </menclose>
+                </math>";
+    test("pl", "ClearSpeak", expr, "strzałka w lewo, obejmujący 3 drugie koniec obramowania")?;
+    return Ok(());
+
+}
+
+#[test]
+fn menclose_right_up_down_arrow() -> Result<()> {
+    let expr = "<math>
+                    <menclose notation=' rightarrow downarrow  uparrow  '> <mfrac><mn>3</mn><mn>2</mn></mfrac> </menclose>
+                </math>";
+    test("pl", "ClearSpeak", expr, "strzałka w górę, strzałka w dół, strzałka w prawo, obejmujący 3 drugie koniec obramowania")?;
+    return Ok(());
+
+}
+
+#[test]
+fn menclose_northeastarrow() -> Result<()> {
+    let expr = "<math>
+                    <menclose notation='northeastarrow'> <mfrac><mn>3</mn><mn>2</mn></mfrac> </menclose>
+                </math>";
+    test("pl", "ClearSpeak", expr, "strzałka na północny wschód, obejmujący 3 drugie koniec obramowania")?;
+    return Ok(());
+
+}
+
+#[test]
+fn menclose_other_single_arrows() -> Result<()> {
+    let expr = "<math>
+                    <menclose notation='northwestarrow southwestarrow southeastarrow'> <mfrac><mn>3</mn><mn>2</mn></mfrac> </menclose>
+                </math>";
+    test("pl", "ClearSpeak", expr, "strzałka na południowy wschód, strzałka na południowy zachód, strzałka na północny zachód, obejmujący 3 drugie koniec obramowania")?;
+    return Ok(());
+
+}
+
+#[test]
+fn menclose_northwestsoutheastarrow() -> Result<()> {
+    let expr = "<math>
+                    <menclose notation='northwestsoutheastarrow'> <mfrac><mn>3</mn><mn>2</mn></mfrac> </menclose>
+                </math>";
+    test("pl", "ClearSpeak", expr, "strzałka dwukierunkowa ukośna w dół, obejmujący 3 drugie koniec obramowania")?;
+    return Ok(());
+
+}
+
+#[test]
+fn menclose_other_double_arrows() -> Result<()> {
+    let expr = "<math>
+                    <menclose notation='updownarrow leftrightarrow northeastsouthwestarrow'>  <mfrac><mn>3</mn><mn>2</mn></mfrac> </menclose>
+                </math>";
+    test("pl", "ClearSpeak", expr, "strzałka dwukierunkowa pionowa, strzałka dwukierunkowa pozioma, strzałka dwukierunkowa ukośna w górę, obejmujący 3 drugie koniec obramowania")?;
+    return Ok(());
+
+}
+
+#[test]
+fn menclose_madrub() -> Result<()> {
+    let expr = "<math>
+                    <menclose notation='madrub'> <mfrac><mn>3</mn><mn>2</mn></mfrac> </menclose>
+                </math>";
+    test("pl", "ClearSpeak", expr, "arabski symbol silni, obejmujący 3 drugie koniec obramowania")?;
+    return Ok(());
+
+}
+
+#[test]
+fn menclose_phasorangle() -> Result<()> {
+    let expr = "<math>
+                    <menclose notation='phasorangle'> <mfrac><mn>3</mn><mn>2</mn></mfrac> </menclose>
+                </math>";
+    test("pl", "ClearSpeak", expr, "kąt fazowy, obejmujący 3 drugie koniec obramowania")?;
+    return Ok(());
+
+}
+
+#[test]
+fn menclose_circle_phasorangle() -> Result<()> {
+    let expr = "<math>
+                    <menclose notation='phasorangle circle'> <mfrac><mn>3</mn><mn>2</mn></mfrac> </menclose>
+                </math>";
+    test("pl", "ClearSpeak", expr, "okrąg, kąt fazowy, obejmujący 3 drugie koniec obramowania")?;
+    return Ok(());
+
+}
+
+#[test]
+fn menclose_longdiv() -> Result<()> {
+    let expr = "<math>
+                    <menclose notation='longdiv'> <mfrac><mn>3</mn><mn>2</mn></mfrac> </menclose>
+                </math>";
+    test("pl", "ClearSpeak", expr, "znak dzielenia pisemnego, obejmujący 3 drugie koniec obramowania")?;
+    return Ok(());
+
+}
+
+#[test]
+fn menclose_longdiv_default() -> Result<()> {
+    let expr = "<math>
+                    <menclose> <mfrac><mn>3</mn><mn>2</mn></mfrac> </menclose>
+                </math>";
+    test("pl", "ClearSpeak", expr, "znak dzielenia pisemnego, obejmujący 3 drugie koniec obramowania")?;
+    return Ok(());
+
+}
+
+#[test]
+fn menclose_longdiv_empty_string() -> Result<()> {
+    let expr = "<math>
+                    <menclose notation=''> <mfrac><mn>3</mn><mn>2</mn></mfrac> </menclose>
+                </math>";
+    test("pl", "ClearSpeak", expr, "znak dzielenia pisemnego, obejmujący 3 drugie koniec obramowania")?;
+    return Ok(());
+
+}
+
+#[test]
+fn menclose_longdiv_whitespace_string() -> Result<()> {
+    let expr = "<math>
+                    <menclose notation='  '> <mfrac><mn>3</mn><mn>2</mn></mfrac> </menclose>
+                </math>";
+    test("pl", "ClearSpeak", expr, "znak dzielenia pisemnego, obejmujący 3 drugie koniec obramowania")?;
+    return Ok(());
+
+}
+
+#[test]
+fn menclose_radical() -> Result<()> {
+    let expr = "<math>
+                    <menclose notation='radical'> <mfrac><mn>3</mn><mn>2</mn></mfrac> </menclose>
+                </math>";
+    test("pl", "ClearSpeak", expr, "pierwiastek kwadratowy, obejmujący 3 drugie koniec obramowania")?;
+    return Ok(());
+
+}
+
+#[test]
+fn simple_speak_menclose_top_bottom() -> Result<()> {
+    let expr = "<math>
+                    <menclose notation='top bottom'>  <mfrac><mn>3</mn><mn>2</mn></mfrac> </menclose>
+                </math>";
+    test("pl", "SimpleSpeak", expr, "linia na góra, dół, obejmujący 3 drugie koniec obramowania")?;
+    return Ok(());
+
+}

--- a/tests/Languages/pl/ClearSpeak/mfrac.rs
+++ b/tests/Languages/pl/ClearSpeak/mfrac.rs
@@ -1,0 +1,313 @@
+/// Tests for fractions
+///   includes simple fractions and more complex fractions
+///   also tests mixed fractions (implicit and explicit)
+use crate::common::*;
+use anyhow::Result;
+
+#[test]
+fn common_fraction_half() -> Result<()> {
+    let expr = "<math>
+                    <mfrac> <mn>1</mn> <mn>2</mn> </mfrac>
+                </math>";
+    test("pl", "ClearSpeak", expr, "jedna druga")?;
+    return Ok(());
+
+}
+
+#[test]
+fn common_fraction_thirds() -> Result<()> {
+    let expr = "<math>
+                    <mfrac> <mn>2</mn> <mn>3</mn> </mfrac>
+                </math>";
+    test("pl", "ClearSpeak", expr, "dwie trzecie")?;
+    return Ok(());
+
+}
+
+#[test]
+fn common_fraction_tenths() -> Result<()> {
+    let expr = "<math>
+                    <mfrac> <mn>17</mn> <mn>10</mn> </mfrac>
+                </math>";
+    test_prefs("pl", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Fractions", "Auto")], expr, "17 dziesiąte")?;
+    test_prefs("pl", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Fractions", "Ordinal")], expr, "17 dziesiąte")?;
+    return Ok(());
+
+}
+
+#[test]
+#[allow(non_snake_case)]
+fn not_ClearSpeak_common_fraction_tenths() -> Result<()> {
+    let expr = "<math>
+                    <mfrac> <mn>89</mn> <mn>10</mn> </mfrac>
+                </math>";
+    test_prefs("pl", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Fractions", "Auto")], expr, "89 przez 10")?;
+    test_prefs("pl", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Fractions", "Ordinal")], expr, "89 dziesiąte")?;
+    return Ok(());
+
+}
+
+#[test]
+fn non_simple_fraction() -> Result<()> {
+    let expr = "
+    <math>
+        <mrow>
+        <mfrac>
+        <mrow>
+        <mi>x</mi><mo>+</mo><mi>y</mi></mrow>
+        <mrow>
+        <mi>x</mi><mo>-</mo><mi>y</mi></mrow>
+        </mfrac>
+        </mrow>
+    </math>";
+    test_prefs("pl", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Fractions", "Auto")], expr, "ułamek z licznikiem; x plus y; i mianownikiem x minus y")?;
+    test_prefs("pl", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Fractions", "Ordinal")], expr, "ułamek z licznikiem; x plus y; i mianownikiem x minus y")?;
+    test_prefs("pl", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Fractions", "Over")], expr, "x plus y przez x minus y")?;
+    test_prefs("pl", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Fractions", "FracOver")], expr, "ułamek x plus y przez x minus y")?;
+    test_prefs("pl", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Fractions", "General")], expr, "ułamek z licznikiem; x plus y; i mianownikiem x minus y")?;
+    test_prefs("pl", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Fractions", "EndFrac")], expr, "ułamek z licznikiem; x plus y; i mianownikiem x minus y; koniec ułamka")?;
+    test_prefs("pl", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Fractions", "GeneralEndFrac")], expr, "ułamek z licznikiem; x plus y; i mianownikiem x minus y; koniec ułamka")?;
+    test_prefs("pl", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Fractions", "OverEndFrac")], expr, "x plus y przez x minus y, koniec ułamka")?;
+    test_prefs("pl", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Fractions", "Per")], expr, "x plus y na x minus y")?;
+    test_prefs("pl", "ClearSpeak", vec![("Verbosity", "Verbose"),("ClearSpeak_Fractions", "Auto")], expr, "ułamek z licznikiem; x plus y; i mianownikiem x minus y; koniec ułamka")?;
+    return Ok(());
+
+}
+
+#[test]
+fn frac_with_units() -> Result<()> {
+    let expr = "
+    <math>
+        <mrow>
+        <mn>62</mn>
+        <mfrac>
+        <mi intent=':unit'>mi</mi>
+        <mi intent=':unit'>hr</mi>
+        </mfrac>
+        </mrow>
+    </math>";
+    test("pl", "ClearSpeak", expr, "62 milas na godzina")?;
+    return Ok(());
+
+}
+
+
+#[test]
+fn mixed_number() -> Result<()> {
+    let expr = "<math>
+                    <mn>3</mn>
+                    <mfrac> <mn>1</mn> <mn>2</mn> </mfrac>
+                </math>";
+    test("pl", "ClearSpeak", expr, "3 i jedna druga")?;
+    return Ok(());
+
+}
+
+#[test]
+fn explicit_mixed_number() -> Result<()> {
+    let expr = "<math>
+                    <mn>3</mn>
+                    <mo>&#x2064;</mo>
+                    <mfrac> <mn>1</mn> <mn>8</mn> </mfrac>
+                </math>";
+    test("pl", "ClearSpeak", expr, "3 i jedna ósma")?;
+    return Ok(());
+
+}
+
+#[test]
+fn mixed_number_big() -> Result<()> {
+    let expr = "<math>
+                    <mn>3</mn>
+                    <mfrac> <mn>7</mn> <mn>83</mn> </mfrac>
+                </math>";
+    test("pl", "ClearSpeak", expr, "3 i 7 przez 83")?;
+    return Ok(());
+
+}
+
+#[test]
+fn simple_text() -> Result<()> {
+    let expr = "<math>
+    <mfrac> <mi>rise</mi> <mi>run</mi> </mfrac>
+                </math>";
+    test("pl", "ClearSpeak", expr, "rise przez run")?;
+    return Ok(());
+
+}
+
+#[test]
+fn number_and_text() -> Result<()> {
+    let expr = "<math>
+            <mfrac>
+            <mrow>
+                <mn>2</mn><mtext>miles</mtext></mrow>
+            <mrow>
+                <mn>3</mn><mtext>gallons</mtext></mrow>
+            </mfrac>
+        </math>";
+    test("pl", "ClearSpeak", expr, "2 miles przez 3 gallons")?;
+    return Ok(());
+
+}
+
+
+#[test]
+fn nested_simple_fractions() -> Result<()> {
+    let expr = "<math>
+                <mrow>
+                <mfrac>
+                    <mrow>
+                    <mfrac>
+                        <mn>1</mn>
+                        <mn>2</mn>
+                    </mfrac>
+                    </mrow>
+                    <mrow>
+                    <mfrac>
+                        <mn>2</mn>
+                        <mn>3</mn>
+                    </mfrac>
+                    </mrow>
+                </mfrac>
+                </mrow>
+            </math>";
+    test_prefs("pl", "ClearSpeak", vec![("ClearSpeak_Fractions", "Auto")], expr, "jedna druga przez dwie trzecie")?;
+    test_prefs("pl", "ClearSpeak", vec![("ClearSpeak_Fractions", "Ordinal")], expr, "jedna druga przez dwie trzecie")?;
+    test_prefs("pl", "ClearSpeak", vec![("ClearSpeak_Fractions", "Over")], expr, "1 przez 2 przez 2 przez 3")?;
+    test_prefs("pl", "ClearSpeak", vec![("ClearSpeak_Fractions", "FracOver")], expr,
+            "ułamek ułamek 1 przez 2 przez ułamek 2 przez 3")?;
+    test_prefs("pl", "ClearSpeak", vec![("ClearSpeak_Fractions", "General")], expr,
+            "ułamek z licznikiem ułamek z licznikiem 1; i mianownikiem 2; i mianownikiem ułamek z licznikiem 2; i mianownikiem 3")?;
+    test_prefs("pl", "ClearSpeak", vec![("ClearSpeak_Fractions", "EndFrac")], expr, "jedna druga przez dwie trzecie")?;
+    test_prefs("pl", "ClearSpeak", vec![("ClearSpeak_Fractions", "GeneralEndFrac")], expr,
+            "ułamek z licznikiem ułamek z licznikiem 1; i mianownikiem 2; koniec ułamka; i mianownikiem ułamek z licznikiem 2; i mianownikiem 3; koniec ułamka; koniec ułamka")?;
+    test_prefs("pl", "ClearSpeak", vec![("ClearSpeak_Fractions", "OverEndFrac")], expr,
+            "1 przez 2, koniec ułamka, przez 2 przez 3, koniec ułamka; koniec ułamka")?;
+            return Ok(());
+
+}
+
+
+#[test]
+fn semi_nested_fraction() -> Result<()> {
+    let expr = "<math>
+                <mrow>
+                        <mfrac>
+                        <mrow>
+                        <mfrac>
+                        <mn>2</mn>
+                        <mn>3</mn>
+                        </mfrac>
+                        <mi>x</mi>
+                    </mrow>
+                    <mn>6</mn>
+                    </mfrac>
+                </mrow>
+                </math>";
+    test("pl", "ClearSpeak", expr, "dwie trzecie x przez 6")?;
+    return Ok(());
+
+}
+
+#[test]
+fn general_nested_fraction() -> Result<()> {
+    let expr = "
+    <math>
+    <mrow>
+        <mfrac>
+        <mrow>
+        <mfrac>
+            <mn>10</mn>
+            <mi>n</mi>
+        </mfrac>
+        </mrow>
+        <mrow>
+        <mfrac>
+        <mn>2</mn>
+        <mi>n</mi>
+        </mfrac>
+        </mrow>
+        </mfrac>
+        </mrow>
+    </math>
+                    ";
+    test("pl", "ClearSpeak", expr, "ułamek z licznikiem; 10 przez n; i mianownikiem 2 przez n")?;
+    return Ok(());
+
+}
+
+#[test]
+fn complex_nested_fraction() -> Result<()> {
+    let expr = "
+    <math>
+    <mrow>
+        <mfrac>
+        <mrow>
+        <mfrac>
+            <mrow> <mi>n</mi> <mo>+</mo> <mn>10</mn> </mrow>
+            <mi>n</mi>
+        </mfrac>
+        </mrow>
+        <mrow>
+        <mfrac>
+        <mn>2</mn>
+        <mi>n</mi>
+        </mfrac>
+        </mrow>
+        </mfrac>
+        </mrow>
+    </math>
+                    ";
+    test("pl", "ClearSpeak", expr, "ułamek z licznikiem; ułamek z licznikiem; n plus 10; i mianownikiem n; i mianownikiem 2 przez n")?;
+    return Ok(());
+
+}
+
+#[test]
+fn simple_function() -> Result<()> {
+    let expr = "<math><mfrac><mrow><mi>f</mi><mo>(</mo><mi>x</mi><mo>)</mo></mrow><mn>2</mn></mfrac></math>";
+    test_prefs("pl", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Fractions", "Auto")], expr, "f z x przez 2")?;
+    test_prefs("pl", "ClearSpeak", vec![("Verbosity", "Verbose"), ("ClearSpeak_Fractions", "Auto")], expr, "f z x przez 2, koniec ułamka")?;
+    return Ok(());
+
+}
+
+#[test]
+fn function_over_function() -> Result<()> {
+    let expr = "<math><mfrac>
+            <mrow><mi>f</mi><mo>(</mo><mi>x</mi><mo>)</mo></mrow>
+            <mrow><mi>g</mi><mo>(</mo><mi>x</mi><mo>)</mo></mrow>
+        </mfrac></math>";
+    test_prefs("pl", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Fractions", "Auto")], expr, "f z x przez g z x")?;
+    test_prefs("pl", "ClearSpeak", vec![("Verbosity", "Verbose"), ("ClearSpeak_Fractions", "Auto")], expr, "f z x przez g z x, koniec ułamka")?;
+    return Ok(());
+
+}
+
+#[test]
+fn non_simple_function_over_function() -> Result<()> {
+    let expr = "<math><mfrac>
+            <mrow><mi>f</mi><mo>(</mo><mi>x</mi><mo>+</mo><mn>1</mn><mo>)</mo></mrow>
+            <mrow><mi>g</mi><mo>(</mo><mi>x</mi><mo>)</mo></mrow>
+        </mfrac></math>";
+    test_prefs("pl", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Fractions", "Auto")], expr,
+             "ułamek z licznikiem; f z, nawias otwierający, x plus 1, nawias zamykający; i mianownikiem g z x")?;
+    test_prefs("pl", "ClearSpeak", vec![("Verbosity", "Verbose"), ("ClearSpeak_Fractions", "Auto")], expr,
+             "ułamek z licznikiem; f z, nawias otwierający, x plus 1, nawias zamykający; i mianownikiem g z x; koniec ułamka")?;
+             return Ok(());
+
+}
+
+#[test]
+fn binomial() -> Result<()> {
+    let expr = "<math>
+                    <mn>2</mn>
+                    <mo>(</mo>
+                    <mfrac linethickness='0'> <mn>7</mn> <mn>3</mn> </mfrac>
+                    <mo>)</mo>
+                </math>";
+    test("pl", "ClearSpeak", expr, "2 razy 7 po 3")?;
+    return Ok(());
+
+}

--- a/tests/Languages/pl/ClearSpeak/mroot.rs
+++ b/tests/Languages/pl/ClearSpeak/mroot.rs
@@ -1,0 +1,171 @@
+use crate::common::*;
+use anyhow::Result;
+
+#[test]
+fn msqrt_simple() -> Result<()> {
+    let expr = "<math>
+                    <msqrt> <mi>x</mi> </msqrt>
+                </math>";
+    test("pl", "ClearSpeak", expr, "pierwiastek kwadratowy z x")?;
+    return Ok(());
+
+}
+
+#[test]
+fn msqrt_simple_end_root() -> Result<()> {
+    let expr = "<math>
+                    <msqrt> <mi>x</mi> </msqrt>
+                </math>";
+    test_ClearSpeak("pl", "ClearSpeak_Roots", "RootEnd", expr, "pierwiastek kwadratowy z x, koniec pierwiastka")?;
+    return Ok(());
+
+}
+
+#[test]
+fn msqrt_simple_positive() -> Result<()> {
+    let expr = "<math>
+                    <msqrt> <mi>x</mi> </msqrt>
+                </math>";
+    test_ClearSpeak("pl", "ClearSpeak_Roots", "PosNegSqRoot", expr, "plus pierwiastek kwadratowy z x")?;
+    return Ok(());
+
+}
+
+#[test]
+fn msqrt_simple_pos_end_root() -> Result<()> {
+    let expr = "<math>
+                    <msqrt> <mi>x</mi> </msqrt>
+                </math>";
+    test_ClearSpeak("pl", "ClearSpeak_Roots", "PosNegSqRootEnd", expr, "plus pierwiastek kwadratowy z x, koniec pierwiastka")?;
+    return Ok(());
+
+}
+
+#[test]
+fn msqrt_simple_pos_end_with_neg_root() -> Result<()> {
+    let expr = "<math>
+                    <mo>-</mo> <msqrt> <mi>x</mi> </msqrt>
+                    <mo>-</mo> <mroot> <mi>x</mi> <mn>3</mn></mroot>
+                </math>";
+    test_ClearSpeak("pl", "ClearSpeak_Roots", "PosNegSqRootEnd", expr, 
+    "minus pierwiastek kwadratowy z x, koniec pierwiastka; minus, plus pierwiastek sześcienny z x, koniec pierwiastka")?;
+    return Ok(());
+
+}
+
+#[test]
+fn mroot_simple_pos_end_with_neg_root() -> Result<()> {
+    let expr = "<math>
+                    <mo>-</mo> <mroot> <mi>x</mi> <mn>3</mn></mroot>
+                    <mo>-</mo> <msqrt> <mi>x</mi> </msqrt>
+
+                </math>";
+    test_ClearSpeak("pl", "ClearSpeak_Roots", "PosNegSqRoot", expr, 
+    "minus pierwiastek sześcienny z x; minus plus pierwiastek kwadratowy z x")?;
+    return Ok(());
+
+}
+
+#[test]
+fn neg_without_root() -> Result<()> {
+    let expr = "<math>
+                    <mo>-</mo> <mi>x</mi> <mo>-</mo> <mi>y</mi>
+                </math>";
+    test("pl", "ClearSpeak", expr, "minus x minus y")?;
+    return Ok(());
+
+}
+
+#[test]
+fn msqrt() -> Result<()> {
+    let expr = "<math>
+                    <msqrt>
+                        <mrow> <mi>x</mi> <mo>+</mo> <mi>y</mi> </mrow>
+                    </msqrt>
+                </math>";
+    test("pl", "ClearSpeak", expr, "pierwiastek kwadratowy z x plus y")?;
+    return Ok(());
+
+}
+
+#[test]
+fn mroot_as_square_root() -> Result<()> {
+    let expr = "<math>
+                    <mroot> <mi>x</mi> <mn>2</mn> </mroot>
+                </math>";
+    test("pl", "ClearSpeak", expr, "pierwiastek kwadratowy z x")?;
+    return Ok(());
+
+}
+
+#[test]
+fn cube_root() -> Result<()> {
+    let expr = "<math>
+                    <mroot> <mi>x</mi> <mn>3</mn> </mroot>
+                </math>";
+    test("pl", "ClearSpeak", expr, "pierwiastek sześcienny z x")?;
+    return Ok(());
+
+}
+
+#[test]
+fn ordinal_root() -> Result<()> {
+    let expr = "<math>
+                    <mroot> <mi>x</mi> <mn>9</mn> </mroot>
+                </math>";
+    test("pl", "ClearSpeak", expr, "dziewiątej pierwiastek z x")?;
+    return Ok(());
+
+}
+
+#[test]
+fn simple_mi_root() -> Result<()> {
+    let expr = "<math>
+                    <mroot> <mi>x</mi> <mi>n</mi> </mroot>
+                </math>";
+    test("pl", "ClearSpeak", expr, "n pierwiastek z x")?;
+    return Ok(());
+
+}
+
+#[test]
+fn mroot_simple_pos_end_root() -> Result<()> {
+    let expr = "<math>
+                <mroot> <mi>x</mi> <mi>t</mi> </mroot>
+                </math>";
+    test_ClearSpeak("pl", "ClearSpeak_Roots", "PosNegSqRootEnd", expr, "plus t pierwiastek z x, koniec pierwiastka")?;
+    return Ok(());
+
+}
+
+#[test]
+fn mroot_simple_end_root() -> Result<()> {
+    let expr = "<math>
+                    <mroot> <mrow> <mi>x</mi> <mo>+</mo> <mi>y</mi> </mrow> 
+                    <mn>21</mn></mroot>
+                </math>";
+    test_ClearSpeak("pl", "ClearSpeak_Roots", "RootEnd", expr, "dwadzieścia pierwszej pierwiastek z x plus y, koniec pierwiastka")?;
+    return Ok(());
+
+}
+
+#[test]
+fn simple_fraction_power() -> Result<()> {
+    let expr = "<math>
+                    <mroot>
+                        <mi>x</mi> 
+                        <mfrac><mn>1</mn><mn>3</mn></mfrac>
+                    </mroot>
+                </math>";
+    test("pl", "ClearSpeak", expr, "jedna trzecia pierwiastek z x")?;
+    return Ok(());
+
+}
+
+#[test]
+fn no_double_the_532() -> Result<()> {
+    let expr = "<math><mroot><msqrt><mn>42</mn></msqrt><mn>3</mn></mroot></math>";
+    test("pl", "ClearSpeak", expr, "pierwiastek sześcienny z pierwiastek kwadratowy z 42")?;
+    return Ok(());
+
+}

--- a/tests/Languages/pl/ClearSpeak/msup.rs
+++ b/tests/Languages/pl/ClearSpeak/msup.rs
@@ -1,0 +1,382 @@
+/// Tests for superscripts
+///   simple superscripts
+///   complex/nested superscripts
+use crate::common::*;
+use anyhow::Result;
+
+#[test]
+fn squared() -> Result<()> {
+    let expr = "<math>
+                    <msup> <mi>x</mi> <mn>2</mn> </msup>
+                </math>";
+    test_prefs("pl", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Exponents", "Auto")], expr, "x do kwadratu")?;
+    test_prefs("pl", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Exponents", "Ordinal")], expr, "x do potęgi drugiej")?;
+    test_prefs("pl", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Exponents", "OrdinalPower")], expr, "x do potęgi drugiej")?;
+    test_prefs("pl", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Exponents", "AfterPower")], expr, "x do potęgi 2")?;
+
+    return Ok(());
+
+}
+
+#[test]
+fn cubed() -> Result<()> {
+  let expr = "<math>
+                  <msup> <mi>x</mi> <mn>3</mn> </msup>
+              </math>";
+  test_prefs("pl", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Exponents", "Auto")], expr, "x do sześcianu")?;
+  test_prefs("pl", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Exponents", "Ordinal")], expr, "x do potęgi trzeciej")?;
+  test_prefs("pl", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Exponents", "OrdinalPower")], expr, "x do potęgi trzeciej")?;
+  test_prefs("pl", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Exponents", "AfterPower")], expr, "x do potęgi 3")?;
+  return Ok(());
+
+}
+
+#[test]
+fn ordinal_power() -> Result<()> {
+  let expr = "<math>
+                  <msup> <mn>3</mn> <mn>5</mn> </msup>
+              </math>";
+  test_prefs("pl", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Exponents", "Auto")], expr, "3 do potęgi piątej")?;
+  test_prefs("pl", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Exponents", "Ordinal")], expr, "3 do potęgi piątej")?;
+  test_prefs("pl", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Exponents", "OrdinalPower")], expr, "3 do potęgi piątej")?;
+  test_prefs("pl", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Exponents", "AfterPower")], expr, "3 do potęgi 5")?;
+  return Ok(());
+
+}
+
+
+#[test]
+fn zero_power() -> Result<()> {
+  let expr = "<math>
+                    <msup> <mn>3</mn> <mn>0</mn> </msup>
+                </math>";
+  test_prefs("pl", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Exponents", "Auto")], expr, "3 do potęgi 0")?;
+  test_prefs("pl", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Exponents", "Ordinal")], expr, "3 do potęgi 0")?;
+  test_prefs("pl", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Exponents", "OrdinalPower")], expr, "3 do potęgi 0")?;
+  test_prefs("pl", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Exponents", "AfterPower")], expr, "3 do potęgi 0")?;
+  return Ok(());
+
+}
+
+#[test]
+fn simple_mi_power() -> Result<()> {
+  let expr = "<math>
+                    <msup> <mn>4</mn> <mi>x</mi> </msup>
+                </math>";
+  test_prefs("pl", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Exponents", "Auto")], expr, "4 do potęgi x")?;
+  test_prefs("pl", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Exponents", "Ordinal")], expr, "4 do potęgi x")?;
+  test_prefs("pl", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Exponents", "OrdinalPower")], expr, "4 do potęgi x")?;
+  test_prefs("pl", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Exponents", "AfterPower")], expr, "4 do potęgi x")?;
+  return Ok(());
+
+}
+
+#[test]
+fn decimal_power() -> Result<()> {
+  let expr = "<math>
+                  <msup> <mn>3</mn> <mn>5.0</mn> </msup>
+              </math>";
+  test_prefs("pl", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Exponents", "Auto")], expr, "3 do potęgi 50")?;
+  test_prefs("pl", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Exponents", "Ordinal")], expr, "3 do potęgi 50")?;
+  test_prefs("pl", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Exponents", "OrdinalPower")], expr, "3 do potęgi 50")?;
+  test_prefs("pl", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Exponents", "AfterPower")], expr, "3 do potęgi 50")?;
+  return Ok(());
+
+}
+
+#[test]
+fn non_simple_power() -> Result<()> {
+  let expr = "<math>
+        <msup> <mn>3</mn>  <mrow> <mi>y</mi><mo>+</mo><mn>2</mn></mrow>  </msup>
+    </math>";
+  test_prefs("pl", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Exponents", "Auto")], expr, "3 do potęgi y plus 2")?;
+  test_prefs("pl", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Exponents", "Ordinal")], expr, "3 do potęgi y plus 2")?;
+  test_prefs("pl", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Exponents", "OrdinalPower")], expr, "3 do potęgi y plus 2")?;
+  test_prefs("pl", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Exponents", "AfterPower")], expr, "3 do potęgi y plus 2")?;
+  return Ok(());
+
+}
+
+#[test]
+fn negative_power() -> Result<()> {
+  let expr = "<math>
+                  <msup> <mn>3</mn> <mrow> <mo>-</mo> <mn>2</mn> </mrow> </msup>
+              </math>";
+  test_prefs("pl", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Exponents", "Auto")], expr, "3 do potęgi minus 2")?;
+  test_prefs("pl", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Exponents", "Ordinal")], expr, "3 do potęgi minus 2")?;
+  test_prefs("pl", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Exponents", "OrdinalPower")], expr, "3 do potęgi minus 2")?;
+  test_prefs("pl", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Exponents", "AfterPower")], expr, "3 do potęgi minus 2")?;
+  return Ok(());
+
+}
+
+#[test]
+fn simple_fraction_power() -> Result<()> {
+  let expr = "<math>
+                    <msup>
+                        <mi>x</mi> 
+                        <mfrac><mn>1</mn><mn>3</mn></mfrac>
+                    </msup>
+                </math>";
+  test("pl", "ClearSpeak", expr, "x do potęgi jedna trzecia")?;
+  return Ok(());
+
+}
+
+#[test]
+fn nested_squared_power_with_coef() -> Result<()> {
+  let expr = "<math>
+      <mrow>
+      <msup>
+        <mn>3</mn>
+        <mrow>
+        <mn>2</mn>
+        <msup>
+          <mi>x</mi>
+          <mn>2</mn>
+        </msup>
+        </mrow>
+      </msup>
+      </mrow>
+      </math>";
+  test_prefs("pl", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Exponents", "Auto")], expr, "3 do potęgi 2 x do kwadratu")?;
+  test_prefs("pl", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Exponents", "Ordinal")], expr, "3 do wykładnika, 2 x do potęgi drugiej, koniec wykładnika")?;
+  test_prefs("pl", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Exponents", "OrdinalPower")], expr, "3 do wykładnika, 2 x do potęgi drugiej, koniec wykładnika")?;
+  test_prefs("pl", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Exponents", "AfterPower")], expr, "3 do wykładnika, 2 x do potęgi 2; koniec wykładnika")?;
+
+  return Ok(());
+
+}
+
+#[test]
+fn nested_squared_power_with_neg_coef() -> Result<()> {
+    let expr = "<math>
+      <mrow>
+      <msup>
+        <mn>3</mn>
+        <mrow>
+        <mo>-</mo>
+        <mn>2</mn>
+        <msup>
+          <mi>x</mi>
+          <mn>2</mn>
+        </msup>
+        </mrow>
+      </msup>
+      </mrow>
+    </math>";
+  test("pl", "ClearSpeak", expr, "3 do potęgi minus 2 x do kwadratu")?;
+  return Ok(());
+
+}
+
+
+#[test]
+fn nested_cubed_power() -> Result<()> {
+    let expr = "<math>
+      <msup>
+      <mi>y</mi> 
+      <msup>
+          <mfrac><mn>4</mn><mn>5</mn></mfrac>
+          <mn>3</mn>
+      </msup>
+    </msup>
+  </math>";
+  test("pl", "ClearSpeak", expr, "y do potęgi 4 piąte do sześcianu")?;
+  return Ok(());
+
+}
+
+#[test]
+fn nested_cubed_power_with_neg_base() -> Result<()> {
+    let expr = "<math>
+      <msup>
+      <mi>y</mi> 
+        <mrow>
+            <mo>-</mo>
+            <msup>
+                <mfrac><mn>4</mn><mn>5</mn></mfrac>
+                <mn>3</mn>
+            </msup>
+        </mrow>
+    </msup>
+    </math>";
+  test("pl", "ClearSpeak", expr, "y do potęgi minus 4 piąte do sześcianu")?;
+  return Ok(());
+
+}
+
+#[test]
+fn nested_number_times_squared() -> Result<()> {
+  let expr = "<math>
+      <mrow>
+      <msup>
+        <mi>e</mi>
+        <mrow>
+        <mfrac>
+          <mn>1</mn>
+          <mn>2</mn>
+          </mfrac>
+          <msup>
+          <mi>x</mi>
+          <mn>2</mn>
+          </msup>
+        </mrow>
+      </msup>
+      </mrow>
+      </math>";
+  test_prefs("pl", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Exponents", "Auto")], expr, "e do potęgi jedna druga x do kwadratu")?;
+  return Ok(());
+
+}
+
+#[test]
+fn nested_negative_number_times_squared() -> Result<()> {
+  let expr = "<math>
+      <mrow>
+      <msup>
+        <mi>e</mi>
+        <mrow>
+        <mo>&#x2212;</mo><mfrac>
+          <mn>1</mn>
+          <mn>2</mn>
+        </mfrac>
+        <msup>
+          <mi>x</mi>
+          <mn>2</mn>
+        </msup>
+        </mrow>
+      </msup>
+      </mrow>
+      </math>";
+  test_prefs("pl", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Exponents", "Auto")], expr, "e do potęgi minus jedna druga x do kwadratu")?;
+  test_prefs("pl", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Exponents", "Ordinal")], expr, "e do wykładnika, minus jedna druga x do potęgi drugiej, koniec wykładnika")?;
+  test_prefs("pl", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Exponents", "OrdinalPower")], expr, "e do wykładnika, minus jedna druga x do potęgi drugiej, koniec wykładnika")?;
+  test_prefs("pl", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Exponents", "AfterPower")], expr, "e do wykładnika, minus jedna druga x do potęgi 2; koniec wykładnika")?;
+  return Ok(());
+
+}
+
+#[test]
+fn nested_expr_to_tenth() -> Result<()> {
+  let expr = "<math>
+      <mrow>
+      <msup>
+        <mn>3</mn>
+        <mrow>
+        <msup>
+          <mn>3</mn>
+          <mrow>
+          <mn>10</mn></mrow>
+        </msup>
+        </mrow>
+      </msup>
+      </mrow>
+      </math>";
+  test_prefs("pl", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Exponents", "Auto")], expr, "3 do wykładnika, 3 do potęgi dziesiątej, koniec wykładnika")?;
+  test_prefs("pl", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Exponents", "Ordinal")], expr, "3 do wykładnika, 3 do potęgi dziesiątej, koniec wykładnika")?;
+  test_prefs("pl", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Exponents", "OrdinalPower")], expr, "3 do wykładnika, 3 do potęgi dziesiątej, koniec wykładnika")?;
+  test_prefs("pl", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Exponents", "AfterPower")], expr, "3 do wykładnika, 3 do potęgi 10; koniec wykładnika")?;
+
+  return Ok(());
+
+}
+
+#[test]
+fn nested_non_simple_squared_exp() -> Result<()> {
+  let expr = "<math>
+      <mrow>
+      <msup>
+        <mn>3</mn>
+        <mrow>
+        <msup>
+          <mrow>
+          <mrow><mo>(</mo>
+            <mrow>
+            <mi>x</mi><mo>+</mo><mn>1</mn></mrow>
+          <mo>)</mo></mrow></mrow>
+          <mn>2</mn>
+        </msup>
+        </mrow>
+      </msup>
+      </mrow>
+      </math>";
+  test_prefs("pl", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Exponents", "Auto")], expr, "3 do wykładnika, nawias otwierający, x plus 1, nawias zamykający do kwadratu, koniec wykładnika")?;
+  test_prefs("pl", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Exponents", "Ordinal")], expr, "3 do wykładnika, nawias otwierający, x plus 1, nawias zamykający do potęgi drugiej, koniec wykładnika")?;
+  test_prefs("pl", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Exponents", "OrdinalPower")], expr, "3 do wykładnika, nawias otwierający, x plus 1, nawias zamykający do potęgi drugiej, koniec wykładnika")?;
+  test_prefs("pl", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Exponents", "AfterPower")], expr, "3 do wykładnika, nawias otwierający, x plus 1, nawias zamykający do potęgi 2; koniec wykładnika")?;
+  return Ok(());
+
+}
+
+#[test]
+fn nested_default_power() -> Result<()> {
+  let expr = "<math>
+    <msup>
+    <mi>t</mi> 
+    <msup>
+        <mfrac><mn>4</mn><mn>5</mn></mfrac>
+        <mi>n</mi>
+    </msup>
+  </msup>
+</math>";
+  test("pl", "ClearSpeak", expr, "t do wykładnika, 4 piąte do potęgi n, koniec wykładnika")?;
+  return Ok(());
+
+}
+
+#[test]
+fn nested_complex_power() -> Result<()> {
+  let expr = "<math>
+      <mrow>
+      <msup>
+        <mi>e</mi>
+        <mrow>
+        <mo>&#x2212;</mo><mfrac>
+          <mn>1</mn>
+          <mn>2</mn>
+        </mfrac>
+        <msup>
+          <mrow>
+          <mrow><mo>(</mo>
+            <mrow>
+            <mfrac>
+              <mrow>
+              <mi>x</mi><mo>&#x2212;</mo><mi>&#x03BC;</mi></mrow>
+              <mi>&#x03C3;</mi>
+            </mfrac>
+            </mrow>
+          <mo>)</mo></mrow></mrow>
+          <mn>2</mn>
+        </msup>
+        </mrow>
+      </msup>
+      </mrow>
+      </math>";
+  test_prefs("pl", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Exponents", "Auto")], expr,
+       "e do wykładnika, minus jedna druga razy; nawias otwierający; ułamek z licznikiem; x minus mi; i mianownikiem sigma; nawias zamykający do kwadratu, koniec wykładnika")?;
+  test_prefs("pl", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Exponents", "Ordinal")], expr,
+       "e do wykładnika, minus jedna druga razy; nawias otwierający; ułamek z licznikiem; x minus mi; i mianownikiem sigma; nawias zamykający do potęgi drugiej, koniec wykładnika")?;
+  test_prefs("pl", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Exponents", "OrdinalPower")], expr,
+       "e do wykładnika, minus jedna druga razy; nawias otwierający; ułamek z licznikiem; x minus mi; i mianownikiem sigma; nawias zamykający do potęgi drugiej, koniec wykładnika")?;
+  test_prefs("pl", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Exponents", "AfterPower")], expr,
+       "e do wykładnika, minus jedna druga razy; nawias otwierający; ułamek z licznikiem; x minus mi; i mianownikiem sigma; nawias zamykający do potęgi 2; koniec wykładnika")?;
+       return Ok(());
+
+}
+
+#[test]
+fn default_power() -> Result<()> {
+    let expr = "<math>
+      <msup>
+      <mi>t</mi> 
+      <mfrac>
+          <mrow><mi>b</mi><mo>+</mo><mn>1</mn></mrow>
+          <mn>3</mn>
+      </mfrac>
+    </msup>
+  </math>";
+  test("pl", "ClearSpeak", expr, "t do potęgi ułamek z licznikiem; b plus 1; i mianownikiem 3")?;
+  return Ok(());
+
+}

--- a/tests/Languages/pl/ClearSpeak/multiline.rs
+++ b/tests/Languages/pl/ClearSpeak/multiline.rs
@@ -168,6 +168,6 @@ fn continued_row() -> Result<()> {
   </mtable>
 </math>";
 test("pl", "SimpleSpeak", expr,
-     "2 równanies; równanie 1; x równa się y plus 1; równanie 2; y równa się 1")?;
+     "2 równania; równanie 1; x równa się y plus 1; równanie 2; y równa się 1")?;
     return Ok(());
 }

--- a/tests/Languages/pl/ClearSpeak/multiline.rs
+++ b/tests/Languages/pl/ClearSpeak/multiline.rs
@@ -1,0 +1,173 @@
+use crate::common::*;
+use anyhow::Result;
+
+
+#[test]
+fn case_1() -> Result<()> {
+  let expr = "<math>
+    <mi>f</mi>
+    <mrow>
+      <mo>(</mo>
+      <mi>x</mi>
+      <mo>)</mo>
+    </mrow>
+    <mo>=</mo>
+    <mrow>
+      <mo stretchy='true'>{</mo>
+      <mtable>
+        <mtr><mtd><mo>-</mo><mn>1</mn></mtd><mtd><mtext>if</mtext></mtd><mtd><mi>x</mi><mo>&lt;</mo><mn>0</mn></mtd></mtr>
+        <mtr><mtd><mn>0</mn></mtd><mtd><mtext>if</mtext></mtd><mtd><mi>x</mi><mo>=</mo><mn>0</mn></mtd></mtr>
+        <mtr><mtd><mn>1</mn></mtd><mtd><mtext>if</mtext></mtd><mtd><mi>x</mi><mo>&gt;</mo><mn>0</mn></mtd></mtr>
+      </mtable>
+    </mrow>
+  </math>
+   ";
+  test_ClearSpeak("pl", "ClearSpeak_MultiLineLabel", "Auto", expr,
+    "f z x równa się; 3 przypadki; przypadek 1; minus 1 if x jest mniejsze niż 0; przypadek 2; 0 if x równa się 0; przypadek 3; 1 if x jest większe niż 0"
+    )?;
+    return Ok(());
+}
+
+#[test]
+fn equation_auto() -> Result<()> {
+    let expr = "<math>
+     <mrow>
+      <mtable>
+       <mtr> <mtd> <mrow> <mi>x</mi><mo>+</mo><mi>y</mi></mrow> </mtd>  <mtd><mo>=</mo> </mtd>  <mtd><mn>7</mn></mtd>  </mtr>
+       <mtr> <mtd> <mrow> <mn>2</mn><mi>x</mi><mo>+</mo><mn>3</mn><mi>y</mi></mrow></mtd>  <mtd><mo>=</mo></mtd>  <mtd><mrow><mn>17</mn></mrow></mtd> </mtr>
+      </mtable></mrow>
+    </math>
+   ";
+   test_ClearSpeak("pl", "ClearSpeak_MultiLineLabel", "Auto", expr,
+                "2 linie; linia 1; x plus y, równa się 7; linia 2; 2 x plus 3 y; równa się 17")?;
+    return Ok(());
+}
+
+
+#[test]
+fn equation_plus_at_start() -> Result<()> {
+  let expr = "<math>
+     <mrow>
+      <mtable>
+       <mtr> <mtd> <mi>x</mi></mtd><mtd><mo>+</mo><mi>y</mi> </mtd>  <mtd><mo>=</mo> </mtd>  <mtd><mn>7</mn></mtd>  </mtr>
+       <mtr> <mtd> <mn>2</mn><mi>x</mi></mtd><mtd><mo>+</mo><mn>3</mn><mi>y</mi></mtd>  <mtd><mo>=</mo></mtd>  <mtd><mrow><mn>17</mn></mrow></mtd> </mtr>
+      </mtable></mrow>
+    </math>
+   ";
+   test_ClearSpeak("pl", "ClearSpeak_MultiLineLabel", "Auto", expr, "2 linie; linia 1; x plus y równa się 7; linia 2; 2 x, plus 3 y, równa się 17")?;
+    return Ok(());
+}
+
+#[test]
+fn equation_case() -> Result<()> {
+    let expr = "<math>
+     <mrow>
+      <mtable>
+       <mtr> <mtd> <mrow> <mi>x</mi><mo>+</mo><mi>y</mi></mrow> </mtd>  <mtd><mo>=</mo> </mtd>  <mtd><mn>7</mn></mtd>  </mtr>
+       <mtr> <mtd> <mrow> <mn>2</mn><mi>x</mi><mo>+</mo><mn>3</mn><mi>y</mi></mrow></mtd>  <mtd><mo>=</mo></mtd>  <mtd><mrow><mn>17</mn></mrow></mtd> </mtr>
+      </mtable></mrow>
+    </math>
+   ";
+   test_ClearSpeak("pl", "ClearSpeak_MultiLineLabel", "Case", expr, 
+   "2 przypadki; przypadek 1; x plus y, równa się 7; przypadek 2; 2 x plus 3 y; równa się 17")?;
+    return Ok(());
+}
+
+#[test]
+fn equation_constraint() -> Result<()> {
+  let expr = "<math>
+     <mrow>
+      <mtable>
+       <mtr> <mtd> <mrow> <mi>x</mi><mo>+</mo><mi>y</mi></mrow> </mtd>  <mtd><mo>=</mo> </mtd>  <mtd><mn>7</mn></mtd>  </mtr>
+       <mtr> <mtd> <mrow> <mn>2</mn><mi>x</mi><mo>+</mo><mn>3</mn><mi>y</mi></mrow></mtd>  <mtd><mo>=</mo></mtd>  <mtd><mrow><mn>17</mn></mrow></mtd> </mtr>
+      </mtable></mrow>
+    </math>
+   ";
+   test_ClearSpeak("pl", "ClearSpeak_MultiLineLabel", "Constraint", expr, "2 warunki; warunek 1; x plus y, równa się 7; warunek 2; 2 x plus 3 y; równa się 17")?;
+   return Ok(());
+}
+
+#[test]
+fn equation_equation() -> Result<()> {
+    let expr = "<math>
+     <mrow>
+      <mtable>
+       <mtr> <mtd> <mrow> <mi>x</mi><mo>+</mo><mi>y</mi></mrow> </mtd>  <mtd><mo>=</mo> </mtd>  <mtd><mn>7</mn></mtd>  </mtr>
+       <mtr> <mtd> <mrow> <mn>2</mn><mi>x</mi><mo>+</mo><mn>3</mn><mi>y</mi></mrow></mtd>  <mtd><mo>=</mo></mtd>  <mtd><mrow><mn>17</mn></mrow></mtd> </mtr>
+      </mtable></mrow>
+    </math>
+   ";
+   test_ClearSpeak("pl", "ClearSpeak_MultiLineLabel", "Equation", expr, "2 równania; równanie 1; x plus y, równa się 7; równanie 2; 2 x plus 3 y; równa się 17")?;
+   return Ok(());
+}
+
+#[test]
+fn equation_line() -> Result<()> {
+    let expr = "<math>
+     <mrow>
+      <mtable>
+       <mtr> <mtd> <mrow> <mi>x</mi><mo>+</mo><mi>y</mi></mrow> </mtd>  <mtd><mo>=</mo> </mtd>  <mtd><mn>7</mn></mtd>  </mtr>
+       <mtr> <mtd> <mrow> <mn>2</mn><mi>x</mi><mo>+</mo><mn>3</mn><mi>y</mi></mrow></mtd>  <mtd><mo>=</mo></mtd>  <mtd><mrow><mn>17</mn></mrow></mtd> </mtr>
+      </mtable></mrow>
+    </math>
+   ";
+   test_ClearSpeak("pl", "ClearSpeak_MultiLineLabel", "Line", expr, "2 linie; linia 1; x plus y, równa się 7; linia 2; 2 x plus 3 y; równa się 17")?;
+    return Ok(());
+}
+
+#[test]
+fn equation_none() -> Result<()> {
+    let expr = "<math>
+     <mrow>
+      <mtable>
+       <mtr> <mtd> <mrow> <mi>x</mi><mo>+</mo><mi>y</mi></mrow> </mtd>  <mtd><mo>=</mo> </mtd>  <mtd><mn>7</mn></mtd>  </mtr>
+       <mtr> <mtd> <mrow> <mn>2</mn><mi>x</mi><mo>+</mo><mn>3</mn><mi>y</mi></mrow></mtd>  <mtd><mo>=</mo></mtd>  <mtd><mrow><mn>17</mn></mrow></mtd> </mtr>
+      </mtable></mrow>
+    </math>
+   ";
+   test_ClearSpeak("pl", "ClearSpeak_MultiLineLabel", "None", expr,
+        "2 linie; x plus y, równa się 7; 2 x plus 3 y; równa się 17")?;
+   return Ok(());
+}
+
+#[test]
+fn equation_row() -> Result<()> {
+    let expr = "<math>
+     <mrow>
+      <mtable>
+       <mtr> <mtd> <mrow> <mi>x</mi><mo>+</mo><mi>y</mi></mrow> </mtd>  <mtd><mo>=</mo> </mtd>  <mtd><mn>7</mn></mtd>  </mtr>
+       <mtr> <mtd> <mrow> <mn>2</mn><mi>x</mi><mo>+</mo><mn>3</mn><mi>y</mi></mrow></mtd>  <mtd><mo>=</mo></mtd>  <mtd><mrow><mn>17</mn></mrow></mtd> </mtr>
+      </mtable></mrow>
+    </math>
+   ";
+   test_ClearSpeak("pl", "ClearSpeak_MultiLineLabel", "Row", expr, "2 wiersze; wiersz 1; x plus y, równa się 7; wiersz 2; 2 x plus 3 y; równa się 17")?;
+   return Ok(());
+}
+
+#[test]
+fn equation_step() -> Result<()> {
+    let expr = "<math>
+     <mrow>
+      <mtable>
+       <mtr> <mtd> <mrow> <mi>x</mi><mo>+</mo><mi>y</mi></mrow> </mtd>  <mtd><mo>=</mo> </mtd>  <mtd><mn>7</mn></mtd>  </mtr>
+       <mtr> <mtd> <mrow> <mn>2</mn><mi>x</mi><mo>+</mo><mn>3</mn><mi>y</mi></mrow></mtd>  <mtd><mo>=</mo></mtd>  <mtd><mrow><mn>17</mn></mrow></mtd> </mtr>
+      </mtable></mrow>
+    </math>
+   ";
+   test_ClearSpeak("pl", "ClearSpeak_MultiLineLabel", "Step", expr, "2 kroki; krok 1; x plus y, równa się 7; krok 2; 2 x plus 3 y; równa się 17")?;
+   return Ok(());
+}
+
+#[test]
+fn continued_row() -> Result<()> {
+  let expr = "<math>
+  <mtable intent=':system-of-equations'>
+   <mtr><mtd><mi>x</mi></mtd><mtd><mo>=</mo></mtd><mtd><mi>y</mi></mtd></mtr>
+   <mtr intent=':continued-row'><mtd/><mtd/><mtd><mrow><mo>+</mo><mn>1</mn></mrow></mtd></mtr>
+   <mtr><mtd><mi>y</mi></mtd><mtd><mo>=</mo></mtd><mtd><mn>1</mn></mtd></mtr>
+  </mtable>
+</math>";
+test("pl", "SimpleSpeak", expr,
+     "2 równanies; równanie 1; x równa się y plus 1; równanie 2; y równa się 1")?;
+    return Ok(());
+}

--- a/tests/Languages/pl/ClearSpeak/sets.rs
+++ b/tests/Languages/pl/ClearSpeak/sets.rs
@@ -1,0 +1,531 @@
+use crate::common::*;
+use anyhow::Result;
+
+#[test]
+fn complex() -> Result<()> {
+    let expr = "<math>
+                    <mi>ℂ</mi>
+                </math>";
+    test("pl", "ClearSpeak", expr, "liczby zespolone")?;
+    return Ok(());
+
+}
+
+#[test]
+fn natural() -> Result<()> {
+    let expr = "<math>
+                    <mi>ℕ</mi>
+                </math>";
+    test("pl", "ClearSpeak", expr, "liczby naturalne")?;
+    return Ok(());
+
+}
+
+#[test]
+fn rationals() -> Result<()> {
+    let expr = "<math>
+                    <mi>ℚ</mi>
+                </math>";
+    test("pl", "ClearSpeak", expr, "liczby wymierne")?;
+    return Ok(());
+
+}
+
+#[test]
+fn reals() -> Result<()> {
+    let expr = "<math>
+                    <mi>ℝ</mi>
+                </math>";
+    test("pl", "ClearSpeak", expr, "liczby rzeczywiste")?;
+    return Ok(());
+
+}
+
+#[test]
+fn integers() -> Result<()> {
+    let expr = "<math>
+                    <mi>ℤ</mi>
+                </math>";
+    test("pl", "ClearSpeak", expr, "liczby całkowite")?;
+    return Ok(());
+
+}
+
+
+
+#[test]
+fn msup_complex() -> Result<()> {
+    let expr = "<math>
+                <msup>
+                    <mi>ℂ</mi>
+                    <mn>2</mn>
+                </msup>
+                </math>";
+    test("pl", "ClearSpeak", expr, "C 2")?;
+    return Ok(());
+
+}
+
+#[test]
+fn msup_natural() -> Result<()> {
+    let expr = "<math>
+                <msup>
+                    <mi>ℕ</mi>
+                    <mn>2</mn>
+                </msup>
+            </math>";
+    test("pl", "ClearSpeak", expr, "N 2")?;
+    return Ok(());
+
+}
+
+#[test]
+fn msup_rationals() -> Result<()> {
+    let expr = "<math>
+                <msup>
+                    <mi>ℚ</mi>
+                    <mn>2</mn>
+                </msup>
+            </math>";
+    test("pl", "ClearSpeak", expr, "Q 2")?;
+    return Ok(());
+
+}
+
+#[test]
+fn msup_reals() -> Result<()> {
+    let expr = "<math>
+                <msup>
+                    <mi>ℝ</mi>
+                    <mn>3</mn>
+                </msup>
+            </math>";
+    test("pl", "ClearSpeak", expr, "R 3")?;
+    return Ok(());
+
+}
+
+#[test]
+fn msup_integers() -> Result<()> {
+    let expr = "<math>
+                <msup>
+                    <mi>ℤ</mi>
+                    <mn>4</mn>
+                </msup>
+            </math>";
+    test("pl", "ClearSpeak", expr, "Z 4")?;
+    return Ok(());
+
+}
+
+#[test]
+fn msup_positive_integers() -> Result<()> {
+    let expr = "<math>
+                <msup>
+                    <mi>ℤ</mi>
+                    <mo>+</mo>
+                </msup>
+            </math>";
+    test("pl", "ClearSpeak", expr, "plus liczby całkowite")?;
+    return Ok(());
+
+}
+
+#[test]
+fn msup_negative_integers() -> Result<()> {
+    let expr = "<math>
+                <msup>
+                    <mi>ℤ</mi>
+                    <mo>-</mo>
+                </msup>
+            </math>";
+    test("pl", "ClearSpeak", expr, "minus liczby całkowite")?;
+    return Ok(());
+
+}
+
+#[test]
+fn msup_positive_rationals() -> Result<()> {
+    let expr = "<math>
+                <msup>
+                    <mi>ℚ</mi>
+                    <mo>+</mo>
+                </msup>
+            </math>";
+    test("pl", "ClearSpeak", expr, "plus liczby wymierne")?;
+    return Ok(());
+
+}
+
+#[test]
+fn msup_negative_rationals() -> Result<()> {
+    let expr = "<math>
+                <msup>
+                    <mi>ℚ</mi>
+                    <mo>-</mo>
+                </msup>
+            </math>";
+    test("pl", "ClearSpeak", expr, "minus liczby wymierne")?;
+    return Ok(());
+
+}
+
+#[test]
+fn empty_set() -> Result<()> {
+    let expr = "<math>
+                <mo>{</mo> <mo>}</mo>
+            </math>";
+    test("pl", "ClearSpeak", expr, "zbiór pusty")?;
+    return Ok(());
+
+}
+
+#[test]
+fn single_element_set() -> Result<()> {
+    let expr = "<math>
+                <mo>{</mo> <mn>12</mn><mo>}</mo>
+            </math>";
+    test("pl", "ClearSpeak", expr, "zbiór 12")?;
+    return Ok(());
+
+}
+
+#[test]
+fn multiple_element_set() -> Result<()> {
+    let expr = "<math>
+                <mo>{</mo> <mn>5</mn> <mo>,</mo> <mn>10</mn>  <mo>,</mo> <mn>15</mn> <mo>}</mo>
+            </math>";
+    test("pl", "ClearSpeak", expr, "zbiór 5 przecinek, 10 przecinek, 15")?;
+    return Ok(());
+
+}
+
+#[test]
+fn set_with_colon() -> Result<()> {
+    let expr = "<math>
+                    <mo>{</mo> <mrow><mi>x</mi><mo>:</mo><mi>x</mi><mo>&#x003E;</mo><mn>2</mn></mrow> <mo>}</mo>
+            </math>";
+    test("pl", "ClearSpeak", expr, "zbiór wszystkie x takich że x jest większe niż 2")?;
+    return Ok(());
+
+}
+
+#[test]
+fn set_with_bar() -> Result<()> {
+    let expr = "<math>
+                    <mo>{</mo> <mrow><mi>x</mi><mo>|</mo><mi>x</mi><mo>&#x003E;</mo><mn>2</mn></mrow> <mo>}</mo>
+            </math>";
+    test("pl", "ClearSpeak", expr, "zbiór wszystkie x takich że x jest większe niż 2")?;
+    return Ok(());
+
+}
+
+#[test]
+fn element_alone() -> Result<()> {
+    let expr = "<math>
+            <mn>3</mn><mo>+</mo><mn>2</mn><mi>i</mi><mo>∉</mo><mi>ℝ</mi>
+        </math>";
+    test("pl", "ClearSpeak", expr, "3 plus 2 i, nie jest elementem zbioru, liczby rzeczywiste")?;
+    return Ok(());
+
+}
+
+#[test]
+fn element_under_sum() -> Result<()> {
+    let expr = "<math>
+            <munder>
+                <mo>∑</mo>
+                <mrow> <mi>i</mi> <mo>∈</mo> <mi>ℤ</mi> </mrow>
+            </munder>
+            <mfrac>
+                <mn>1</mn>
+                <mrow> <msup>  <mi>i</mi> <mn>2</mn> </msup> </mrow>
+            </mfrac>
+        </math>";
+    test("pl", "ClearSpeak", expr,
+                    "suma przez i jest elementem zbioru, liczby całkowite z; ułamek z licznikiem 1; i mianownikiem i do kwadratu")?;
+                    return Ok(());
+
+}
+
+#[test]
+fn complicated_set_with_colon() -> Result<()> {
+    let expr = "<math>
+            <mo>{</mo>
+            <mi>x</mi>
+            <mo>∈</mo>
+            <mi>ℤ</mi>
+            <mo>:</mo>
+            <mn>2</mn>
+            <mo>&#x003C;</mo>
+            <mi>x</mi>
+            <mo>&#x003C;</mo>
+            <mn>7</mn>
+            <mo>}</mo>
+        </math>";
+    test("pl", "ClearSpeak", expr, "zbiór wszystkie x do liczby całkowite takich że 2 jest mniejsze niż x jest mniejsze niż 7")?;
+    return Ok(());
+
+}
+
+#[test]
+fn complicated_set_with_mtext() -> Result<()> {
+    // as of 8/5/21, parsing of "|" is problematic in the example, so <mrows> are needed for this test
+    let expr = "<math>
+        <mo>{</mo>
+        <mrow> <mi>x</mi><mo>∈</mo><mi>ℕ</mi></mrow>
+        <mo>|</mo>
+        <mrow><mi>x</mi> <mtext>is an even number</mtext> </mrow>
+        <mo>}</mo>
+        </math>";
+    test("pl", "ClearSpeak", expr, 
+            "zbiór wszystkie x do liczby naturalne takich że x is an even number")?;
+            return Ok(());
+
+}
+
+
+#[test]
+fn set_with_bar_member() -> Result<()> {
+    let expr = "<math>
+            <mo>{</mo>
+            <mi>x</mi>
+            <mo>∈</mo>
+            <mi>ℤ</mi>
+            <mo>:</mo>
+            <mi>x</mi>
+            <mo>&#x003E;</mo>
+            <mn>5</mn>
+            <mo>}</mo>
+            </math>";
+    test_ClearSpeak("pl", "ClearSpeak_SetMemberSymbol", "Member",
+                expr, "zbiór wszystkie x element zbioru liczby całkowite takich że x jest większe niż 5")?;
+                return Ok(());
+
+}
+
+#[test]
+fn element_alone_member() -> Result<()> {
+    let expr = "<math>
+            <mn>3</mn><mo>+</mo><mn>2</mn><mi>i</mi><mo>∉</mo><mi>ℝ</mi>
+        </math>";
+    test_ClearSpeak("pl", "ClearSpeak_SetMemberSymbol", "Member",
+                expr, "3 plus 2 i, nie jest elementem zbioru, liczby rzeczywiste")?;
+                return Ok(());
+
+}
+
+#[test]
+fn element_under_sum_member() -> Result<()> {
+    let expr = "<math>
+            <munder>
+                <mo>∑</mo>
+                <mrow> <mi>i</mi> <mo>∈</mo> <mi>ℤ</mi> </mrow>
+            </munder>
+            <mfrac>
+                <mn>1</mn>
+                <mrow> <msup>  <mi>i</mi> <mn>2</mn> </msup> </mrow>
+            </mfrac>
+        </math>";
+    test_ClearSpeak("pl", "ClearSpeak_SetMemberSymbol", "Member",
+                expr, "suma przez i jest elementem zbioru, liczby całkowite z; ułamek z licznikiem 1; i mianownikiem i do kwadratu")?;
+                return Ok(());
+
+}
+
+
+#[test]
+fn set_with_bar_element() -> Result<()> {
+    let expr = "<math>
+            <mo>{</mo>
+            <mi>x</mi>
+            <mo>∈</mo>
+            <mi>ℤ</mi>
+            <mo>:</mo>
+            <mi>x</mi>
+            <mo>&#x003E;</mo>
+            <mn>5</mn>
+            <mo>}</mo>
+            </math>";
+    test_ClearSpeak("pl", "ClearSpeak_SetMemberSymbol", "Element",
+                expr, "zbiór wszystkie x należy do liczby całkowite takich że x jest większe niż 5")?;
+                return Ok(());
+
+}
+
+#[test]
+fn element_alone_element() -> Result<()> {
+    let expr = "<math>
+            <mn>3</mn><mo>+</mo><mn>2</mn><mi>i</mi><mo>∉</mo><mi>ℝ</mi>
+        </math>";
+    test_ClearSpeak("pl", "ClearSpeak_SetMemberSymbol", "Element",
+                expr, "3 plus 2 i, nie jest elementem zbioru, liczby rzeczywiste")?;
+                return Ok(());
+
+}
+
+#[test]
+fn element_under_sum_element() -> Result<()> {
+    let expr = "<math>
+            <munder>
+                <mo>∑</mo>
+                <mrow> <mi>i</mi> <mo>∈</mo> <mi>ℤ</mi> </mrow>
+            </munder>
+            <mfrac>
+                <mn>1</mn>
+                <mrow> <msup>  <mi>i</mi> <mn>2</mn> </msup> </mrow>
+            </mfrac>
+        </math>";
+    test_ClearSpeak("pl", "ClearSpeak_SetMemberSymbol", "Element",
+                expr, "suma przez i jest elementem zbioru, liczby całkowite z; ułamek z licznikiem 1; i mianownikiem i do kwadratu")?;
+                return Ok(());
+
+}
+
+#[test]
+fn set_with_bar_in() -> Result<()> {
+    let expr = "<math>
+            <mo>{</mo>
+            <mi>x</mi>
+            <mo>∈</mo>
+            <mi>ℤ</mi>
+            <mo>:</mo>
+            <mi>x</mi>
+            <mo>&#x003E;</mo>
+            <mn>5</mn>
+            <mo>}</mo>
+            </math>";
+    test_ClearSpeak("pl", "ClearSpeak_SetMemberSymbol", "In",
+                expr, "zbiór wszystkie x do liczby całkowite takich że x jest większe niż 5")?;
+                return Ok(());
+
+}
+
+#[test]
+fn element_alone_in() -> Result<()> {
+    let expr = "<math>
+            <mn>3</mn><mo>+</mo><mn>2</mn><mi>i</mi><mo>∉</mo><mi>ℝ</mi>
+        </math>";
+    test_ClearSpeak("pl", "ClearSpeak_SetMemberSymbol", "In",
+                expr, "3 plus 2 i, nie należy do liczby rzeczywiste")?;
+                return Ok(());
+
+}
+
+#[test]
+fn element_under_sum_in() -> Result<()> {
+    let expr = "<math>
+            <munder>
+                <mo>∑</mo>
+                <mrow> <mi>i</mi> <mo>∈</mo> <mi>ℤ</mi> </mrow>
+            </munder>
+            <mfrac>
+                <mn>1</mn>
+                <mrow> <msup>  <mi>i</mi> <mn>2</mn> </msup> </mrow>
+            </mfrac>
+        </math>";
+    test_ClearSpeak("pl", "ClearSpeak_SetMemberSymbol", "In",
+                expr, "suma przez i należy do liczby całkowite z; ułamek z licznikiem 1; i mianownikiem i do kwadratu")?;
+                return Ok(());
+
+}
+
+#[test]
+fn set_with_bar_belongs() -> Result<()> {
+    let expr = "<math>
+            <mo>{</mo>
+            <mi>x</mi>
+            <mo>∈</mo>
+            <mi>ℤ</mi>
+            <mo>:</mo>
+            <mi>x</mi>
+            <mo>&#x003E;</mo>
+            <mn>5</mn>
+            <mo>}</mo>
+            </math>";
+    test_ClearSpeak("pl", "ClearSpeak_SetMemberSymbol", "Belongs",
+                expr, "zbiór wszystkie x należące do liczby całkowite takich że x jest większe niż 5")?;
+                return Ok(());
+
+}
+
+#[test]
+fn element_alone_belongs() -> Result<()> {
+    let expr = "<math>
+            <mn>3</mn><mo>+</mo><mn>2</mn><mi>i</mi><mo>∉</mo><mi>ℝ</mi>
+        </math>";
+    test_ClearSpeak("pl", "ClearSpeak_SetMemberSymbol", "Belongs",
+                expr, "3 plus 2 i, nie należy do liczby rzeczywiste")?;
+                return Ok(());
+
+}
+
+#[test]
+fn element_under_sum_belongs() -> Result<()> {
+    let expr = "<math>
+            <munder>
+                <mo>∑</mo>
+                <mrow> <mi>i</mi> <mo>∈</mo> <mi>ℤ</mi> </mrow>
+            </munder>
+            <mfrac>
+                <mn>1</mn>
+                <mrow> <msup>  <mi>i</mi> <mn>2</mn> </msup> </mrow>
+            </mfrac>
+        </math>";
+    test_ClearSpeak("pl", "ClearSpeak_SetMemberSymbol", "Belongs",
+                expr, "suma przez i należy do liczby całkowite z; ułamek z licznikiem 1; i mianownikiem i do kwadratu")?;
+                return Ok(());
+
+}
+
+
+#[test]
+fn set_member_woall() -> Result<()> {
+    let expr = "<math>
+            <mo>{</mo>
+            <mi>x</mi>
+            <mo>∈</mo>
+            <mi>ℤ</mi>
+            <mo>:</mo>
+            <mi>x</mi>
+            <mo>&#x003E;</mo>
+            <mn>5</mn>
+            <mo>}</mo>
+            </math>";
+            test_ClearSpeak_prefs("pl", vec![("ClearSpeak_SetMemberSymbol", "Member"), ("ClearSpeak_Sets", "woAll")],
+                expr, "zbiór x element zbioru liczby całkowite takich że x jest większe niż 5")?;
+                return Ok(());
+
+}
+
+#[test]
+fn multiple_element_set_woall() -> Result<()> {
+    let expr = "<math>
+                <mo>{</mo> <mn>5</mn> <mo>,</mo> <mn>10</mn>  <mo>,</mo> <mn>15</mn> <mo>}</mo>
+            </math>";
+    test_ClearSpeak("pl", "ClearSpeak_Sets", "woAll", expr, "zbiór 5 przecinek, 10 przecinek, 15")?;
+    return Ok(());
+
+}
+
+#[test]
+fn multiple_element_set_silent_bracket() -> Result<()> {
+    let expr = "<math>
+                <mo>{</mo> <mn>5</mn> <mo>,</mo> <mn>10</mn>  <mo>,</mo> <mn>15</mn> <mo>}</mo>
+            </math>";
+            test_ClearSpeak("pl", "ClearSpeak_Sets", "SilentBracket", expr, "5 przecinek, 10 przecinek, 15")?;
+            return Ok(());
+
+        }
+
+#[test]
+fn silent_bracket() -> Result<()> {
+    let expr = "<math>
+                <mo>{</mo><mrow><mi>x</mi><mo>|</mo><mi>x</mi><mo>&#x003E;</mo><mn>2</mn></mrow><mo>}</mo>
+            </math>";
+            test_ClearSpeak("pl", "ClearSpeak_Sets", "SilentBracket", expr,
+                    "zbiór wszystkie x takich że x jest większe niż 2")?;
+                    return Ok(());
+
+        }
+

--- a/tests/Languages/pl/ClearSpeak/symbols_and_adornments.rs
+++ b/tests/Languages/pl/ClearSpeak/symbols_and_adornments.rs
@@ -1,0 +1,377 @@
+use crate::common::*;
+use anyhow::Result;
+
+#[test]
+fn multiplication() -> Result<()> {
+    let expr = "<math>
+                    <mn>2</mn><mo>×</mo><mn>3</mn>
+                </math>";
+    test("pl", "ClearSpeak", expr, "2 razy 3")?;
+    return Ok(());
+
+}
+
+#[test]
+fn multiplication_by() -> Result<()> {
+    let expr = "<math>
+                    <mn>2</mn><mo>×</mo><mn>3</mn>
+                </math>";
+    test_ClearSpeak("pl", "ClearSpeak_MultSymbolX", "By", expr, "2 na 3")?;
+    return Ok(());
+
+}
+
+#[test]
+fn multiplication_cross() -> Result<()> {
+    let expr = "<math>
+                    <mi>u</mi><mo>×</mo><mi>v</mi>
+                </math>";
+    test_ClearSpeak("pl", "ClearSpeak_MultSymbolX", "Cross", expr, "u krzyż v")?;
+    return Ok(());
+
+}
+
+#[test]
+fn ellipses_auto_start() -> Result<()> {
+    let expr = "<math>
+            <mi>…</mi><mo>,</mo>
+            <mo>-</mo><mn>2</mn><mo>,</mo><mo>-</mo><mn>1</mn><mo>,</mo><mn>0</mn>
+        </math>";
+    test("pl", "ClearSpeak", expr, "trzy kropki przecinek, minus 2 przecinek, minus 1 przecinek, 0")?;
+    return Ok(());
+
+}
+
+#[test]
+fn ellipses_auto_end() -> Result<()> {
+    let expr = "<math>
+            <mn>1</mn>
+            <mo>,</mo>
+            <mn>2</mn>
+            <mo>,</mo>
+            <mn>3</mn>
+            <mo>,</mo>
+            <mi>…</mi>
+        </math>";
+    test_ClearSpeak("pl", "ClearSpeak_Ellipses", "Auto", expr, "1 przecinek, 2 przecinek, 3 przecinek, trzy kropki")?;
+    return Ok(());
+
+}
+
+#[test]
+fn ellipses_auto_middle() -> Result<()> {
+    let expr = "<math>
+            <mrow>
+                <mn>1</mn>
+                <mo>,</mo>
+                <mn>2</mn>
+                <mo>,</mo>
+                <mn>3</mn>
+                <mo>,</mo>
+                <mi>…</mi>
+                <mo>,</mo>
+                <mn>20</mn>
+            </mrow>
+        </math>";
+    test_ClearSpeak("pl", "ClearSpeak_Ellipses", "Auto", expr,
+            "1 przecinek, 2 przecinek, 3 przecinek, trzy kropki przecinek, 20")?;
+            return Ok(());
+
+}
+
+#[test]
+fn ellipses_auto_both() -> Result<()> {
+    let expr = "<math>
+            <mi>…</mi><mo>,</mo>
+            <mo>-</mo><mn>2</mn><mo>,</mo><mo>-</mo><mn>1</mn><mo>,</mo><mn>0</mn><mo>,</mo><mn>1</mn><mo>,</mo><mn>2</mn>
+            <mo>,</mo><mi>…</mi>
+       </math>";
+    test_ClearSpeak("pl", "ClearSpeak_Ellipses", "Auto", expr,
+            "trzy kropki przecinek, minus 2 przecinek, minus 1 przecinek, 0 przecinek, 1 przecinek, 2 przecinek, trzy kropki")?;
+            return Ok(());
+
+}
+
+#[test]
+fn ellipses_and_so_on_start() -> Result<()> {
+    let expr = "<math>
+            <mi>…</mi><mo>,</mo>
+            <mo>-</mo><mn>2</mn><mo>,</mo><mo>-</mo><mn>1</mn><mo>,</mo><mn>0</mn>
+        </math>";
+        test_ClearSpeak("pl", "ClearSpeak_Ellipses", "AndSoOn", expr, "trzy kropki przecinek, minus 2 przecinek, minus 1 przecinek, 0")?;
+        return Ok(());
+
+}
+
+#[test]
+fn ellipses_and_so_on_end() -> Result<()> {
+    let expr = "<math>
+            <mn>1</mn>
+            <mo>,</mo>
+            <mn>2</mn>
+            <mo>,</mo>
+            <mn>3</mn>
+            <mo>,</mo>
+            <mi>…</mi>
+        </math>";
+    test_ClearSpeak("pl", "ClearSpeak_Ellipses", "AndSoOn", expr, "1 przecinek, 2 przecinek, 3 i tak dalej")?;
+    return Ok(());
+
+}
+
+#[test]
+fn ellipses_and_so_on_middle() -> Result<()> {
+    let expr = "<math>
+            <mrow>
+                <mn>1</mn>
+                <mo>,</mo>
+                <mn>2</mn>
+                <mo>,</mo>
+                <mn>3</mn>
+                <mo>,</mo>
+                <mi>…</mi>
+                <mo>,</mo>
+                <mn>20</mn>
+            </mrow>
+        </math>";
+    test_ClearSpeak("pl", "ClearSpeak_Ellipses", "AndSoOn", expr,
+            "1 przecinek, 2 przecinek, 3 i tak dalej aż do 20")?;
+            return Ok(());
+
+}
+
+#[test]
+fn ellipses_and_so_on_both() -> Result<()> {
+    let expr = "<math>
+            <mi>…</mi><mo>,</mo>
+            <mo>-</mo><mn>2</mn><mo>,</mo><mo>-</mo><mn>1</mn><mo>,</mo><mn>0</mn><mo>,</mo><mn>1</mn><mo>,</mo><mn>2</mn>
+            <mo>,</mo><mi>…</mi>
+       </math>";
+    test_ClearSpeak("pl", "ClearSpeak_Ellipses", "AndSoOn", expr,
+            "trzy kropki przecinek, minus 2 przecinek, minus 1 przecinek, 0 przecinek, 1 przecinek, 2 przecinek, trzy kropki")?;
+            return Ok(());
+
+}
+
+#[test]
+fn vertical_line_auto() -> Result<()> {
+    let expr = "<math>
+        <mn>3</mn><mo>|</mo><mn>6</mn>
+    </math>";
+    test_ClearSpeak("pl", "ClearSpeak_VerticalLine", "Auto", expr,
+            "3 dzieli 6")?;
+            return Ok(());
+
+}
+
+#[test]
+fn vertical_line_divides() -> Result<()> {
+    let expr = "<math>
+        <mn>3</mn><mo>|</mo><mn>6</mn>
+    </math>";
+    test_ClearSpeak("pl", "ClearSpeak_VerticalLine", "Divides", expr,
+            "3 dzieli 6")?;
+            return Ok(());
+
+}
+
+    #[test]
+    fn vertical_line_given() -> Result<()> {
+        let expr = "<math>
+            <mn>3</mn><mo>|</mo><mn>6</mn>
+        </math>";
+        test_ClearSpeak("pl", "ClearSpeak_VerticalLine", "Given", expr,
+                "3 pod warunkiem 6")?;
+                return Ok(());
+
+    }
+
+    #[test]
+    fn vertical_line_probability_given() -> Result<()> {
+        let expr = "<math>
+                <mi>P</mi>
+                <mrow>
+                    <mo>(</mo>
+                    <mrow>
+                        <mi>A</mi>
+                        <mo>|</mo>
+                        <mi>B</mi>
+                    </mrow>
+                    <mo>)</mo>
+                </mrow>
+            </math>";
+        test_ClearSpeak_prefs("pl", vec![("ClearSpeak_VerticalLine", "Given"), ("ClearSpeak_ImpliedTimes", "None")]
+                        , expr, "wielka p; nawias otwierający, wielka a pod warunkiem wielka b; nawias zamykający")?;
+                        return Ok(());
+    }
+
+#[test]
+fn vertical_line_set() -> Result<()> {
+    let expr = "<math>
+        <mo>{</mo>
+        <mrow>
+            <mi>x</mi>
+            <mo>|</mo>
+            <mi>x</mi>
+            <mo>&gt;</mo>
+            <mn>0</mn>
+        </mrow>
+        <mo>}</mo>    
+    </math>";
+    test_ClearSpeak("pl", "ClearSpeak_VerticalLine", "Auto", expr,
+            "zbiór wszystkie x takich że x jest większe niż 0")?;
+            return Ok(());
+
+}
+
+
+#[test]
+fn vertical_line_set_such_that() -> Result<()> {
+    let expr = "<math>
+        <mo>{</mo>
+        <mrow>
+            <mi>x</mi>
+            <mo>|</mo>
+            <mi>x</mi>
+            <mo>&gt;</mo>
+            <mn>0</mn>
+        </mrow>
+        <mo>}</mo>    
+    </math>";
+    test_ClearSpeak("pl", "ClearSpeak_VerticalLine", "SuchThat", expr,
+            "zbiór wszystkie x takich że x jest większe niż 0")?;
+            return Ok(());
+
+}
+
+#[test]
+fn vertical_line_set_given() -> Result<()> {
+    let expr = "<math>
+        <mo>{</mo>
+        <mrow>
+            <mi>x</mi>
+            <mo>|</mo>
+            <mi>x</mi>
+            <mo>&gt;</mo>
+            <mn>0</mn>
+        </mrow>
+        <mo>}</mo>    
+    </math>";
+    // the rules for set will override all the options -- ClearSpeak spec should be clarified
+    test_ClearSpeak("pl", "ClearSpeak_VerticalLine", "Given", expr,
+            "zbiór wszystkie x takich że x jest większe niż 0")?;
+            return Ok(());
+
+}
+
+#[test]
+fn vertical_line_set_and_abs() -> Result<()> {
+    let expr = "<math>
+            <mo>{</mo>
+            <mrow>
+                <mi>x</mi>
+                <mo>&#x007C;</mo>
+                <mrow>
+                    <mo>|</mo>
+                    <mi>x</mi>
+                    <mo>|</mo>
+                </mrow>
+                <mo>&gt;</mo>
+                <mn>2</mn>
+            </mrow>
+            <mo>}</mo>
+        </math>";
+    test_ClearSpeak("pl", "ClearSpeak_VerticalLine", "Auto", expr,
+        "zbiór wszystkie x takich że wartość bezwzględna z x; jest większe niż 2")?;
+        return Ok(());
+
+}
+
+#[test]
+fn vertical_line_evaluated_at() -> Result<()> {
+    let expr = "<math>
+            <mi>f</mi>
+            <mrow>
+                <mo>(</mo>
+                <mi>x</mi>
+                <mo>)</mo>
+            </mrow>
+            <msub>
+                <mo>&#x007C;</mo>
+                <mrow>
+                    <mi>x</mi>
+                    <mo>=</mo>
+                    <mn>5</mn>
+                </mrow>
+            </msub>
+        </math>";
+    test_ClearSpeak("pl", "ClearSpeak_VerticalLine", "Auto", expr,
+        "f z x obliczone w, x równa się 5")?;
+        return Ok(());
+
+}
+
+#[test]
+fn vertical_line_evaluated_at_both() -> Result<()> {
+    let expr = "<math>
+            <msup>
+            <mi>x</mi>
+            <mn>2</mn>
+            </msup>
+            <mo>+</mo>
+            <mi>x</mi>
+            <msubsup>
+                <mstyle mathsize='140%' displaystyle='true'> <mo>&#x007C;</mo> </mstyle>
+                <mn>0</mn>
+                <mn>1</mn>
+            </msubsup>
+        </math>";
+    test_ClearSpeak("pl", "ClearSpeak_VerticalLine", "Auto", expr,
+        "x do kwadratu plus x, obliczone w 1 minus to samo wyrażenie obliczone w 0")?;
+        return Ok(());
+
+}
+#[test]
+fn vertical_line_evaluated_at_divides() -> Result<()> {
+    let expr = "<math>
+            <mi>f</mi>
+            <mrow>
+                <mo>(</mo>
+                <mi>x</mi>
+                <mo>)</mo>
+            </mrow>
+            <msub>
+                <mo>&#x007C;</mo>
+                <mrow>
+                    <mi>x</mi>
+                    <mo>=</mo>
+                    <mn>5</mn>
+                </mrow>
+            </msub>
+        </math>";
+    test_ClearSpeak("pl", "ClearSpeak_VerticalLine", "Divides", expr,
+        "f z x obliczone w, x równa się 5")?;
+        return Ok(());
+
+}
+
+#[test]
+fn vertical_line_evaluated_at_both_given() -> Result<()> {
+    let expr = "<math>
+            <msup>
+            <mi>x</mi>
+            <mn>2</mn>
+            </msup>
+            <mo>+</mo>
+            <mi>x</mi>
+            <msubsup>
+                <mstyle mathsize='140%' displaystyle='true'> <mo>&#x007C;</mo> </mstyle>
+                <mn>0</mn>
+                <mn>1</mn>
+            </msubsup>
+        </math>";
+    test_ClearSpeak("pl", "ClearSpeak_VerticalLine", "Given", expr,
+        "x do kwadratu plus x, obliczone w 1 minus to samo wyrażenie obliczone w 0")?;
+        return Ok(());
+
+}

--- a/tests/Languages/pl/SimpleSpeak/functions.rs
+++ b/tests/Languages/pl/SimpleSpeak/functions.rs
@@ -1,0 +1,412 @@
+/// Tests for:
+/// *  functions including trig functions, logs, and functions to powers
+/// *  implied times/functional call and explicit times/function call
+/// *  parens
+/// These are all intertwined, so they are in one file
+use crate::common::*;
+use anyhow::Result;
+
+#[test]
+fn trig_names() -> Result<()> {
+    let expr = "<math><mrow>
+    <mi>sin</mi><mi>x</mi><mo>+</mo>
+    <mi>cos</mi><mi>y</mi><mo>+</mo>
+    <mi>tan</mi><mi>z</mi><mo>+</mo>
+    <mi>sec</mi><mi>&#x03B1;</mi><mo>+</mo>
+    <mi>csc</mi><mi>&#x03D5;</mi><mo>+</mo>
+    <mi>cot</mi><mi>&#x03C6;</mi>
+    </mrow></math>";
+    test("pl", "SimpleSpeak", expr, "sinus z x plus cosinus z y plus tangens z z plus sekans z alfa, plus kosekans z fi plus cotangens z fi")?;
+    return Ok(());
+
+}
+
+#[test]
+fn hyperbolic_trig_names() -> Result<()> {
+    let expr = "<math><mrow>
+    <mi>sinh</mi><mi>x</mi><mo>+</mo>
+    <mi>cosh</mi><mi>y</mi><mo>+</mo>
+    <mi>tanh</mi><mi>z</mi><mo>+</mo>
+    <mi>sech</mi><mi>&#x03B1;</mi><mo>+</mo>
+    <mi>csch</mi><mi>&#x03D5;</mi><mo>+</mo>
+    <mi>coth</mi><mi>&#x03C6;</mi>
+    </mrow></math>";
+    test("pl", "SimpleSpeak", expr, "sinus hiperboliczny z x, plus cosinus hiperboliczny z y, plus tangens hiperboliczny z z, plus sekans hiperboliczny z alfa, plus kosekans hiperboliczny z fi, plus cotangens hiperboliczny z fi")?;
+                                return Ok(());
+
+}
+
+
+#[test]
+fn inverse_trig() -> Result<()> {
+    let expr = "<math><msup><mi>sin</mi><mrow><mo>-</mo><mn>1</mn></mrow></msup><mi>x</mi></math>";
+    test("pl", "SimpleSpeak", expr, "odwrotność sinus z x")?;
+    return Ok(());
+
+}
+
+#[test]
+fn trig_squared() -> Result<()> {
+    let expr = "<math><msup><mi>sin</mi><mn>2</mn></msup><mi>x</mi></math>";
+    test("pl", "SimpleSpeak", expr, "sinus do kwadratu z x")?;
+    return Ok(());
+
+}
+
+#[test]
+fn trig_cubed() -> Result<()> {
+    let expr = "<math><msup><mi>tan</mi><mn>3</mn></msup><mi>x</mi></math>";
+    test("pl", "SimpleSpeak", expr, "tangens do sześcianu z x")?;
+    return Ok(());
+
+}
+
+#[test]
+fn trig_fourth() -> Result<()> {
+    let expr = "<math><msup><mi>sec</mi><mn>4</mn></msup><mi>x</mi></math>";
+    test("pl", "SimpleSpeak", expr, "sekans do potęgi czwartej, z x")?;
+    return Ok(());
+
+}
+
+
+#[test]
+fn trig_power_other() -> Result<()> {
+    let expr = "<math><msup><mi>sinh</mi><mrow>><mi>n</mi><mo>-</mo><mn>1</mn></mrow></msup><mi>x</mi></math>";
+    test("pl", "SimpleSpeak", expr, "sinus hiperboliczny do potęgi n minus 1, z x")?;
+    return Ok(());
+
+}
+
+#[test]
+fn simple_log() -> Result<()> {
+    let expr = "<math> <mrow>  <mi>log</mi><mi>x</mi></mrow> </math>";
+    test("pl", "SimpleSpeak", expr, "logarytm z x")?;
+    return Ok(());
+
+}
+
+#[test]
+fn principal_value_log() -> Result<()> {
+    let expr = "<math><mrow><mi>Log</mi><mi>z</mi></mrow></math>";
+    test("pl", "SimpleSpeak", expr, "Log z z")?;
+    return Ok(());
+
+}
+
+#[test]
+fn normal_log() -> Result<()> {
+    let expr = "<math><mrow><mi>log</mi><mrow><mo>(</mo><mrow><mi>x</mi><mo>+</mo><mi>y</mi></mrow><mo>)</mo></mrow></mrow></math>";
+    test("pl", "SimpleSpeak", expr, "logarytm z, nawias otwierający, x plus y, nawias zamykający")?;
+    return Ok(());
+
+}
+
+#[test]
+fn simple_log_with_base() -> Result<()> {
+    let expr = "<math> <mrow>  <msub><mi>log</mi><mi>b</mi></msub><mi>x</mi></mrow> </math>";
+    test("pl", "SimpleSpeak", expr, "logarytm o podstawie b, z x")?;
+    return Ok(());
+
+}
+
+#[test]
+fn normal_log_with_base() -> Result<()> {
+    let expr = "<math><mrow><msub><mi>log</mi><mi>b</mi></msub><mrow><mo>(</mo><mrow><mi>x</mi><mo>+</mo><mi>y</mi></mrow><mo>)</mo></mrow></mrow></math>";
+    test("pl", "SimpleSpeak", expr, "logarytm o podstawie b, z, nawias otwierający, x plus y, nawias zamykający")?;
+    return Ok(());
+
+}
+
+#[test]
+fn normal_ln() -> Result<()> {
+    let expr = "<math><mrow><mi>ln</mi><mrow><mo>(</mo><mrow><mi>x</mi><mo>+</mo><mi>y</mi></mrow><mo>)</mo></mrow></mrow></math>";
+    test_prefs("pl", "SimpleSpeak", vec![("Verbosity", "Terse")],
+                expr, "l n, otwórz x plus y zamknij")?;
+    test_prefs("pl", "SimpleSpeak", vec![("Verbosity", "Medium")],
+                expr, "logarytm naturalny z, nawias otwierający, x plus y, nawias zamykający")?;
+    test_prefs("pl", "SimpleSpeak", vec![("Verbosity", "Verbose")],
+                expr, "logarytm naturalny z, nawias otwierający, x plus y, nawias zamykający")?;
+                return Ok(());
+
+}
+
+#[test]
+fn simple_ln() -> Result<()> {
+    let expr = "<math> <mrow>  <mi>ln</mi><mi>x</mi></mrow> </math>";
+    test_prefs("pl", "SimpleSpeak", vec![("Verbosity", "Terse")],
+                expr, "l n x")?;
+    test_prefs("pl", "SimpleSpeak", vec![("Verbosity", "Medium")],
+                expr, "logarytm naturalny z x")?;
+    test_prefs("pl", "SimpleSpeak", vec![("Verbosity", "Verbose")],
+                expr, "logarytm naturalny z x")?;
+                return Ok(());
+
+}
+
+#[test]
+fn other_names() -> Result<()> {
+    let expr = "<math> <mrow><mi>Cov</mi><mi>x</mi></mrow> </math>";
+    test_prefs("pl", "SimpleSpeak", vec![("Verbosity", "Terse")],
+                expr, "kowariancja x")?;
+    test_prefs("pl", "SimpleSpeak", vec![("Verbosity", "Medium")],
+                expr, "kowariancja x")?;
+    let expr = "<math> <mrow><mi>exp</mi><mo>(</mo><mi>x</mi><mo>)</mo></mrow> </math>";
+    test_prefs("pl", "SimpleSpeak", vec![("Verbosity", "Terse")],
+                expr, "eksponenta x")?;
+    test_prefs("pl", "SimpleSpeak", vec![("Verbosity", "Medium")],
+                expr, "funkcja wykładnicza z x")?;
+                return Ok(());
+
+}
+
+#[test]
+fn explicit_function_call_with_parens() -> Result<()> {
+    let expr = "<math><mrow><mi>t</mi><mo>&#x2061;</mo><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>";
+    test("pl", "SimpleSpeak", expr, "t z x")?;
+    return Ok(());
+
+}
+
+
+#[test]
+fn explicit_times_with_parens() -> Result<()> {
+    let expr = "<math><mrow><mi>t</mi><mo>&#x2062;</mo><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>";
+    test("pl", "SimpleSpeak", expr, "t razy x")?;
+    return Ok(());
+
+}
+
+#[test]
+fn explicit_function_call() -> Result<()> {
+    let expr = "<math><mrow><mi>t</mi><mo>&#x2061;</mo><mrow><mi>x</mi></mrow></mrow></math>";
+    test("pl", "SimpleSpeak", expr, "t z x")?;
+    return Ok(());
+
+}
+
+#[test]
+fn explicit_times() -> Result<()> {
+    let expr = "<math><mrow><mi>t</mi><mo>&#x2062;</mo><mrow><mi>x</mi></mrow></mrow></math>";
+    test("pl", "SimpleSpeak", expr, "t x")?;
+    return Ok(());
+
+}
+
+
+/*
+    * Tests for times
+    */
+#[test]
+fn no_times_binomial() -> Result<()> {
+    let expr = "<math><mrow><mi>x</mi> <mo>&#x2062;</mo> <mi>y</mi></mrow></math>";
+    test("pl", "SimpleSpeak", expr, "x y")?;
+    return Ok(());
+
+}
+
+#[test]
+fn times_following_paren() -> Result<()> {
+    let expr = "<math><mrow>
+        <mn>2</mn>
+        <mrow>  <mo>(</mo> <mn>3</mn>  <mo>)</mo> </mrow>
+        </mrow></math>";
+    test("pl", "SimpleSpeak", expr, "2 razy 3")?;
+    return Ok(());
+
+}
+
+#[test]
+fn times_preceding_paren() -> Result<()> {
+    let expr = "<math><mrow>
+        <mrow>  <mo>(</mo> <mn>2</mn>  <mo>)</mo> </mrow>
+        <mn>3</mn>
+        </mrow></math>";
+    test("pl", "SimpleSpeak", expr, "2 razy 3")?;
+    return Ok(());
+
+}
+
+#[test]
+fn no_times_sqrt() -> Result<()> {
+    let expr = "<math><mrow>
+        <msqrt> <mi>a</mi>  </msqrt>
+        <msqrt> <mi>b</mi>  </msqrt>
+        <mo>=</mo>
+        <msqrt> <mrow>  <mi>a</mi><mi>b</mi></mrow> </msqrt>
+        </mrow></math>";
+    test("pl", "SimpleSpeak", expr, 
+            "pierwiastek kwadratowy z a; razy pierwiastek kwadratowy z b; równa się, pierwiastek kwadratowy z a b, koniec pierwiastka")?;
+    test_prefs("pl", "SimpleSpeak", vec![("Impairment", "LearningDisability")], expr,
+            "pierwiastek kwadratowy z a; razy pierwiastek kwadratowy z b; równa się, pierwiastek kwadratowy z a b")?;
+            return Ok(());
+
+}
+
+/*
+    * Tests for parens
+    */
+    #[test]
+    fn no_parens_number() -> Result<()> {
+        let expr = "<math><mrow>
+        <mrow><mo>(</mo>
+        <mn>25</mn>
+        <mo>)</mo></mrow>
+        <mi>x</mi>
+        </mrow></math>";
+        test("pl", "SimpleSpeak", expr, "25 razy x")?;
+        return Ok(());
+
+    }
+
+    #[test]
+    fn no_parens_monomial() -> Result<()> {
+        let expr = "<math><mrow>
+        <mi>b</mi>
+        <mrow><mo>(</mo>
+        <mrow><mi>x</mi><mi>y</mi></mrow>
+        <mo>)</mo></mrow>
+        </mrow></math>";
+        test("pl", "SimpleSpeak", expr, "b, nawias otwierający, x y nawias zamykający")?;
+        return Ok(());
+
+    }
+
+    #[test]
+    fn no_parens_negative_number() -> Result<()> {
+        let expr = "<math><mrow>
+        <mn>2</mn><mo>+</mo>
+        <mrow><mo>(</mo>
+        <mrow><mo>&#x2212;</mo><mn>2</mn></mrow>
+        <mo>)</mo></mrow>
+        </mrow></math>";
+        test("pl", "SimpleSpeak", expr, "2 plus minus 2")?;
+        return Ok(());
+
+    }
+
+
+    #[test]
+    fn no_parens_negative_number_with_var() -> Result<()> {
+        let expr = "<math><mrow>
+        <mrow><mo>(</mo>
+        <mrow><mo>&#x2212;</mo><mn>2</mn></mrow><mi>x</mi>
+        <mo>)</mo></mrow>
+        <mo>+</mo><mn>1</mn>
+        </mrow></math>";
+        test("pl", "SimpleSpeak", expr, "minus 2 x, plus 1")?;
+        return Ok(());
+
+    }
+
+    #[test]
+    fn parens_superscript() -> Result<()> {
+        let expr = "<math><mrow>
+        <mrow>
+        <msup>
+        <mrow>
+            <mrow><mo>(</mo>
+            <mrow> <mn>2</mn><mi>x</mi></mrow>
+            <mo>)</mo></mrow></mrow>
+        <mn>2</mn>
+        </msup>
+        </mrow>
+    </mrow></math>";
+        test("pl", "SimpleSpeak", expr, "nawias otwierający, 2 x nawias zamykający do kwadratu")?;
+        return Ok(());
+
+    }
+
+    #[test]
+    fn no_parens_fraction() -> Result<()> {
+        let expr = "<math><mrow>
+        <mn>2</mn>
+        <mo>+</mo>
+        <mrow>
+            <mrow><mo>(</mo>
+            <mfrac> <mn>1</mn><mn>2</mn></mfrac>
+            <mo>)</mo></mrow></mrow>
+    </mrow></math>";
+        test("pl", "SimpleSpeak", expr, "2 plus jedna druga")?;
+        return Ok(());
+
+    }
+
+
+    // Tests for the four types of intervals in SimpleSpeak
+    #[test]
+    fn parens_interval_open_open() -> Result<()> {
+        let expr = "<math> 
+        <mrow intent='open-interval($start, $end)'><mo>(</mo>
+        <mrow> <mo arg='open'>(</mo><mi arg='start'>c</mi><mo>,</mo><mi arg='end'>d</mi></mrow><mo arg='close'>)</mo>
+        <mo>)</mo></mrow>
+    </math>";
+    test("pl", "SimpleSpeak",expr, "przedział otwarty od c do d")?;
+    return Ok(());
+
+}
+
+#[test]
+    fn parens_interval_closed_open() -> Result<()> {
+        let expr = "<math> 
+        <mrow intent='closed-open-interval($start, $end)'><mo>[</mo>
+            <mrow> <mo arg='open'>[(]</mo><mi arg='start'>c</mi><mo>,</mo><mi arg='end'>d</mi></mrow><mo arg='close'>)</mo>
+            <mo>)</mo></mrow>
+        </math>";
+    test("pl", "SimpleSpeak",expr, "przedział lewostronnie domknięty prawostronnie otwarty od c do d")?;
+    return Ok(());
+
+}
+
+
+#[test]
+fn parens_interval_open_closed() -> Result<()> {
+    let expr = "<math> 
+    <mrow intent='open-closed-interval($start, $end)'><mo>(</mo>
+        <mrow> <mo arg='open'>(</mo><mi arg='start'>c</mi><mo>,</mo><mi arg='end'>d</mi></mrow><mo arg='close'>]</mo>
+        <mo>]</mo></mrow>
+    </math>";
+    test("pl", "SimpleSpeak",expr,"przedział lewostronnie otwarty prawostronnie domknięty od c do d")?;
+    return Ok(());
+
+}
+
+
+#[test]
+fn parens_interval_closed_closed() -> Result<()> {
+    let expr = "<math> 
+        <mrow intent='closed-interval($start, $end)'><mo>[</mo>
+            <mrow> <mo arg='open'>[(]</mo><mi arg='start'>c</mi><mo>,</mo><mi arg='end'>d</mi></mrow><mo arg='close'>]</mo>
+            <mo>]</mo></mrow>
+    </math>";
+    test("pl", "SimpleSpeak",expr, "przedział domknięty od c do d")?;
+    return Ok(());
+
+}
+
+    #[test]
+    fn parens_interval_neg_infinity_open_open() -> Result<()> {
+        let expr = "<math> 
+        <mrow intent='open-interval($start, $end)'><mo arg='open'>(</mo>
+        <mrow><mrow arg='start'><mo>-</mo> <mi>∞</mi></mrow><mo>,</mo><mi arg='end'>d</mi></mrow><mo arg='close'>)</mo>
+        <mo>)</mo></mrow>
+    </math>";
+    test("pl", "SimpleSpeak",expr,
+    "przedział otwarty od minus nieskończoność do d")?;
+    return Ok(());
+
+}
+
+    #[test]
+    fn parens_interval_neg_infinity_open_closed() -> Result<()> {
+        let expr = "<math> 
+        <mrow intent='open-closed-interval($start, $end)'><mo arg='open'>(</mo>
+        <mrow><mrow arg='start'><mo>-</mo> <mi>∞</mi></mrow><mo>,</mo><mi arg='end'>d</mi></mrow><mo arg='close'>]</mo>
+        <mo>]</mo></mrow>
+    </math>";
+    test("pl", "SimpleSpeak",expr,
+    "przedział lewostronnie otwarty prawostronnie domknięty od minus nieskończoność do d")?;
+    return Ok(());
+
+}
+

--- a/tests/Languages/pl/SimpleSpeak/geometry.rs
+++ b/tests/Languages/pl/SimpleSpeak/geometry.rs
@@ -1,0 +1,36 @@
+/// Tests for geometry listed in intent
+///   ABC as mtext and as separated letters
+use crate::common::*;
+use anyhow::Result;
+
+#[test]
+fn arc() -> Result<()> {
+  let expr = "<math>  <mover><mrow><mi>B</mi><mi>C</mi></mrow><mo>⌒</mo></mover> </math>";
+  test("pl", "SimpleSpeak", expr, "łuk wielka b wielka c")?;
+  return Ok(());
+
+}
+
+#[test]
+fn ray() -> Result<()> {
+  let expr = "<math> <mover><mrow><mi>X</mi><mi>Y</mi></mrow><mo>&#xAF;</mo></mover> </math>";
+  test("pl", "SimpleSpeak", expr, "odcinek wielka x wielka y")?;
+  return Ok(());
+
+}
+
+#[test]
+fn arc_mtext() -> Result<()> {
+  let expr = "<math> <mover><mtext>BC</mtext><mo>⌒</mo></mover> </math>";
+  test("pl", "SimpleSpeak", expr, "łuk wielka b wielka c")?;
+  return Ok(());
+
+}
+
+#[test]
+fn ray_mtext() -> Result<()> {
+  let expr = "<math> <mover><mtext>XY</mtext><mo>→</mo></mover> </math>";
+  test("pl", "SimpleSpeak", expr, "półprosta wielka x wielka y")?;
+  return Ok(());
+
+}

--- a/tests/Languages/pl/SimpleSpeak/large_ops.rs
+++ b/tests/Languages/pl/SimpleSpeak/large_ops.rs
@@ -1,0 +1,235 @@
+use crate::common::*;
+use anyhow::Result;
+
+#[test]
+fn sum_both() -> Result<()> {
+    let expr = "<math>
+        <munderover>
+            <mo>∑</mo>
+            <mrow><mi>n</mi><mo>=</mo><mn>1</mn></mrow>
+            <mrow><mn>10</mn></mrow>
+        </munderover>
+        <mi>n</mi>
+    </math>";
+    test("pl", "SimpleSpeak", expr, "suma od n równa się 1, do 10; n")?;
+    return Ok(());
+
+}
+
+#[test]
+fn sum_under() -> Result<()> {
+    let expr = "<math>
+        <munder>
+            <mo>∑</mo>
+            <mi>S</mi>
+        </munder>
+        <mi>i</mi>
+    </math>";
+    test("pl", "SimpleSpeak", expr, "suma przez wielka s z i")?;
+    return Ok(());
+
+}
+#[test]
+fn sum_both_msubsup() -> Result<()> {
+    let expr = "<math>
+        <msubsup>
+            <mo>∑</mo>
+            <mrow><mi>n</mi><mo>=</mo><mn>1</mn></mrow>
+            <mrow><mn>10</mn></mrow>
+        </msubsup>
+        <mi>n</mi>
+    </math>";
+    test("pl", "SimpleSpeak", expr, "suma od n równa się 1, do 10; n")?;
+    return Ok(());
+
+}
+
+#[test]
+fn sum_sub() -> Result<()> {
+    let expr = "<math>
+        <msub>
+            <mo>∑</mo>
+            <mi>S</mi>
+        </msub>
+        <mi>i</mi>
+    </math>";
+    test("pl", "SimpleSpeak", expr, "suma przez wielka s z i")?;
+    return Ok(());
+
+}
+
+#[test]
+fn sum() -> Result<()> {
+    let expr = "<math>
+            <mo>∑</mo>
+            <msub><mi>a</mi><mi>i</mi></msub>
+    </math>";
+    test("pl", "SimpleSpeak", expr, "suma, a indeks dolny i")?;
+    return Ok(());
+
+}
+
+#[test]
+fn product_both() -> Result<()> {
+    let expr = "<math>
+        <munderover>
+            <mo>∏</mo>
+            <mrow><mi>n</mi><mo>=</mo><mn>1</mn></mrow>
+            <mrow><mn>10</mn></mrow>
+        </munderover>
+        <mi>n</mi>
+    </math>";
+    test("pl", "SimpleSpeak", expr, "iloczyn od n równa się 1, do 10; n")?;
+    return Ok(());
+
+}
+
+#[test]
+fn product_under() -> Result<()> {
+    let expr = "<math>
+        <munder>
+            <mo>∏</mo>
+            <mi>S</mi>
+        </munder>
+        <mi>i</mi>
+    </math>";
+    test("pl", "SimpleSpeak", expr, "iloczyn przez wielka s z i")?;
+    return Ok(());
+
+}
+
+#[test]
+fn product() -> Result<()> {
+    let expr = "<math>
+            <mo>∏</mo>
+            <msub><mi>a</mi><mi>i</mi></msub>
+    </math>";
+    test("pl", "SimpleSpeak", expr, "iloczyn, a indeks dolny i")?;
+    return Ok(());
+
+}
+
+#[test]
+fn intersection_both() -> Result<()> {
+    let expr = "<math>
+        <munderover>
+            <mo>⋂</mo>
+            <mrow><mi>i</mi><mo>=</mo><mn>1</mn> </mrow>
+            <mn>10</mn>
+        </munderover>
+        <msub><mi>S</mi><mi>i</mi></msub>
+    </math>";
+    test("pl", "SimpleSpeak", expr, "przecięcie od i równa się 1, do 10; wielka s indeks dolny i")?;
+    return Ok(());
+
+}
+
+#[test]
+fn intersection_under() -> Result<()> {
+    let expr = "<math>
+        <munder>
+            <mo>⋂</mo>
+            <mi>C</mi>
+        </munder>
+        <msub><mi>S</mi><mi>i</mi></msub>
+    </math>";
+    test("pl", "SimpleSpeak", expr, "przecięcie przez wielka c z, wielka s indeks dolny i")?;
+    return Ok(());
+
+}
+
+#[test]
+fn intersection() -> Result<()> {
+    let expr = "<math>
+            <mo>⋂</mo>
+            <msub><mi>S</mi><mi>i</mi></msub>
+            </math>";
+    test("pl", "SimpleSpeak", expr, "przecięcie, wielka s indeks dolny i")?;
+    return Ok(());
+
+}
+
+#[test]
+fn union_both() -> Result<()> {
+    let expr = "<math>
+        <munderover>
+            <mo>⋃</mo>
+            <mrow><mi>i</mi><mo>=</mo><mn>1</mn> </mrow>
+            <mn>10</mn>
+        </munderover>
+        <msub><mi>S</mi><mi>i</mi></msub>
+    </math>";
+    test("pl", "SimpleSpeak", expr, "suma zbiorów od i równa się 1, do 10; wielka s indeks dolny i")?;
+    return Ok(());
+
+}
+
+#[test]
+fn union_under() -> Result<()> {
+    let expr = "<math>
+        <munder>
+            <mo>⋃</mo>
+            <mi>C</mi>
+        </munder>
+        <msub><mi>S</mi><mi>i</mi></msub>
+    </math>";
+    test("pl", "SimpleSpeak", expr, "suma zbiorów przez wielka c z, wielka s indeks dolny i")?;
+    return Ok(());
+
+}
+
+#[test]
+fn union() -> Result<()> {
+    let expr = "<math>
+            <mo>⋃</mo>
+            <msub><mi>S</mi><mi>i</mi></msub>
+            </math>";
+    test("pl", "SimpleSpeak", expr, "suma zbiorów, wielka s indeks dolny i")?;
+    return Ok(());
+
+}
+
+#[test]
+fn integral_both() -> Result<()> {
+    let expr = "<math>
+            <mrow>
+                <msubsup>
+                    <mo>∫</mo>
+                    <mn>0</mn>
+                    <mn>1</mn>
+                </msubsup>
+                <mrow><mi>f</mi><mrow><mo>(</mo><mi>x</mi> <mo>)</mo></mrow></mrow>
+            </mrow>
+            <mtext>&#x2009;</mtext><mi>d</mi><mi>x</mi>
+        </math>";
+    test("pl", "SimpleSpeak", expr, "całka od 0, do 1; f z x; d x")?;
+    return Ok(());
+
+}
+
+#[test]
+fn integral_under() -> Result<()> {
+    let expr = "<math>
+        <munder>
+            <mo>∫</mo>
+            <mi>ℝ</mi>
+        </munder>
+        <mrow><mi>f</mi><mrow><mo>(</mo><mi>x</mi> <mo>)</mo></mrow></mrow>
+        <mi>d</mi><mi>x</mi>
+        </math>";
+    test("pl", "SimpleSpeak", expr, "całka przez liczby rzeczywiste z; f z x d x")?;
+    return Ok(());
+
+}
+
+#[test]
+fn integral() -> Result<()> {
+    let expr = "<math>
+            <mo>∫</mo>
+            <mrow><mi>f</mi><mrow><mo>(</mo><mi>x</mi> <mo>)</mo></mrow></mrow>
+            <mi>d</mi><mi>x</mi>
+            </math>";
+    test("pl", "SimpleSpeak", expr, "całka, f z x d x")?;
+    return Ok(());
+
+}

--- a/tests/Languages/pl/SimpleSpeak/linear_algebra.rs
+++ b/tests/Languages/pl/SimpleSpeak/linear_algebra.rs
@@ -1,0 +1,111 @@
+use crate::common::*;
+use anyhow::Result;
+
+#[test]
+fn transpose() -> Result<()> {
+  let expr = "<math> <msup><mi>M</mi><mi>T</mi></msup> </math>";
+  test("pl", "SimpleSpeak", expr, "wielka m transponowane")?;
+  return Ok(());
+
+}
+
+#[test]
+fn trace() -> Result<()> {
+  let expr = "<math> <mi>Tr</mi><mi>M</mi> </math>";
+  test("pl", "SimpleSpeak", expr, "ślad z wielka m")?;
+  return Ok(());
+
+}
+
+#[test]
+fn dimension() -> Result<()> {
+  let expr = "<math> <mi>Dim</mi><mi>M</mi> </math>";
+  test("pl", "SimpleSpeak", expr, "wymiar z wielka m")?;
+  return Ok(());
+
+}
+
+#[test]
+fn homomorphism() -> Result<()> {
+  let expr = "<math> <mi>Hom</mi><mo>(</mo><mi>M</mi><mo>)</mo> </math>";
+  test("pl", "SimpleSpeak", expr, "homomorfizm z wielka m")?;
+  return Ok(());
+
+}
+
+#[test]
+fn kernel() -> Result<()> {
+  let expr = "<math> <mi>ker</mi><mrow><mo>(</mo><mi>L</mi><mo>)</mo></mrow> </math>";
+  test("pl", "SimpleSpeak", expr, "jądro z wielka l")?;
+  return Ok(());
+
+}
+
+#[test]
+fn norm() -> Result<()> {
+  let expr = "  <math>
+    <mrow>
+      <mo>∥</mo>
+      <mi>f</mi>
+      <mo>∥</mo>
+    </mrow>
+</math>
+";
+  test("pl", "SimpleSpeak", expr, "norma z f")?;
+  return Ok(());
+
+}
+
+#[test]
+fn norm_non_simple() -> Result<()> {
+  let expr = "  <math>
+    <mrow>
+      <mo>∥</mo>
+      <mi>x</mi>
+      <mo>+</mo>
+      <mi>y</mi>
+      <mo>∥</mo>
+    </mrow>
+</math>
+";
+  test("pl", "SimpleSpeak", expr, "norma z x plus y koniec normy")?;
+  return Ok(());
+
+}
+
+#[test]
+fn norm_subscripted() -> Result<()> {
+  let expr = "  <math>
+    <msub>
+      <mrow>
+        <mo>∥</mo>
+        <mi>f</mi>
+        <mo>∥</mo>
+      </mrow>
+      <mi>p</mi>
+    </msub>
+</math>
+";
+  test("pl", "SimpleSpeak", expr, "norma p z f")?;
+  return Ok(());
+
+}
+
+#[test]
+fn not_gradient() -> Result<()> {
+  // the nabla is at the end, so it can't be gradient because it doesn't operate on anything
+  let expr = r#"<math>
+  <mo>(</mo>
+  <mi>b</mi>
+  <mo>&#x22C5;</mo>
+  <mrow>
+    <mo>&#x2207;</mo>
+  </mrow>
+  <mo>)</mo>
+  <mi>a</mi>
+</math>
+"#;
+  test("pl", "SimpleSpeak", expr, "nawias otwierający, b razy nabla, nawias zamykający; razy a")?;
+  return Ok(());
+
+}

--- a/tests/Languages/pl/SimpleSpeak/mfrac.rs
+++ b/tests/Languages/pl/SimpleSpeak/mfrac.rs
@@ -1,0 +1,356 @@
+/// Tests for fractions
+///   includes simple fractions and more complex fractions
+///   also tests mixed fractions (implicit and explicit)
+use crate::common::*;
+use anyhow::Result;
+
+#[test]
+fn common_fraction_half() -> Result<()> {
+    let expr = "<math>
+                    <mfrac> <mn>1</mn> <mn>2</mn> </mfrac>
+                </math>";
+    test("pl", "SimpleSpeak", expr, "jedna druga")?;
+    return Ok(());
+
+}
+
+#[test]
+fn common_fraction_thirds() -> Result<()> {
+    let expr = "<math>
+                    <mfrac> <mn>2</mn> <mn>3</mn> </mfrac>
+                </math>";
+    test("pl", "SimpleSpeak", expr, "dwie trzecie")?;
+    return Ok(());
+
+}
+
+#[test]
+fn common_fraction_tenths() -> Result<()> {
+    let expr = "<math>
+                    <mfrac> <mn>17</mn> <mn>10</mn> </mfrac>
+                </math>";
+    test("pl", "SimpleSpeak", expr, "17 dziesiąte")?;
+    return Ok(());
+
+}
+
+#[test]
+#[allow(non_snake_case)]
+fn not_SimpleSpeak_common_fraction_tenths() -> Result<()> {
+    let expr = "<math>
+                    <mfrac> <mn>89</mn> <mn>10</mn> </mfrac>
+                </math>";
+    test("pl", "SimpleSpeak", expr, "89 przez 10")?;
+    return Ok(());
+
+}
+
+#[test]
+fn non_simple_fraction() -> Result<()> {
+    let expr = "
+    <math>
+        <mrow>
+        <mfrac>
+        <mrow> <mi>x</mi><mo>+</mo><mi>y</mi> </mrow>
+        <mrow>
+        <mi>x</mi><mo>-</mo><mi>y</mi></mrow>
+        </mfrac>
+        </mrow>
+    </math>
+                            ";
+    test("pl", "SimpleSpeak", expr, "ułamek, x plus y, przez, x minus y, koniec ułamka")?;
+    return Ok(());
+
+}
+
+#[test]
+fn nested_fraction() -> Result<()> {
+    let expr = "
+    <math>
+        <mrow>
+        <mfrac>
+        <mrow> <mi>x</mi><mo>+</mo>  <mfrac><mn>1</mn><mi>y</mi></mfrac>  </mrow>
+        <mrow>
+        <mi>x</mi><mo>-</mo><mi>y</mi></mrow>
+        </mfrac>
+        </mrow>
+    </math>
+                            ";
+    test("pl", "SimpleSpeak", expr, "ułamek, x plus, ułamek, 1 przez y, koniec ułamka; przez, x minus y, koniec ułamka")?;
+    return Ok(());
+
+}
+
+
+#[test]
+fn deeply_nested_fraction_msqrt() -> Result<()> {
+    let expr = "
+    <math>
+        <mrow>
+        <mfrac>
+        <mrow> <mi>x</mi><mo>+</mo>  <msqrt><mrow><mfrac><mn>1</mn><mi>y</mi></mfrac></mrow> </msqrt> </mrow>
+        <mrow>
+        <mi>x</mi><mo>-</mo><mi>y</mi></mrow>
+        </mfrac>
+        </mrow>
+    </math>
+                            ";
+    test("pl", "SimpleSpeak", expr, "ułamek, x plus, pierwiastek kwadratowy z 1 przez y; koniec pierwiastka; przez, x minus y, koniec ułamka")?;
+    return Ok(());
+
+}
+
+#[test]
+fn deeply_nested_fraction_mrow_msqrt() -> Result<()> {
+    let expr = "
+    <math>
+        <mrow>
+        <mfrac>
+        <mrow> <mi>x</mi><mo>+</mo>  <msqrt><mrow><mn>2</mn><mo>+</mo><mfrac><mn>1</mn><mi>y</mi></mfrac></mrow> </msqrt> </mrow>
+        <mrow>
+        <mi>x</mi><mo>-</mo><mi>y</mi></mrow>
+        </mfrac>
+        </mrow>
+    </math>
+                            ";
+    test("pl", "SimpleSpeak", expr, "ułamek, x plus; pierwiastek kwadratowy z 2 plus 1 przez y; koniec pierwiastka; przez, x minus y, koniec ułamka")?;
+    return Ok(());
+
+}
+
+#[test]
+fn numerator_simple_fraction() -> Result<()> {
+    let expr = "
+    <math>
+        <mrow>
+        <mfrac>
+        <mrow> <mi>x</mi></mrow>
+        <mrow>
+            <mi>x</mi><mo>-</mo><mi>y</mi></mrow>
+        </mfrac>
+        </mrow>
+    </math>
+                            ";
+    test("pl", "SimpleSpeak", expr, "ułamek, x przez, x minus y, koniec ułamka")?;
+    return Ok(());
+
+}
+
+#[test]
+fn denominator_simple_fraction() -> Result<()> {
+    let expr = "
+    <math>
+        <mfrac>
+            <mrow> <mi>x</mi><mo>-</mo><mi>y</mi></mrow>
+            <mrow> <mi>x</mi></mrow>
+        </mfrac>
+    </math>
+                            ";
+    test("pl", "SimpleSpeak", expr, "ułamek, x minus y, przez x, koniec ułamka")?;
+    return Ok(());
+
+}
+
+
+#[test]
+fn frac_with_units() -> Result<()> {
+    let expr = "
+    <math>
+        <mrow>
+        <mn>62</mn>
+        <mfrac>
+        <mi intent=':unit'>mi</mi>
+        <mi intent=':unit'>hr</mi>
+        </mfrac>
+        </mrow>
+    </math>";
+    test("pl", "SimpleSpeak", expr, "62 milas na godzina")?;
+    return Ok(());
+
+}
+
+#[test]
+fn singular_frac_with_units() -> Result<()> {
+    let expr = "
+    <math>
+        <mrow>
+        <mn>1</mn>
+        <mfrac>
+        <mi intent=':unit'>gal</mi>
+        <mi intent=':unit'>mi</mi>
+        </mfrac>
+        </mrow>
+    </math>";
+    test("pl", "SimpleSpeak", expr, "1 galon na mila")?;
+    return Ok(());
+
+}
+
+#[test]
+fn number_in_numerator_with_units() -> Result<()> {
+    let expr = "
+    <math>
+        <mfrac>
+            <mrow>
+                <mn>3</mn>
+                <mi intent=':unit'>gal</mi>
+            </mrow>
+            <mi intent=':unit'>mi</mi>
+        </mfrac>
+    </math>";
+    test("pl", "SimpleSpeak", expr, "3 galons na mila")?;
+    return Ok(());
+
+}
+
+#[test]
+fn units_with_powers() -> Result<()> {
+    let expr = "
+    <math>
+        <mfrac>
+            <mrow> <mn>3</mn> <mi intent=':unit'>m</mi> </mrow>
+            <msup> <mi intent=':unit'>s</mi><mn>2</mn> </msup>
+        </mfrac>
+    </math>";
+    test("pl", "SimpleSpeak", expr, "3 metrs na sekunda do kwadratu")?;
+    return Ok(());
+
+}
+
+
+#[test]
+fn mixed_number() -> Result<()> {
+    let expr = "<math>
+                    <mn>3</mn>
+                    <mfrac> <mn>1</mn> <mn>2</mn> </mfrac>
+                </math>";
+    test("pl", "SimpleSpeak", expr, "3 i jedna druga")?;
+    return Ok(());
+
+}
+
+#[test]
+fn explicit_mixed_number() -> Result<()> {
+    let expr = "<math>
+                    <mn>3</mn>
+                    <mo>&#x2064;</mo>
+                    <mfrac> <mn>1</mn> <mn>8</mn> </mfrac>
+                </math>";
+    test("pl", "SimpleSpeak", expr, "3 i jedna ósma")?;
+    return Ok(());
+
+}
+
+#[test]
+fn mixed_number_big() -> Result<()> {
+    let expr = "<math>
+                    <mn>3</mn>
+                    <mfrac> <mn>7</mn> <mn>83</mn> </mfrac>
+                </math>";
+    test("pl", "SimpleSpeak", expr, "3 i 7 osiemdziesiąt trzecich")?;
+    return Ok(());
+
+}
+
+#[test]
+fn simple_text() -> Result<()> {
+    let expr = "<math>
+    <mfrac> <mi>rise</mi> <mi>run</mi> </mfrac>
+                </math>";
+    test("pl", "SimpleSpeak", expr, "rise przez run")?;
+    return Ok(());
+
+}
+
+#[test]
+fn number_and_text() -> Result<()> {
+    let expr = "<math>
+            <mfrac>
+            <mrow>
+                <mn>2</mn><mtext>miles</mtext></mrow>
+            <mrow>
+                <mn>3</mn><mtext>gallons</mtext></mrow>
+            </mfrac>
+        </math>";
+    test("pl", "SimpleSpeak", expr, "ułamek, 2 miles, przez, 3 gallons, koniec ułamka")?;
+    return Ok(());
+
+}
+
+
+#[test]
+fn nested_simple_fractions() -> Result<()> {
+    let expr = "<math>
+                <mrow>
+                <mfrac>
+                    <mrow>
+                    <mfrac>
+                        <mn>1</mn>
+                        <mn>2</mn>
+                    </mfrac>
+                    </mrow>
+                    <mrow>
+                    <mfrac>
+                        <mn>2</mn>
+                        <mn>3</mn>
+                    </mfrac>
+                    </mrow>
+                </mfrac>
+                </mrow>
+            </math>";
+    test("pl", "SimpleSpeak", expr, "ułamek, jedna druga, przez, dwie trzecie, koniec ułamka")?;
+    return Ok(());
+
+}
+
+#[test]
+fn binomial() -> Result<()> {
+    let expr = "<math>
+                    <mn>2</mn>
+                    <mo>(</mo>
+                    <mfrac linethickness='0'> <mn>7</mn> <mn>3</mn> </mfrac>
+                    <mo>)</mo>
+                </math>";
+    test("pl", "SimpleSpeak", expr, "2 razy 7 po 3")?;
+    return Ok(());
+
+}
+
+#[test]
+fn binomial_non_simple_top() -> Result<()> {
+    let expr = "<math>
+                    <mn>2</mn>
+                    <mo>(</mo>
+                    <mfrac linethickness='0'> <mrow><mi>n</mi><mo>+</mo><mn>7</mn></mrow> <mn>3</mn> </mfrac>
+                    <mo>)</mo>
+                </math>";
+    test("pl", "SimpleSpeak", expr, "2 razy, symbol newtona n plus 7 po 3")?;
+    return Ok(());
+
+}
+
+#[test]
+fn binomial_non_simple_bottom() -> Result<()> {
+    let expr = "<math>
+                    <mn>2</mn>
+                    <mo>(</mo>
+                    <mfrac linethickness='0'> <mn>7</mn> <mrow><mi>k</mi><mo>+</mo><mn>3</mn></mrow> </mfrac>
+                    <mo>)</mo>
+                </math>";
+    test("pl", "SimpleSpeak", expr, "2 razy, 7 po k plus 3 koniec symbolu newtona")?;
+    return Ok(());
+
+}
+
+#[test]
+fn binomial_non_simple_top_and_bottom() -> Result<()> {
+    let expr = "<math>
+                    <mn>2</mn>
+                    <mo>(</mo>
+                    <mfrac linethickness='0'> <mrow><mi>n</mi><mo>+</mo><mn>7</mn></mrow> <mrow><mi>k</mi><mo>+</mo><mn>3</mn></mrow> </mfrac>
+                    <mo>)</mo>
+                </math>";
+    test("pl", "SimpleSpeak", expr, "2 razy; symbol newtona n plus 7 po k plus 3 koniec symbolu newtona")?;
+    return Ok(());
+
+}

--- a/tests/Languages/pl/SimpleSpeak/msup.rs
+++ b/tests/Languages/pl/SimpleSpeak/msup.rs
@@ -1,0 +1,379 @@
+/// Tests for superscripts
+///   simple superscripts
+///   complex/nested superscripts
+use crate::common::*;
+use anyhow::Result;
+
+#[test]
+fn squared() -> Result<()> {
+    let expr = "<math>
+                    <msup> <mi>x</mi> <mn>2</mn> </msup>
+                </math>";
+    test("pl", "SimpleSpeak", expr, "x do kwadratu")?;
+    return Ok(());
+
+}
+
+#[test]
+fn cubed() -> Result<()> {
+    let expr = "<math>
+                    <msup> <mi>x</mi> <mn>3</mn> </msup>
+                </math>";
+    test("pl", "SimpleSpeak", expr, "x do sześcianu")?;
+    return Ok(());
+
+}
+
+#[test]
+    fn ordinal_power() -> Result<()> {
+        let expr = "<math>
+                        <msup> <mi>x</mi> <mn>4</mn> </msup>
+                    </math>";
+        test("pl", "SimpleSpeak", expr, "x do potęgi czwartej")?;
+        return Ok(());
+
+    }
+
+#[test]
+fn simple_mi_power() -> Result<()> {
+    let expr = "<math>
+                    <msup> <mi>x</mi> <mi>n</mi> </msup>
+                </math>";
+  test("pl", "SimpleSpeak", expr, "x do potęgi n")?;
+  return Ok(());
+
+}
+
+#[test]
+fn zero_power() -> Result<()> {
+    let expr = "<math>
+                    <msup> <mi>x</mi> <mn>0</mn> </msup>
+                </math>";
+    test("pl", "SimpleSpeak", expr, "x do potęgi 0")?;
+    return Ok(());
+
+}
+
+
+#[test]
+fn decimal_power() -> Result<()> {
+    let expr = "<math>
+                    <msup> <mi>x</mi> <mn>2,0</mn> </msup>
+                </math>";
+    test("pl", "SimpleSpeak", expr, "x do potęgi 2,0")?;
+    return Ok(());
+
+}
+
+#[test]
+fn non_simple_power() -> Result<()> {
+    let expr = "<math>
+      <mrow>
+      <msup>
+        <mn>3</mn>
+        <mrow>
+        <mi>y</mi><mo>+</mo><mn>2</mn></mrow>
+      </msup>
+      </mrow>
+                </math>";
+    test("pl", "SimpleSpeak", expr, "3 do potęgi y plus 2")?;
+    return Ok(());
+
+}
+
+#[test]
+fn negative_power() -> Result<()> {
+    let expr = "<math>
+                    <msup>
+                        <mi>x</mi>
+                        <mrow> <mo>-</mo> <mn>2</mn> </mrow>
+                    </msup>
+                </math>";
+    test("pl", "SimpleSpeak", expr, "x do potęgi minus 2")?;
+    return Ok(());
+
+}
+
+#[test]
+fn simple_fraction_power() -> Result<()> {
+  let expr = "<math>
+                  <msup>
+                      <mi>x</mi> 
+                      <mfrac><mn>1</mn><mn>3</mn></mfrac>
+                  </msup>
+              </math>";
+  test("pl", "SimpleSpeak", expr, "x do potęgi jedna trzecia")?;
+  return Ok(());
+
+}
+
+#[test]
+fn nested_squared_power_with_coef() -> Result<()> {
+    let expr = "<math>
+      <mrow>
+      <msup>
+        <mn>3</mn>
+        <mrow>
+        <mn>2</mn>
+        <msup>
+          <mi>x</mi>
+          <mn>2</mn>
+        </msup>
+        </mrow>
+      </msup>
+      </mrow>
+      </math>";
+  test("pl", "SimpleSpeak", expr, "3 do potęgi 2 x do kwadratu")?;
+  return Ok(());
+
+}
+
+#[test]
+fn nested_squared_power_with_neg_coef() -> Result<()> {
+    let expr = "<math>
+    <mrow>
+    <msup>
+      <mn>3</mn>
+      <mrow>
+      <mo>-</mo>
+      <mn>2</mn>
+      <msup>
+        <mi>x</mi>
+        <mn>2</mn>
+      </msup>
+      </mrow>
+    </msup>
+    </mrow>
+  </math>";
+  test("pl", "SimpleSpeak", expr, "3 do potęgi minus 2 x do kwadratu")?;
+  return Ok(());
+
+}
+
+
+#[test]
+fn nested_cubed_power() -> Result<()> {
+    let expr = "<math>
+      <msup>
+      <mi>y</mi> 
+      <msup>
+          <mfrac><mn>4</mn><mn>5</mn></mfrac>
+          <mn>3</mn>
+      </msup>
+    </msup>
+  </math>";
+  test("pl", "SimpleSpeak", expr, "y do potęgi 4 piąte do sześcianu")?;
+  return Ok(());
+
+}
+
+#[test]
+fn nested_cubed_power_with_neg_base() -> Result<()> {
+    let expr = "<math>
+      <msup>
+      <mi>y</mi> 
+        <mrow>
+            <mo>-</mo>
+            <msup>
+                <mfrac><mn>4</mn><mn>5</mn></mfrac>
+                <mn>3</mn>
+            </msup>
+        </mrow>
+    </msup>
+    </math>";
+  test("pl", "SimpleSpeak", expr, "y do potęgi minus 4 piąte do sześcianu")?;
+  return Ok(());
+
+}
+
+#[test]
+fn nested_number_times_squared() -> Result<()> {
+    let expr = "<math>
+        <mrow>
+        <msup>
+          <mi>e</mi>
+          <mrow>
+          <mfrac>
+            <mn>1</mn>
+            <mn>2</mn>
+            </mfrac>
+            <msup>
+            <mi>x</mi>
+            <mn>2</mn>
+            </msup>
+          </mrow>
+        </msup>
+        </mrow>
+        </math>";
+  test("pl", "SimpleSpeak", expr, "e do potęgi jedna druga x do kwadratu")?;
+  return Ok(());
+
+}
+
+#[test]
+fn nested_negative_number_times_squared() -> Result<()> {
+  let expr = "<math>
+    <mrow>
+    <msup>
+      <mi>e</mi>
+      <mrow>
+      <mo>&#x2212;</mo><mfrac>
+        <mn>1</mn>
+        <mn>2</mn>
+      </mfrac>
+      <msup>
+        <mi>x</mi>
+        <mn>2</mn>
+      </msup>
+      </mrow>
+    </msup>
+    </mrow>
+    </math>";
+  test("pl", "SimpleSpeak", expr, "e do potęgi minus jedna druga, x do kwadratu")?;
+  return Ok(());
+
+}
+
+#[test]
+fn nested_expr_to_tenth() -> Result<()> {
+    let expr = "<math>
+      <mrow>
+      <msup>
+        <mn>3</mn>
+        <mrow>
+        <msup>
+          <mn>3</mn>
+          <mrow>
+          <mn>10</mn></mrow>
+        </msup>
+        </mrow>
+      </msup>
+      </mrow>
+      </math>";
+  test("pl", "SimpleSpeak", expr, "3 do potęgi 3 do potęgi dziesiątej")?;
+  return Ok(());
+
+}
+
+#[test]
+fn nested_non_simple_squared_exp() -> Result<()> {
+    let expr = "<math>
+      <mrow>
+      <msup>
+        <mn>3</mn>
+        <mrow>
+        <msup>
+          <mrow>
+          <mrow><mo>(</mo>
+            <mrow>
+            <mi>x</mi><mo>+</mo><mn>1</mn></mrow>
+          <mo>)</mo></mrow></mrow>
+          <mn>2</mn>
+        </msup>
+        </mrow>
+      </msup>
+      </mrow>
+      </math>";
+  test("pl", "SimpleSpeak", expr, "3 do potęgi nawias otwierający, x plus 1, nawias zamykający do kwadratu")?;
+  return Ok(());
+
+}
+
+#[test]
+fn nested_simple_power() -> Result<()> {
+    let expr = "<math>
+      <msup>
+      <mi>t</mi> 
+      <msup>
+          <mfrac><mn>4</mn><mn>5</mn></mfrac>
+          <mi>n</mi>
+      </msup>
+    </msup>
+  </math>";
+  test("pl", "SimpleSpeak", expr, "t do potęgi 4 piąte do potęgi n")?;
+  return Ok(());
+
+}
+
+#[test]
+fn nested_end_exponent_power() -> Result<()> {
+    let expr = "<math>
+      <msup>
+      <mi>t</mi> 
+      <msup>
+          <mfrac><mn>4</mn><mn>5</mn></mfrac>
+          <mrow><mi>n</mi><mo>+</mo><mn>1</mn></mrow>
+      </msup>
+    </msup>
+  </math>";
+  test("pl", "SimpleSpeak", expr, "t do potęgi 4 piąte do potęgi n plus 1; koniec wykładnika")?;
+  test_prefs("pl", "SimpleSpeak", vec![("Impairment", "LearningDisability")], expr,
+  "t do potęgi 4 piąte do potęgi n plus 1")?;
+  return Ok(());
+
+}
+
+#[test]
+fn nested_end_exponent_neg_power() -> Result<()> {
+    let expr = "<math>
+      <msup>
+      <mi>t</mi> 
+      <msup>
+          <mfrac><mn>4</mn><mn>5</mn></mfrac>
+          <mrow><mo>-</mo><mn>3</mn></mrow>
+      </msup>
+    </msup>
+  </math>";
+  test("pl", "SimpleSpeak", expr, "t do potęgi 4 piąte do potęgi minus 3, koniec wykładnika")?;
+  return Ok(());
+
+}
+
+#[test]
+fn nested_complex_power() -> Result<()> {
+    let expr = "<math>
+      <mrow>
+      <msup>
+        <mi>e</mi>
+        <mrow>
+        <mo>&#x2212;</mo><mfrac>
+          <mn>1</mn>
+          <mn>2</mn>
+        </mfrac>
+        <msup>
+          <mrow>
+          <mrow><mo>(</mo>
+            <mrow>
+            <mfrac>
+              <mrow>
+              <mi>x</mi><mo>&#x2212;</mo><mi>&#x03BC;</mi></mrow>
+              <mi>&#x03C3;</mi>
+            </mfrac>
+            </mrow>
+          <mo>)</mo></mrow></mrow>
+          <mn>2</mn>
+        </msup>
+        </mrow>
+      </msup>
+      </mrow>
+      </math>";
+  test("pl", "SimpleSpeak", expr, "e do potęgi minus jedna druga razy; nawias otwierający; ułamek, x minus mi, przez sigma, koniec ułamka; nawias zamykający do kwadratu")?;
+  return Ok(());
+
+}
+
+#[test]
+fn default_power() -> Result<()> {
+    let expr = "<math>
+      <msup>
+      <mi>t</mi> 
+      <mfrac>
+          <mrow><mi>b</mi><mo>+</mo><mn>1</mn></mrow>
+          <mn>3</mn>
+      </mfrac>
+    </msup>
+  </math>";
+  test("pl", "SimpleSpeak", expr, "t do potęgi ułamek, b plus 1, przez 3, koniec ułamka")?;
+  return Ok(());
+
+}

--- a/tests/Languages/pl/SimpleSpeak/multiline.rs
+++ b/tests/Languages/pl/SimpleSpeak/multiline.rs
@@ -30,7 +30,7 @@ fn case_1() -> Result<()> {
             </mtable></mrow> </mrow></mrow>
         </math>
    ";
-    test("pl", "SimpleSpeak", expr, "f z x równa się; 3 przypadeks; przypadek 1; minus 1 if x; jest mniejsze niż 0; przypadek 2; 0 if x, równa się 0; przypadek 3; 1 if x, jest większe niż 0")?;
+    test("pl", "SimpleSpeak", expr, "f z x równa się; 3 przypadki; przypadek 1; minus 1 if x; jest mniejsze niż 0; przypadek 2; 0 if x, równa się 0; przypadek 3; 1 if x, jest większe niż 0")?;
     return Ok(());
 }
 
@@ -68,6 +68,6 @@ fn equation_1() -> Result<()> {
       </mtable></mrow>
     </math>
    ";
-    test("pl", "SimpleSpeak", expr, "2 równanies; równanie 1; x plus y, równa się 7; równanie 2; 2 x plus 3 y; równa się 17")?;
+    test("pl", "SimpleSpeak", expr, "2 równania; równanie 1; x plus y, równa się 7; równanie 2; 2 x plus 3 y; równa się 17")?;
     return Ok(());
 }

--- a/tests/Languages/pl/SimpleSpeak/multiline.rs
+++ b/tests/Languages/pl/SimpleSpeak/multiline.rs
@@ -1,0 +1,73 @@
+use crate::common::*;
+use anyhow::Result;
+
+#[test]
+fn case_1() -> Result<()> {
+    let expr = "<math>
+            <mrow>
+            <mi>f</mi><mrow><mo>(</mo>
+            <mi>x</mi>
+            <mo>)</mo></mrow><mo>=</mo><mrow><mo>{</mo> <mrow>
+            <mtable>
+            <mtr>
+                <mtd>
+                <mrow>
+                <mo>&#x2212;</mo><mn>1</mn><mtext>&#x00A0;if&#x00A0;</mtext><mi>x</mi><mo>&#x003C;</mo><mn>0</mn></mrow>
+                </mtd>
+            </mtr>
+            <mtr>
+                <mtd>
+                <mrow>
+                <mn>0</mn><mtext>&#x00A0;if&#x00A0;</mtext><mi>x</mi><mo>=</mo><mn>0</mn></mrow>
+                </mtd>
+            </mtr>
+            <mtr>
+                <mtd>
+                <mrow>
+                <mn>1</mn><mtext>&#x00A0;if&#x00A0;</mtext><mi>x</mi><mo>&#x003E;</mo><mn>0</mn></mrow>
+                </mtd>
+            </mtr>
+            </mtable></mrow> </mrow></mrow>
+        </math>
+   ";
+    test("pl", "SimpleSpeak", expr, "f z x równa się; 3 przypadeks; przypadek 1; minus 1 if x; jest mniejsze niż 0; przypadek 2; 0 if x, równa się 0; przypadek 3; 1 if x, jest większe niż 0")?;
+    return Ok(());
+}
+
+#[test]
+fn equation_1() -> Result<()> {
+    let expr = "<math>
+     <mrow>
+      <mtable>
+       <mtr>
+        <mtd>
+         <mrow>
+          <mi>x</mi><mo>+</mo><mi>y</mi></mrow>
+        </mtd>
+        <mtd>
+         <mo>=</mo>
+        </mtd>
+        <mtd>
+         <mn>7</mn>
+        </mtd>
+       </mtr>
+       <mtr>
+        <mtd>
+         <mrow>
+          <mn>2</mn><mi>x</mi><mo>+</mo><mn>3</mn><mi>y</mi></mrow>
+        </mtd>
+        <mtd>
+         <mo>=</mo>
+        </mtd>
+        <mtd>
+         <mrow>
+          <mn>17</mn></mrow>
+        </mtd>
+       </mtr>
+       
+      </mtable></mrow>
+    </math>
+   ";
+    test("pl", "SimpleSpeak", expr, "2 równanies; równanie 1; x plus y, równa się 7; równanie 2; 2 x plus 3 y; równa się 17")?;
+    return Ok(());
+}

--- a/tests/Languages/pl/SimpleSpeak/sets.rs
+++ b/tests/Languages/pl/SimpleSpeak/sets.rs
@@ -1,0 +1,285 @@
+use crate::common::*;
+use anyhow::Result;
+
+#[test]
+fn complex() -> Result<()> {
+    let expr = "<math>
+                    <mi>ℂ</mi>
+                </math>";
+    test("pl", "SimpleSpeak", expr, "liczby zespolone")?;
+    return Ok(());
+
+}
+
+#[test]
+fn natural() -> Result<()> {
+    let expr = "<math>
+                    <mi>ℕ</mi>
+                </math>";
+    test("pl", "SimpleSpeak", expr, "liczby naturalne")?;
+    return Ok(());
+
+}
+
+#[test]
+fn rationals() -> Result<()> {
+    let expr = "<math>
+                    <mi>ℚ</mi>
+                </math>";
+    test("pl", "SimpleSpeak", expr, "liczby wymierne")?;
+    return Ok(());
+
+}
+
+#[test]
+fn reals() -> Result<()> {
+    let expr = "<math>
+                    <mi>ℝ</mi>
+                </math>";
+    test("pl", "SimpleSpeak", expr, "liczby rzeczywiste")?;
+    return Ok(());
+
+}
+
+#[test]
+fn integers() -> Result<()> {
+    let expr = "<math>
+                    <mi>ℤ</mi>
+                </math>";
+    test("pl", "SimpleSpeak", expr, "liczby całkowite")?;
+    return Ok(());
+
+}
+
+
+
+#[test]
+fn msup_complex() -> Result<()> {
+    let expr = "<math>
+                <msup>
+                    <mi>ℂ</mi>
+                    <mn>2</mn>
+                </msup>
+                </math>";
+    test("pl", "SimpleSpeak", expr, "C 2")?;
+    return Ok(());
+
+}
+
+#[test]
+fn msup_natural() -> Result<()> {
+    let expr = "<math>
+                <msup>
+                    <mi>ℕ</mi>
+                    <mn>2</mn>
+                </msup>
+            </math>";
+    test("pl", "SimpleSpeak", expr, "N 2")?;
+    return Ok(());
+
+}
+
+#[test]
+fn msup_rationals() -> Result<()> {
+    let expr = "<math>
+                <msup>
+                    <mi>ℚ</mi>
+                    <mn>2</mn>
+                </msup>
+            </math>";
+    test("pl", "SimpleSpeak", expr, "Q 2")?;
+    return Ok(());
+
+}
+
+#[test]
+fn msup_reals() -> Result<()> {
+    let expr = "<math>
+                <msup>
+                    <mi>ℝ</mi>
+                    <mn>3</mn>
+                </msup>
+            </math>";
+    test("pl", "SimpleSpeak", expr, "R 3")?;
+    return Ok(());
+
+}
+
+#[test]
+fn msup_integers() -> Result<()> {
+    let expr = "<math>
+                <msup>
+                    <mi>ℤ</mi>
+                    <mn>4</mn>
+                </msup>
+            </math>";
+    test("pl", "SimpleSpeak", expr, "Z 4")?;
+    return Ok(());
+
+}
+
+#[test]
+fn msup_positive_integers() -> Result<()> {
+    let expr = "<math>
+                <msup>
+                    <mi>ℤ</mi>
+                    <mo>+</mo>
+                </msup>
+            </math>";
+    test("pl", "SimpleSpeak", expr, "plus liczby całkowite")?;
+    return Ok(());
+
+}
+
+#[test]
+fn msup_negative_integers() -> Result<()> {
+    let expr = "<math>
+                <msup>
+                    <mi>ℤ</mi>
+                    <mo>-</mo>
+                </msup>
+            </math>";
+    test("pl", "SimpleSpeak", expr, "minus liczby całkowite")?;
+    return Ok(());
+
+}
+
+#[test]
+fn msup_positive_rationals() -> Result<()> {
+    let expr = "<math>
+                <msup>
+                    <mi>ℚ</mi>
+                    <mo>+</mo>
+                </msup>
+            </math>";
+    test("pl", "SimpleSpeak", expr, "plus liczby wymierne")?;
+    return Ok(());
+
+}
+
+#[test]
+fn msup_negative_rationals() -> Result<()> {
+    let expr = "<math>
+                <msup>
+                    <mi>ℚ</mi>
+                    <mo>-</mo>
+                </msup>
+            </math>";
+    test("pl", "SimpleSpeak", expr, "minus liczby wymierne")?;
+    return Ok(());
+
+}
+
+#[test]
+fn empty_set() -> Result<()> {
+    let expr = "<math>
+                <mo>{</mo> <mo>}</mo>
+            </math>";
+    test("pl", "SimpleSpeak", expr, "zbiór pusty")?;
+    return Ok(());
+
+}
+
+#[test]
+fn single_element_set() -> Result<()> {
+    let expr = "<math>
+                <mo>{</mo> <mn>12</mn><mo>}</mo>
+            </math>";
+    test("pl", "SimpleSpeak", expr, "zbiór 12")?;
+    return Ok(());
+
+}
+
+#[test]
+fn multiple_element_set() -> Result<()> {
+    let expr = "<math>
+                <mo>{</mo> <mn>5</mn> <mo>,</mo> <mn>10</mn>  <mo>,</mo> <mn>15</mn> <mo>}</mo>
+            </math>";
+    test("pl", "SimpleSpeak", expr, "zbiór 5 przecinek, 10 przecinek, 15")?;
+    return Ok(());
+
+}
+
+#[test]
+fn set_with_colon() -> Result<()> {
+    let expr = "<math>
+                    <mo>{</mo> <mrow><mi>x</mi><mo>:</mo><mi>x</mi><mo>&#x003E;</mo><mn>2</mn></mrow> <mo>}</mo>
+            </math>";
+    test("pl", "SimpleSpeak", expr, "zbiór wszystkich x takich że x jest większe niż 2")?;
+    return Ok(());
+
+}
+
+#[test]
+fn set_with_bar() -> Result<()> {
+    let expr = "<math>
+                    <mo>{</mo> <mrow><mi>x</mi><mo>|</mo><mi>x</mi><mo>&#x003E;</mo><mn>2</mn></mrow> <mo>}</mo>
+            </math>";
+    test("pl", "SimpleSpeak", expr, "zbiór wszystkich x takich że x jest większe niż 2")?;
+    return Ok(());
+
+}
+
+#[test]
+fn element_alone() -> Result<()> {
+    let expr = "<math>
+            <mn>3</mn><mo>+</mo><mn>2</mn><mi>i</mi><mo>∉</mo><mi>ℝ</mi>
+        </math>";
+    test("pl", "SimpleSpeak", expr, "3 plus 2 i, nie jest elementem zbioru, liczby rzeczywiste")?;
+    return Ok(());
+
+}
+
+#[test]
+fn element_under_sum() -> Result<()> {
+    let expr = "<math>
+            <munder>
+                <mo>∑</mo>
+                <mrow> <mi>i</mi> <mo>∈</mo> <mi>ℤ</mi> </mrow>
+            </munder>
+            <mfrac>
+                <mn>1</mn>
+                <mrow> <msup>  <mi>i</mi> <mn>2</mn> </msup> </mrow>
+            </mfrac>
+        </math>";
+    test("pl", "SimpleSpeak", expr,
+                    "suma przez i jest elementem zbioru, liczby całkowite z; ułamek, 1 przez, i do kwadratu, koniec ułamka")?;
+                    return Ok(());
+
+}
+
+#[test]
+fn complicated_set_with_colon() -> Result<()> {
+    let expr = "<math>
+            <mo>{</mo>
+            <mi>x</mi>
+            <mo>∈</mo>
+            <mi>ℤ</mi>
+            <mo>:</mo>
+            <mn>2</mn>
+            <mo>&#x003C;</mo>
+            <mi>x</mi>
+            <mo>&#x003C;</mo>
+            <mn>7</mn>
+            <mo>}</mo>
+        </math>";
+    test("pl", "SimpleSpeak", expr, "zbiór wszystkich x elementem zbioru, liczby całkowite takich że 2 jest mniejsze niż x jest mniejsze niż 7")?;
+    return Ok(());
+
+}
+
+#[test]
+fn complicated_set_with_mtext() -> Result<()> {
+    // as of 8/5/21, parsing of "|" is problematic an element of the example, so <mrows> are needed for this test
+    let expr = "<math>
+        <mo>{</mo>
+        <mrow> <mi>x</mi><mo>∈</mo><mi>ℕ</mi></mrow>
+        <mo>|</mo>
+        <mrow><mi>x</mi> <mtext>&#x00A0;is&#x00A0;an&#x00A0;even&#x00A0;number</mtext> </mrow>
+        <mo>}</mo>
+        </math>";
+    test("pl", "SimpleSpeak", expr, 
+            "zbiór wszystkich x elementem zbioru, liczby naturalne takich że x is an even number")?;
+            return Ok(());
+
+}

--- a/tests/Languages/pl/SimpleSpeak/subscripts.rs
+++ b/tests/Languages/pl/SimpleSpeak/subscripts.rs
@@ -1,0 +1,64 @@
+use crate::common::*;
+use anyhow::Result;
+
+#[test]
+fn msub_simple() -> Result<()> {
+    let expr = "<math> <msub> <mi>x</mi> <mn>1</mn> </msub> </math>";
+    test_prefs("pl", "SimpleSpeak", vec![("Verbosity", "Terse")], expr, "x 1")?;
+    test_prefs("pl", "SimpleSpeak", vec![("Verbosity", "Medium")], expr, "x indeks dolny 1")?;
+    test_prefs("pl", "SimpleSpeak", vec![("Verbosity", "Verbose")], expr, "x indeks dolny 1")?;
+    return Ok(());
+
+  }
+
+#[test]
+fn msub_not_simple() -> Result<()> {
+    let expr = "<math> <msub> <mi>x</mi> <mn>1.2</mn> </msub> </math>";
+    test_prefs("pl", "SimpleSpeak", vec![("Verbosity", "Terse")], expr, "x indeks dolny 12")?;
+    return Ok(());
+
+  }
+
+#[test]
+fn msubsup_not_simple() -> Result<()> {
+    let expr = "<math> <msubsup> <mi>x</mi> <mn>1.2</mn> <mn>3</mn></msubsup> </math>";
+    test_prefs("pl", "SimpleSpeak", vec![("Verbosity", "Terse")], expr, "x indeks dolny 12, do sześcianu")?;
+    return Ok(());
+
+  }
+
+#[test]
+fn msub_simple_mi() -> Result<()> {
+    let expr = "<math> <msub> <mi>x</mi> <mi>i</mi> </msub> </math>";
+    test_prefs("pl", "SimpleSpeak", vec![("Verbosity", "Terse")], expr, "x indeks dolny i")?;
+    test_prefs("pl", "SimpleSpeak", vec![("Verbosity", "Verbose")], expr, "x indeks dolny i")?;
+    return Ok(());
+
+}
+
+#[test]
+fn msub_simple_number_follows() -> Result<()> {
+    let expr = "<math> <msub> <mi>x</mi> <mn>1</mn> </msub> <msup><mn>10</mn><mn>2</mn></msup> </math>";
+    test_prefs("pl", "SimpleSpeak", vec![("Verbosity", "Terse")], expr, "x 1, 10 do kwadratu")?;
+    test_prefs("pl", "SimpleSpeak", vec![("Verbosity", "Verbose")], expr, "x indeks dolny 1; 10 do kwadratu")?;
+    return Ok(());
+
+}
+
+#[test]
+fn msub_simple_non_number_follows() -> Result<()> {
+    let expr = "<math> <msubsup> <mi>x</mi> <mn>1</mn> <mn>2</mn> </msubsup> </math>";
+    test_prefs("pl", "SimpleSpeak", vec![("Verbosity", "Terse")], expr, "x 1, do kwadratu")?;
+    test_prefs("pl", "SimpleSpeak", vec![("Verbosity", "Verbose")], expr, "x indeks dolny 1, do kwadratu")?;
+    return Ok(());
+
+}
+
+#[test]
+fn msubsup_simple() -> Result<()> {
+    let expr = "<math> <msub> <mi>x</mi> <mn>1</mn> </msub> <msup><mi>x</mi>,<mn>2</mn></msup> </math>";
+    test_prefs("pl", "SimpleSpeak", vec![("Verbosity", "Terse")], expr, "x 1, x do kwadratu")?;
+    test_prefs("pl", "SimpleSpeak", vec![("Verbosity", "Verbose")], expr, "x indeks dolny 1; x do kwadratu")?;
+    return Ok(());
+
+}

--- a/tests/Languages/pl/alphabets.rs
+++ b/tests/Languages/pl/alphabets.rs
@@ -1,0 +1,415 @@
+/// Tests for rules shared between various speech styles:
+/// *  this has tests focused on the various alphabets
+use crate::common::*;
+use anyhow::Result;
+
+
+#[test]
+fn special_alphabet_chars() -> Result<()> {
+  let expr = "<math> <mi>ℌ</mi><mo>,</mo><mi>ℭ</mi></math>";
+  test("pl", "SimpleSpeak", expr, "fraktura wielka h, przecinek, fraktura wielka c")?;
+  let expr = "<math> <mi>ℍ</mi><mo>,</mo><mi>ℿ</mi></math>";
+  test("pl", "SimpleSpeak", expr, "dwukreskowe wielka h, przecinek; dwukreskowe wielka pi")?;
+  let expr = "<math> <mi>ℐ</mi><mo>,</mo><mi>ℳ</mi></math>";
+  test("pl", "SimpleSpeak", expr, "pisane wielka i przecinek, pisane wielka m")?;
+  return Ok(());
+
+}
+
+#[test]
+fn greek() -> Result<()> {
+    let expr = "<math> <mi>Α</mi><mo>,</mo><mi>Ω</mi></math>";
+    test("pl", "SimpleSpeak", expr, "wielka alfa przecinek, wielka omega")?;
+    let expr = "<math> <mi>α</mi><mo>,</mo><mi>ω</mi></math>";
+    test("pl", "SimpleSpeak", expr, "alfa przecinek, omega")?;
+    // MathType private space versions
+    let expr = "<math> <mi></mi><mo>,</mo><mi></mi></math>";
+    test("pl", "SimpleSpeak", expr, "dwukreskowe wielka delta, przecinek; dwukreskowe wielka ypsilon")?;
+    let expr = "<math> <mi>α</mi><mo>,</mo><mi>ω</mi></math>";
+    test("pl", "SimpleSpeak", expr, "alfa przecinek, omega")?;
+    return Ok(());
+
+}
+
+#[test]
+fn cap_cyrillic() -> Result<()> {
+    let expr = "<math> <mi>А</mi><mo>,</mo><mi>Я</mi></math>";
+    test("pl", "SimpleSpeak", expr, "wielka a przecinek, wielka ja")?;
+    return Ok(());
+
+}
+
+#[test]
+fn parenthesized() -> Result<()> {
+    let expr = "<math> <mi>⒜</mi><mo>,</mo><mi>⒵</mi></math>";
+    test("pl", "SimpleSpeak", expr, "w nawiasie a przecinek, w nawiasie z")?;
+    return Ok(());
+
+}
+
+#[test]
+fn circled() -> Result<()> {
+    let expr = "<math> <mi>Ⓐ</mi><mo>,</mo><mi>Ⓩ</mi></math>";
+    test("pl", "SimpleSpeak", expr, "w kółku wielka a, przecinek, w kółku wielka z")?;
+    let expr = "<math> <mi>🅐</mi><mo>,</mo><mi>🅩</mi></math>";
+    test("pl", "SimpleSpeak", expr, "czarny w kółku wielka a, przecinek; czarny w kółku wielka z")?;
+    let expr = "<math> <mi>ⓐ</mi><mo>,</mo><mi>ⓩ</mi></math>";
+    test("pl", "SimpleSpeak", expr, "w kółku a przecinek, w kółku z")?;
+    return Ok(());
+
+}
+
+#[test]
+fn fraktur() -> Result<()> {
+    let expr = "<math> <mi>𝔄</mi><mo>,</mo><mi>𝔜</mi></math>";
+    test("pl", "SimpleSpeak", expr, "fraktura wielka a, przecinek, fraktura wielka y")?;
+    let expr = "<math> <mi>𝔞</mi><mo>,</mo><mi>𝔷</mi></math>";
+    test("pl", "SimpleSpeak", expr, "fraktura a przecinek, fraktura z")?;
+    // MathType private space versions
+    let expr = "<math> <mi></mi><mo>,</mo><mi></mi></math>";
+    test("pl", "SimpleSpeak", expr, "fraktura wielka a, przecinek, fraktura wielka y")?;
+    let expr = "<math> <mi></mi><mo>,</mo><mi></mi></math>";
+    test("pl", "SimpleSpeak", expr, "fraktura a przecinek, fraktura z")?;
+    return Ok(());
+
+}
+
+#[test]
+fn bold_fraktur() -> Result<()> {
+    let expr = "<math> <mi>𝕬</mi><mo>,</mo><mi>𝖅</mi></math>";
+    test("pl", "SimpleSpeak", expr, "fraktura pogrubione wielka a, przecinek; fraktura pogrubione wielka z")?;
+    let expr = "<math> <mi>𝖆</mi><mo>,</mo><mi>𝖟</mi></math>";
+    test("pl", "SimpleSpeak", expr, "fraktura pogrubione a, przecinek; fraktura pogrubione z")?;
+    // MathType private space versions
+    let expr = "<math> <mi></mi><mo>,</mo><mi></mi></math>";
+    test("pl", "SimpleSpeak", expr, "fraktura pogrubione wielka a, przecinek; fraktura pogrubione wielka z")?;
+    let expr = "<math> <mi></mi><mo>,</mo><mi></mi></math>";
+    test("pl", "SimpleSpeak", expr, "fraktura pogrubione a, przecinek; fraktura pogrubione z")?;
+    return Ok(());
+
+}
+
+#[test]
+fn double_struck() -> Result<()> {
+    let expr = "<math> <mi>𝔸</mi><mo>,</mo><mi>𝕐</mi></math>";
+    test("pl", "SimpleSpeak", expr, "dwukreskowe wielka a, przecinek; dwukreskowe wielka y")?;
+    let expr = "<math> <mi>𝕒</mi><mo>,</mo><mi>𝕫</mi></math>";
+    test("pl", "SimpleSpeak", expr, "dwukreskowe a przecinek, dwukreskowe z")?;
+    let expr = "<math> <mi>𝟘</mi><mo>,</mo><mi>𝟡</mi></math>";
+    test("pl", "SimpleSpeak", expr, "dwukreskowe 0 przecinek, dwukreskowe 9")?;
+    // MathType private space versions
+    let expr = "<math> <mi></mi><mo>,</mo><mi></mi></math>";
+    test("pl", "SimpleSpeak", expr, "dwukreskowe wielka a, przecinek; dwukreskowe wielka y")?;
+    let expr = "<math> <mi></mi><mo>,</mo><mi></mi></math>";
+    test("pl", "SimpleSpeak", expr, "dwukreskowe a przecinek, dwukreskowe z")?;
+    let expr = "<math> <mi></mi><mo>,</mo><mi></mi></math>";
+    test("pl", "SimpleSpeak", expr, "dwukreskowe 0 przecinek, dwukreskowe 9")?;
+    return Ok(());
+
+}
+
+#[test]
+fn script() -> Result<()> {
+    let expr = "<math> <mi>𝒜</mi><mo>,</mo><mi>𝒵</mi></math>";
+    test("pl", "SimpleSpeak", expr, "pisane wielka a przecinek, pisane wielka z")?;
+    let expr = "<math> <mi>𝒶</mi><mo>,</mo><mi>𝓏</mi></math>";
+    test("pl", "SimpleSpeak", expr, "pisane a przecinek, pisane z")?;
+    // MathType private space versions
+    let expr = "<math> <mi></mi><mo>,</mo><mi></mi></math>";
+    test("pl", "SimpleSpeak", expr, "pisane wielka a przecinek, pisane wielka z")?;
+    let expr = "<math> <mi></mi><mo>,</mo><mi></mi></math>";
+    test("pl", "SimpleSpeak", expr, "pisane a przecinek, pisane z")?;
+    return Ok(());
+
+}
+
+#[test]
+fn bold_script() -> Result<()> {
+    let expr = "<math> <mi>𝓐</mi><mo>,</mo><mi>𝓩</mi></math>";
+    test("pl", "SimpleSpeak", expr, "pisane pogrubione wielka a, przecinek; pisane pogrubione wielka z")?;
+    let expr = "<math> <mi>𝓪</mi><mo>,</mo><mi>𝔃</mi></math>";
+    test("pl", "SimpleSpeak", expr, "pisane pogrubione a, przecinek, pisane pogrubione z")?;
+    // MathType private space versions
+    let expr = "<math> <mi></mi><mo>,</mo><mi></mi></math>";
+    test("pl", "SimpleSpeak", expr, "pisane pogrubione wielka a, przecinek; pisane pogrubione wielka z")?;
+    let expr = "<math> <mi></mi><mo>,</mo><mi></mi></math>";
+    test("pl", "SimpleSpeak", expr, "pisane pogrubione a, przecinek, pisane pogrubione z")?;
+    return Ok(());
+
+}
+
+#[test]
+fn bold() -> Result<()> {
+    let expr = "<math> <mi>𝐀</mi><mo>,</mo><mi>𝐙</mi></math>";
+    test("pl", "SimpleSpeak", expr, "pogrubione wielka a, przecinek; pogrubione wielka z")?;
+    let expr = "<math> <mi>𝐚</mi><mo>,</mo><mi>𝐳</mi></math>";
+    test("pl", "SimpleSpeak", expr, "pogrubione a przecinek, pogrubione z")?;
+    // MathType private space versions
+    let expr = "<math> <mi></mi><mo>,</mo><mi></mi></math>";
+    test("pl", "SimpleSpeak", expr, "pogrubione wielka a, przecinek; pogrubione wielka z")?;
+    let expr = "<math> <mi></mi><mo>,</mo><mi></mi></math>";
+    test("pl", "SimpleSpeak", expr, "pogrubione a przecinek, pogrubione z")?;
+    return Ok(());
+
+}
+
+#[test]
+fn italic() -> Result<()> {
+    let expr = "<math> <mi>𝐴</mi><mo>,</mo><mi>𝑍</mi></math>";
+    test("pl", "SimpleSpeak", expr, "wielka a przecinek, wielka z")?;
+    let expr = "<math> <mi>𝑎</mi><mo>,</mo><mi>𝑧</mi></math>";
+    test("pl", "SimpleSpeak", expr, "a przecinek, z")?;
+    // MathType private space versions
+    let expr = "<math> <mi></mi><mo>,</mo><mi></mi></math>";
+    test("pl", "SimpleSpeak", expr, "wielka a przecinek, wielka z")?;
+    let expr = "<math> <mi></mi><mo>,</mo><mi></mi></math>";
+    test("pl", "SimpleSpeak", expr, "a przecinek, z")?;
+    return Ok(());
+
+}
+
+#[test]
+fn sans_serif() -> Result<()> {
+  let expr = "<math> <mi>𝖠</mi><mo>,</mo><mi>𝖹</mi></math>";
+  test("pl", "SimpleSpeak", expr, "wielka a przecinek, wielka z")?;
+  let expr = "<math> <mi>𝖺</mi><mo>,</mo><mi>𝗓</mi></math>";
+  test("pl", "SimpleSpeak", expr, "a przecinek, z")?;
+  // MathType private space versions
+  let expr = "<math> <mi></mi><mo>,</mo><mi></mi></math>";
+  test("pl", "SimpleSpeak", expr, "wielka a przecinek, wielka z")?;
+  let expr = "<math> <mi></mi><mo>,</mo><mi></mi></math>";
+  test("pl", "SimpleSpeak", expr, "a przecinek, z")?;
+  return Ok(());
+
+}
+
+#[test]
+fn sans_serif_bold() -> Result<()> {
+    let expr = "<math> <mi>𝗔</mi><mo>,</mo><mi>𝗭</mi></math>";
+    test("pl", "SimpleSpeak", expr, "pogrubione wielka a, przecinek; pogrubione wielka z")?;
+    let expr = "<math> <mi>𝗮</mi><mo>,</mo><mi>𝘇</mi></math>";
+    test("pl", "SimpleSpeak", expr, "pogrubione a przecinek, pogrubione z")?;
+    // MathType private space versions
+    let expr = "<math> <mi></mi><mo>,</mo><mi></mi></math>";
+    test("pl", "SimpleSpeak", expr, "pogrubione wielka a, przecinek; pogrubione wielka z")?;
+    let expr = "<math> <mi></mi><mo>,</mo><mi></mi></math>";
+    test("pl", "SimpleSpeak", expr, "pogrubione a przecinek, pogrubione z")?;
+    return Ok(());
+
+}
+
+#[test]
+fn sans_serif_italic() -> Result<()> {
+    let expr = "<math> <mi>𝘈</mi><mo>,</mo><mi>𝘡</mi></math>";
+    test("pl", "SimpleSpeak", expr, "wielka a przecinek, wielka z")?;
+    let expr = "<math> <mi>𝘢</mi><mo>,</mo><mi>𝘻</mi></math>";
+    test("pl", "SimpleSpeak", expr, "a przecinek, z")?;
+    // MathType private space versions
+    let expr = "<math> <mi></mi><mo>,</mo><mi></mi></math>";
+    test("pl", "SimpleSpeak", expr, "wielka a przecinek, wielka z")?;
+    let expr = "<math> <mi></mi><mo>,</mo><mi></mi></math>";
+    test("pl", "SimpleSpeak", expr, "a przecinek, z")?;
+    return Ok(());
+
+}
+
+#[test]
+fn sans_serif_bold_italic() -> Result<()> {
+    let expr = "<math> <mi>𝘼</mi><mo>,</mo><mi>𝙕</mi></math>";
+    test("pl", "SimpleSpeak", expr, "pogrubione wielka a, przecinek; pogrubione wielka z")?;
+    let expr = "<math> <mi>𝙖</mi><mo>,</mo><mi>𝙯</mi></math>";
+    test("pl", "SimpleSpeak", expr, "pogrubione a przecinek, pogrubione z")?;
+    // MathType private space versions
+    let expr = "<math> <mi></mi><mo>,</mo><mi></mi></math>";
+    test("pl", "SimpleSpeak", expr, "pogrubione wielka a, przecinek; pogrubione wielka z")?;
+    let expr = "<math> <mi></mi><mo>,</mo><mi></mi></math>";
+    test("pl", "SimpleSpeak", expr, "pogrubione a przecinek, pogrubione z")?;
+    return Ok(());
+
+}
+
+#[test]
+fn monospace() -> Result<()> {
+    let expr = "<math> <mi>𝙰</mi><mo>,</mo><mi>𝚉</mi></math>";
+    test("pl", "SimpleSpeak", expr, "wielka a przecinek, wielka z")?;
+    let expr = "<math> <mi>𝚊</mi><mo>,</mo><mi>𝚣</mi></math>";
+    test("pl", "SimpleSpeak", expr, "a przecinek, z")?;
+    // MathType private space versions
+    let expr = "<math> <mi></mi><mo>,</mo><mi></mi></math>";
+    test("pl", "SimpleSpeak", expr, "wielka a przecinek, wielka z")?;
+    let expr = "<math> <mi></mi><mo>,</mo><mi></mi></math>";
+    test("pl", "SimpleSpeak", expr, "a przecinek, z")?;
+    return Ok(());
+
+}
+
+
+#[test]
+fn bold_greek() -> Result<()> {
+    let expr = "<math> <mi>𝚨</mi><mo>,</mo><mi>𝛀</mi></math>";
+    test("pl", "SimpleSpeak", expr, "pogrubione wielka alfa, przecinek; pogrubione wielka omega")?;
+    let expr = "<math> <mi>𝛂</mi><mo>,</mo><mi>𝛚</mi></math>";
+    test("pl", "SimpleSpeak", expr, "pogrubione alfa przecinek, pogrubione omega")?;
+    // MathType private space versions
+    let expr = "<math> <mi></mi><mo>,</mo><mi></mi></math>";
+    test("pl", "SimpleSpeak", expr, "pogrubione wielka alfa, przecinek; pogrubione wielka omega")?;
+    let expr = "<math> <mi></mi><mo>,</mo><mi></mi></math>";
+    test("pl", "SimpleSpeak", expr, "pogrubione alfa przecinek, pogrubione omega")?;
+    return Ok(());
+
+}
+
+#[test]
+fn bold_greek_others() -> Result<()> {
+    let expr = "<math> <mi>𝛛</mi><mo>,</mo><mi>𝛡</mi></math>";
+    test("pl", "SimpleSpeak", expr, "pogrubione pochodna cząstkowa, przecinek, pogrubione pi")?;
+    // MathType private space versions
+    let expr = "<math> <mi></mi><mo>,</mo><mi></mi></math>";
+    test("pl", "SimpleSpeak", expr, "pogrubione pochodna cząstkowa, przecinek, pogrubione pi")?;
+    return Ok(());
+
+}
+
+
+#[test]
+fn italic_greek() -> Result<()> {
+    let expr = "<math> <mi>𝛢</mi><mo>,</mo><mi>𝛺</mi></math>";
+    test("pl", "SimpleSpeak", expr, "wielka alfa przecinek, wielka omega")?;
+    let expr = "<math> <mi>𝛼</mi><mo>,</mo><mi>𝜔</mi></math>";
+    test("pl", "SimpleSpeak", expr, "alfa przecinek, omega")?;
+    // MathType private space versions
+    let expr = "<math> <mi></mi><mo>,</mo><mi></mi></math>";
+    test("pl", "SimpleSpeak", expr, "wielka alfa przecinek, wielka omega")?;
+    let expr = "<math> <mi></mi><mo>,</mo><mi></mi></math>";
+    test("pl", "SimpleSpeak", expr, "alfa przecinek, omega")?;
+    return Ok(());
+
+}
+
+#[test]
+fn italic_greek_others() -> Result<()> {
+    let expr = "<math> <mi>𝜕</mi><mo>,</mo><mi>𝜛</mi></math>";
+    test("pl", "SimpleSpeak", expr, "pochodna cząstkowa, przecinek, pi")?;
+    // MathType private space versions
+    let expr = "<math> <mi></mi><mo>,</mo><mi></mi></math>";
+    test("pl", "SimpleSpeak", expr, "pochodna cząstkowa, przecinek, pi")?;
+    return Ok(());
+
+}
+
+#[test]
+fn bold_italic_greek() -> Result<()> {
+    let expr = "<math> <mi>𝜜</mi><mo>,</mo><mi>𝜴</mi></math>";
+    test("pl", "SimpleSpeak", expr, "pogrubione wielka alfa, przecinek; pogrubione wielka omega")?;
+    let expr = "<math> <mi>𝜶</mi><mo>,</mo><mi>𝝎</mi></math>";
+    test("pl", "SimpleSpeak", expr, "pogrubione alfa przecinek, pogrubione omega")?;
+    // MathType private space versions
+    let expr = "<math> <mi></mi><mo>,</mo><mi></mi></math>";
+    test("pl", "SimpleSpeak", expr, "pogrubione wielka alfa, przecinek; pogrubione wielka omega")?;
+    let expr = "<math> <mi></mi><mo>,</mo><mi></mi></math>";
+    test("pl", "SimpleSpeak", expr, "pogrubione alfa przecinek, pogrubione omega")?;
+    return Ok(());
+
+}
+
+#[test]
+fn bold_italic_greek_others() -> Result<()> {
+    let expr = "<math> <mi>𝝏</mi><mo>,</mo><mi>𝝕</mi></math>";
+    test("pl", "SimpleSpeak", expr, "pogrubione pochodna cząstkowa, przecinek, pogrubione pi")?;
+    // MathType private space versions
+    let expr = "<math> <mi></mi><mo>,</mo><mi></mi></math>";
+    test("pl", "SimpleSpeak", expr, "pogrubione pochodna cząstkowa, przecinek, pogrubione pi")?;
+    return Ok(());
+
+}
+
+#[test]
+fn sans_serif_bold_greek() -> Result<()> {
+    let expr = "<math> <mi>𝝖</mi><mo>,</mo><mi>𝝮</mi></math>";
+    test("pl", "SimpleSpeak", expr, "pogrubione wielka alfa, przecinek; pogrubione wielka omega")?;
+    let expr = "<math> <mi>𝝰</mi><mo>,</mo><mi>𝞈</mi></math>";
+    test("pl", "SimpleSpeak", expr, "pogrubione alfa przecinek, pogrubione omega")?;
+    // MathType private space versions
+    let expr = "<math> <mi></mi><mo>,</mo><mi></mi></math>";
+    test("pl", "SimpleSpeak", expr, "pogrubione wielka alfa, przecinek; pogrubione wielka omega")?;
+    let expr = "<math> <mi></mi><mo>,</mo><mi></mi></math>";
+    test("pl", "SimpleSpeak", expr, "pogrubione alfa przecinek, pogrubione omega")?;
+    return Ok(());
+
+}
+
+#[test]
+fn sans_serif_bold_greek_others() -> Result<()> {
+    let expr = "<math> <mi>𝞉</mi><mo>,</mo><mi>𝞏</mi></math>";
+    test("pl", "SimpleSpeak", expr, "pogrubione pochodna cząstkowa, przecinek, pogrubione pi")?;
+    // MathType private space versions
+    let expr = "<math> <mi></mi><mo>,</mo><mi></mi></math>";
+    test("pl", "SimpleSpeak", expr, "pogrubione pochodna cząstkowa, przecinek, pogrubione pi")?;
+    return Ok(());
+
+}
+
+#[test]
+fn sans_serif_bold_italic_greek() -> Result<()> {
+    let expr = "<math> <mi>𝞐</mi><mo>,</mo><mi>𝞨</mi></math>";
+    test("pl", "SimpleSpeak", expr, "pogrubione wielka alfa, przecinek; pogrubione wielka omega")?;
+    let expr = "<math> <mi>𝞪</mi><mo>,</mo><mi>𝟂</mi></math>";
+    test("pl", "SimpleSpeak", expr, "pogrubione alfa przecinek, pogrubione omega")?;
+    // MathType private space versions
+    let expr = "<math> <mi></mi><mo>,</mo><mi></mi></math>";
+    test("pl", "SimpleSpeak", expr, "pogrubione wielka alfa, przecinek; pogrubione wielka omega")?;
+    let expr = "<math> <mi></mi><mo>,</mo><mi></mi></math>";
+    test("pl", "SimpleSpeak", expr, "pogrubione alfa przecinek, pogrubione omega")?;
+    return Ok(());
+
+}
+
+#[test]
+fn sans_serif_bold_italic_greek_others() -> Result<()> {
+    let expr = "<math> <mi>𝟃</mi><mo>,</mo><mi>𝟉</mi></math>";
+    test("pl", "SimpleSpeak", expr, "pogrubione pochodna cząstkowa, przecinek, pogrubione pi")?;
+    // MathType private space versions
+    let expr = "<math> <mi></mi><mo>,</mo><mi></mi></math>";
+    test("pl", "SimpleSpeak", expr, "pogrubione pochodna cząstkowa, przecinek, pogrubione pi")?;
+    return Ok(());
+
+}
+
+#[test]
+fn pua_regular() -> Result<()> {
+  let expr = "<math> <mi></mi><mo>,</mo><mi></mi></math>";
+  test("pl", "SimpleSpeak", expr, "wielka a przecinek, wielka z")?;
+  return Ok(());
+
+}
+
+#[test]
+fn turned() -> Result<()> {
+    let expr = "<math> <mi>Ⅎ</mi><mo>,</mo><mi>⅄</mi></math>";
+    test("pl", "SimpleSpeak", expr, "odwrócone wielka f, przecinek; odwrócony bezszeryfowe wielka y")?;
+    return Ok(());
+
+  }
+
+#[test]
+fn unicode_typo_regressions() -> Result<()> {
+  test("pl", "SimpleSpeak", "<math><mi>ⁱ</mi></math>", "do potęgi i")?;
+  test("pl", "SimpleSpeak", "<math><mi>☌</mi></math>", "koniunkcja")?;
+  Ok(())
+}
+
+#[test]
+fn enclosed_numbers() -> Result<()> {
+  let expr = "<math> <mi>①</mi><mo>,</mo><mi>⑨</mi></math>";
+  test("pl", "SimpleSpeak", expr, "w kółku 1 przecinek, w kółku 9")?;
+  let expr = "<math> <mi>❶</mi><mo>,</mo><mi>㊿</mi></math>";
+  test("pl", "SimpleSpeak", expr, "czarny w kółku jeden, przecinek; w kółku numer pięćdziesiąt")?;
+  let expr = "<math> <mi>⑴</mi><mo>,</mo><mi>⑼</mi></math>";
+  test("pl", "SimpleSpeak", expr, "w nawiasie 1 przecinek, w nawiasie 9")?;
+  let expr = "<math> <mi>⒈</mi><mo>,</mo><mi>⒐</mi></math>";
+  test("pl", "SimpleSpeak", expr, "1 z kropką przecinek, 9 z kropką")?;
+  let expr = "<math> <mi>⓵</mi><mo>,</mo><mi>⓽</mi></math>";
+  test("pl", "SimpleSpeak", expr, "podwójny w kółku 1, przecinek; podwójny w kółku 9")?;
+  return Ok(());
+
+}

--- a/tests/Languages/pl/chemistry.rs
+++ b/tests/Languages/pl/chemistry.rs
@@ -1,0 +1,766 @@
+/// Tests for rules shared between various speech styles:
+/// *  modified var
+use crate::common::*;
+use anyhow::Result;
+
+#[test]
+fn salt() -> Result<()> {
+  let expr = "<math><mi>Na</mi><mi>Cl</mi></math>";
+  test_prefs("pl", "SimpleSpeak", vec![("Verbosity", "Terse")], expr, "wielka n a, wielka c l")?;
+  return Ok(());
+
+}
+
+#[test]
+fn water() -> Result<()> {
+  let expr = "<math><msub><mi>H</mi><mn>2</mn></msub><mi>O</mi></math>";
+  test_prefs("pl", "ClearSpeak", vec![("Verbosity", "Terse")], expr, "wielka h, 2 wielka o")?;
+  test_prefs("pl", "ClearSpeak", vec![("Verbosity", "Medium")], expr, "wielka h, indeks dolny 2, wielka o")?;
+  test_prefs("pl", "ClearSpeak", vec![("Verbosity", "Verbose")], expr, "wielka h, indeks dolny 2, wielka o")?;
+  return Ok(());
+
+}
+
+#[test]
+fn carbon() -> Result<()> {
+  let expr = "<math><mi>C</mi></math>";     // not enough to trigger recognition
+  test_prefs("pl", "SimpleSpeak", vec![("Verbosity", "Terse")], expr, "wielka c")?;
+  return Ok(());
+
+}
+
+#[test]
+fn sulfate() -> Result<()> {
+  let expr = "<math><mrow><msup>
+          <mrow><mo>[</mo><mi>S</mi><msub><mi>O</mi><mn>4</mn></msub><mo>]</mo></mrow>
+          <mrow><mn>2</mn><mo>&#x2212;</mo></mrow>
+      </msup></mrow></math>";
+  test_prefs("pl", "ClearSpeak", vec![("Verbosity", "Medium")], expr, "nawias kwadratowy otwierający; wielka s, wielka o, indeks dolny 4; nawias kwadratowy zamykający indeks górny 2 minus")?;
+  return Ok(());
+
+}
+
+#[test]
+fn aluminum_sulfate() -> Result<()> {
+  let expr = "<math><mrow><msub><mi>Al</mi><mn>2</mn></msub>
+          <msub><mrow><mo>(</mo><mi>S</mi><msub><mi>O</mi><mn>4</mn></msub><mo>)</mo></mrow><mn>3</mn></msub></mrow></math>";
+  test_prefs("pl", "ClearSpeak", vec![("Verbosity", "Terse")], expr, "wielka a l, 2, otwórz, wielka s, wielka o, 4; zamknij 3")?;
+  test_prefs("pl", "ClearSpeak", vec![("Verbosity", "Medium")], expr, "wielka a l, indeks dolny 2; nawias otwierający; wielka s, wielka o, indeks dolny 4; nawias zamykający indeks dolny 3")?;
+  test_prefs("pl", "ClearSpeak", vec![("Verbosity", "Verbose")], expr, "wielka a l, indeks dolny 2; nawias otwierający; wielka s, wielka o, indeks dolny 4; nawias zamykający indeks dolny 3")?;
+  return Ok(());
+
+}
+
+#[test]
+fn ethanol_bonds() -> Result<()> {
+  let expr = "<math>
+          <mrow>
+              <mi>C</mi>
+              <msub>  <mi>H</mi> <mn>3</mn> </msub>
+              <mo>&#x2212;</mo>
+              <mi>C</mi>
+              <msub>  <mi>H</mi> <mn>2</mn> </msub>
+              <mo>&#x2212;</mo>
+              <mi>O</mi>
+              <mi>H</mi>
+          </mrow>
+      </math>";
+  test_prefs("pl", "ClearSpeak", vec![("Verbosity", "Terse")], expr, "wielka c, wielka h, 3, wiązanie pojedyncze, wielka c, wielka h, 2, wiązanie pojedyncze, wielka o, wielka h")?;
+
+  return Ok(());
+
+}
+
+#[test]
+fn dichlorine_hexoxide() -> Result<()> {
+  let expr = "<math><mrow>
+      <msup>
+        <mrow><mo>[</mo><mi>Cl</mi><msub><mi>O</mi><mn>2</mn></msub><mo>]</mo></mrow>
+        <mo>+</mo>
+      </msup>
+      <msup>
+        <mrow><mo>[</mo><mi>Cl</mi><msub><mi>O</mi><mn>4</mn></msub><mo>]</mo></mrow>
+        <mo>-</mo>
+      </msup>
+    </mrow></math>";
+  test_prefs("pl", "SimpleSpeak", vec![("Verbosity", "Terse")], 
+    expr, "nawias kwadratowy otwierający; wielka c l, wielka o, 2; nawias kwadratowy zamykający plus; nawias kwadratowy otwierający; wielka c l, wielka o, 4; nawias kwadratowy zamykający minus")?;
+  test_prefs("pl", "SimpleSpeak", vec![("Verbosity", "Medium")], 
+    expr, "nawias kwadratowy otwierający; wielka c l, wielka o, indeks dolny 2; nawias kwadratowy zamykający indeks górny plus; nawias kwadratowy otwierający; wielka c l, wielka o, indeks dolny 4; nawias kwadratowy zamykający indeks górny minus")?;
+  test_prefs("pl", "SimpleSpeak", vec![("Verbosity", "Verbose")], 
+    expr, "nawias kwadratowy otwierający; wielka c l, wielka o, indeks dolny 2; nawias kwadratowy zamykający indeks górny plus; nawias kwadratowy otwierający; wielka c l, wielka o, indeks dolny 4; nawias kwadratowy zamykający indeks górny minus")?;
+                          return Ok(());
+
+}
+
+
+#[test]
+fn ethylene_with_bond() -> Result<()> {
+  let expr = "<math><mrow>
+          <msub><mi>H</mi><mn>2</mn></msub><mi>C</mi>
+          <mo>=</mo>
+          <mi>C</mi><msub><mi>H</mi><mn>2</mn></msub>
+      </mrow></math>";
+  test_prefs("pl", "SimpleSpeak", vec![("Verbosity", "Terse")], expr, "wielka h, 2 wielka c, wiązanie podwójne, wielka c, wielka h, 2")?;
+  return Ok(());
+
+}
+
+#[test]
+fn ferric_chloride_aq() -> Result<()> {
+  let expr = "<math><mrow>
+        <mi>Fe</mi>
+        <msub><mi>Cl</mi><mn>3</mn></msub>
+        <mrow><mo>(</mo><mrow><mi>aq</mi></mrow><mo>)</mo></mrow>
+    </mrow></math>";
+  test_prefs("pl", "SimpleSpeak", vec![("Verbosity", "Terse")], expr, "wielka f e, wielka c l, 3 wodny")?;
+  return Ok(());
+
+  }
+
+#[test]
+fn ethylene_with_colon_bond() -> Result<()> {
+  let expr = "<math><mrow>
+          <msub><mi>H</mi><mn>2</mn></msub><mi>C</mi>
+          <mo>::</mo>
+          <mi>C</mi><msub><mi>H</mi><mn>2</mn></msub>
+      </mrow></math>";
+  test_prefs("pl", "SimpleSpeak", vec![("Verbosity", "Terse")], expr, "wielka h, 2 wielka c, wiązanie podwójne, wielka c, wielka h, 2")?;
+  return Ok(());
+
+}
+
+#[test]
+fn beta_decay() -> Result<()> {
+  let expr = "<math>
+      <mmultiscripts>
+        <mtext>C</mtext>
+        <mprescripts />
+        <mn>6</mn>
+        <mn>14</mn>
+      </mmultiscripts>
+      <mo>&#x2192;</mo>
+      <mmultiscripts>
+        <mtext>N</mtext>
+        <mprescripts />
+        <mn>7</mn>
+        <mn>14</mn>
+      </mmultiscripts>
+      <mo>+</mo>
+      <mmultiscripts>
+        <mtext>e</mtext>
+        <mprescripts />
+        <mrow>
+          <mo>&#x2212;</mo>
+          <mn>1</mn>
+        </mrow>
+        <mn>0</mn>
+      </mmultiscripts>
+    </math>";
+    test_prefs("pl", "ClearSpeak", vec![("Verbosity", "Terse")], expr,
+      "14, 6, wielka c; tworzy, 14, 7, wielka n; plus 0, minus 1, e")?;
+    test_prefs("pl", "ClearSpeak", vec![("Verbosity", "Medium")], expr,
+      "indeks górny 14, indeks dolny 6, wielka c; reaguje tworząc; indeks górny 14, indeks dolny 7, wielka n; plus, indeks górny 0, indeks dolny minus 1, e")?;
+    test_prefs("pl", "ClearSpeak", vec![("Verbosity", "Verbose")], expr,
+      "indeks górny 14, indeks dolny 6, wielka c; reaguje tworząc; indeks górny 14, indeks dolny 7, wielka n; plus, indeks górny 0, indeks dolny minus 1, e")?;
+      return Ok(());
+
+}
+
+#[test]
+fn mhchem_beta_decay() -> Result<()> {
+  let expr = "<math>
+      <mrow>
+        <msubsup>
+          <mrow>
+            <mrow>
+              <mpadded width='0'>
+                <mphantom>
+                  <mi>A</mi>
+                </mphantom>
+              </mpadded>
+            </mrow>
+          </mrow>
+          <mrow>
+            <mrow>
+              <mpadded height='0' depth='0'>
+                <mphantom>
+                  <mn>6</mn>
+                </mphantom>
+              </mpadded>
+            </mrow>
+          </mrow>
+          <mrow>
+            <mrow>
+              <mpadded height='0' depth='0'>
+                <mphantom>
+                  <mn>14</mn>
+                </mphantom>
+              </mpadded>
+            </mrow>
+          </mrow>
+        </msubsup>
+        <mspace width='-0.083em'></mspace>
+        <msubsup>
+          <mrow>
+            <mrow>
+              <mpadded width='0'>
+                <mphantom>
+                  <mi>A</mi>
+                </mphantom>
+              </mpadded>
+            </mrow>
+          </mrow>
+          <mrow>
+            <mrow>
+              <mpadded width='0'>
+                <mphantom>
+                  <mn>2</mn>
+                </mphantom>
+              </mpadded>
+            </mrow>
+            <mrow>
+              <mpadded width='0' lspace='-1width'>
+                <mrow>
+                  <mpadded height='0'>
+                    <mn>6</mn>
+                  </mpadded>
+                </mrow>
+              </mpadded>
+            </mrow>
+          </mrow>
+          <mrow>
+            <mrow>
+              <mpadded height='0'>
+                <mrow>
+                  <mpadded width='0'>
+                    <mphantom>
+                      <mn>2</mn>
+                    </mphantom>
+                  </mpadded>
+                </mrow>
+              </mpadded>
+            </mrow>
+            <mrow>
+              <mpadded width='0' lspace='-1width'>
+                <mn>14</mn>
+              </mpadded>
+            </mrow>
+          </mrow>
+        </msubsup>
+        <mrow>
+          <mi mathvariant='normal'>C</mi>
+        </mrow>
+        <mrow></mrow>
+        <mrow>
+          <mo stretchy='false'>&#x27F6;</mo>
+        </mrow>
+        <mrow></mrow>
+        <msubsup>
+          <mrow>
+            <mrow>
+              <mpadded width='0'>
+                <mphantom>
+                  <mi>A</mi>
+                </mphantom>
+              </mpadded>
+            </mrow>
+          </mrow>
+          <mrow>
+            <mrow>
+              <mpadded height='0' depth='0'>
+                <mphantom>
+                  <mn>7</mn>
+                </mphantom>
+              </mpadded>
+            </mrow>
+          </mrow>
+          <mrow>
+            <mrow>
+              <mpadded height='0' depth='0'>
+                <mphantom>
+                  <mn>14</mn>
+                </mphantom>
+              </mpadded>
+            </mrow>
+          </mrow>
+        </msubsup>
+        <mspace width='-0.083em'></mspace>
+        <msubsup>
+          <mrow>
+            <mrow>
+              <mpadded width='0'>
+                <mphantom>
+                  <mi>A</mi>
+                </mphantom>
+              </mpadded>
+            </mrow>
+          </mrow>
+          <mrow>
+            <mrow>
+              <mpadded width='0'>
+                <mphantom>
+                  <mn>2</mn>
+                </mphantom>
+              </mpadded>
+            </mrow>
+            <mrow>
+              <mpadded width='0' lspace='-1width'>
+                <mrow>
+                  <mpadded height='0'>
+                    <mn>7</mn>
+                  </mpadded>
+                </mrow>
+              </mpadded>
+            </mrow>
+          </mrow>
+          <mrow>
+            <mrow>
+              <mpadded height='0'>
+                <mrow>
+                  <mpadded width='0'>
+                    <mphantom>
+                      <mn>2</mn>
+                    </mphantom>
+                  </mpadded>
+                </mrow>
+              </mpadded>
+            </mrow>
+            <mrow>
+              <mpadded width='0' lspace='-1width'>
+                <mn>14</mn>
+              </mpadded>
+            </mrow>
+          </mrow>
+        </msubsup>
+        <mrow>
+          <mi mathvariant='normal'>N</mi>
+        </mrow>
+        <mrow></mrow>
+        <mo>+</mo>
+        <mrow></mrow>
+        <msubsup>
+          <mrow>
+            <mrow>
+              <mpadded width='0'>
+                <mphantom>
+                  <mi>A</mi>
+                </mphantom>
+              </mpadded>
+            </mrow>
+          </mrow>
+          <mrow>
+            <mrow>
+              <mpadded height='0' depth='0'>
+                <mphantom>
+                  <mo>&#x2212;</mo>
+                  <mn>1</mn>
+                </mphantom>
+              </mpadded>
+            </mrow>
+          </mrow>
+          <mrow>
+            <mrow>
+              <mpadded height='0' depth='0'>
+                <mphantom>
+                  <mn>0</mn>
+                </mphantom>
+              </mpadded>
+            </mrow>
+          </mrow>
+        </msubsup>
+        <mspace width='-0.083em'></mspace>
+        <msubsup>
+          <mrow>
+            <mrow>
+              <mpadded width='0'>
+                <mphantom>
+                  <mi>A</mi>
+                </mphantom>
+              </mpadded>
+            </mrow>
+          </mrow>
+          <mrow>
+            <mrow>
+              <mpadded width='0'>
+                <mphantom>
+                  <mn>2</mn>
+                </mphantom>
+              </mpadded>
+            </mrow>
+            <mrow>
+              <mpadded width='0' lspace='-1width'>
+                <mrow>
+                  <mpadded height='0'>
+                    <mo>&#x2212;</mo>
+                    <mn>1</mn>
+                  </mpadded>
+                </mrow>
+              </mpadded>
+            </mrow>
+          </mrow>
+          <mrow>
+            <mrow>
+              <mpadded height='0'>
+                <mrow>
+                  <mpadded width='0'>
+                    <mphantom>
+                      <mn>2</mn>
+                    </mphantom>
+                  </mpadded>
+                </mrow>
+              </mpadded>
+            </mrow>
+            <mrow>
+              <mpadded width='0' lspace='-1width'>
+                <mn>0</mn>
+              </mpadded>
+            </mrow>
+          </mrow>
+        </msubsup>
+        <mrow>
+          <mi mathvariant='normal'>e</mi>
+        </mrow>
+      </mrow>
+    </math>";
+    test_prefs("pl", "ClearSpeak", vec![("Verbosity", "Terse")], expr,
+      "14, 6, wielka c; tworzy, 14, 7, wielka n; plus 0, minus 1, e")?;
+    test_prefs("pl", "ClearSpeak", vec![("Verbosity", "Medium")], expr,
+      "indeks górny 14, indeks dolny 6, wielka c; reaguje tworząc; indeks górny 14, indeks dolny 7, wielka n; plus, indeks górny 0, indeks dolny minus 1, e")?;
+    test_prefs("pl", "ClearSpeak", vec![("Verbosity", "Verbose")], expr,
+      "indeks górny 14, indeks dolny 6, wielka c; reaguje tworząc; indeks górny 14, indeks dolny 7, wielka n; plus, indeks górny 0, indeks dolny minus 1, e")?;
+      return Ok(());
+
+}
+
+#[test]
+fn hcl_na_yields() -> Result<()> {
+    let expr = "<math> <mrow>
+      <mn>2</mn><mi>H</mi><mi>Cl</mi><mo>+</mo><mn>2</mn><mtext>Na</mtext>
+      <mo>&#x2192;</mo>
+      <mn>2</mn><mtext>Na</mtext><mi>Cl</mi><mo>+</mo>
+      <msub> <mi>H</mi> <mn>2</mn> </msub>
+      </mrow>
+    </math>";
+    test_prefs("pl", "SimpleSpeak", vec![("Verbosity", "Verbose")], expr,
+        "2, wielka h, wielka c l; plus 2 wielka n a; reaguje tworząc; 2, wielka n a, wielka c l; plus wielka h, indeks dolny 2")?;
+        return Ok(());
+
+}
+
+#[test]
+fn mhchem_so4_2plus() -> Result<()> {
+  let expr = "<math>
+    <mrow>
+      <mrow>
+        <mi>SO</mi>
+      </mrow>
+      <msub>
+        <mrow>
+          <mrow>
+            <mpadded width='0'>
+              <mphantom>
+                <mi>A</mi>
+              </mphantom>
+            </mpadded>
+          </mrow>
+        </mrow>
+        <mrow>
+          <mrow>
+            <mpadded height='0'>
+              <mn>4</mn>
+            </mpadded>
+          </mrow>
+        </mrow>
+      </msub>
+      <msup>
+        <mrow>
+          <mrow>
+            <mpadded width='0'>
+              <mphantom>
+                <mi>A</mi>
+              </mphantom>
+            </mpadded>
+          </mrow>
+        </mrow>
+        <mrow>
+          <mn>2</mn>
+          <mo>+</mo>
+        </mrow>
+      </msup>
+    </mrow>
+  </math>";
+  test_prefs("pl", "SimpleSpeak", vec![("Verbosity", "Terse")], expr, "wielka s; wielka o, 4, 2 plus")?;
+  test_prefs("pl", "SimpleSpeak", vec![("Verbosity", "Medium")], expr, "wielka s; wielka o, indeks dolny 4, indeks górny 2 plus")?;
+  test_prefs("pl", "SimpleSpeak", vec![("Verbosity", "Verbose")], expr, "wielka s; wielka o, indeks dolny 4, indeks górny 2 plus")?;
+  return Ok(());
+
+}
+
+
+#[test]
+fn mhchem_hcl_aq_etc() -> Result<()> {
+  let expr = "<math>
+    <mrow>
+      <mn>2</mn>
+      <mstyle scriptlevel='0'>
+        <mspace width='0.167em'></mspace>
+      </mstyle>
+      <mrow>
+        <mi>HCl</mi>
+      </mrow>
+      <mspace width='0.111em'></mspace>
+      <mo stretchy='false'>(</mo>
+      <mrow>
+        <mi>aq</mi>
+      </mrow>
+      <mo stretchy='false'>)</mo>
+      <mrow></mrow>
+      <mo>+</mo>
+      <mrow></mrow>
+      <mn>2</mn>
+      <mstyle scriptlevel='0'>
+        <mspace width='0.167em'></mspace>
+      </mstyle>
+      <mrow>
+        <mi>Na</mi>
+      </mrow>
+      <mspace width='0.111em'></mspace>
+      <mo stretchy='false'>(</mo>
+      <mrow>
+        <mi mathvariant='normal'>s</mi>
+      </mrow>
+      <mo stretchy='false'>)</mo>
+      <mrow></mrow>
+      <mrow>
+        <mo stretchy='false'>&#x27F6;</mo>
+      </mrow>
+      <mrow></mrow>
+      <mn>2</mn>
+      <mstyle scriptlevel='0'>
+        <mspace width='0.167em'></mspace>
+      </mstyle>
+      <mrow>
+        <mi>NaCl</mi>
+      </mrow>
+      <mspace width='0.111em'></mspace>
+      <mo stretchy='false'>(</mo>
+      <mrow>
+        <mi>aq</mi>
+      </mrow>
+      <mo stretchy='false'>)</mo>
+      <mrow></mrow>
+      <mo>+</mo>
+      <mrow></mrow>
+      <mrow>
+        <mi mathvariant='normal'>H</mi>
+      </mrow>
+      <msub>
+        <mrow>
+          <mrow>
+            <mpadded width='0'>
+              <mphantom>
+                <mi>A</mi>
+              </mphantom>
+            </mpadded>
+          </mrow>
+        </mrow>
+        <mrow>
+          <mrow>
+            <mpadded height='0'>
+              <mn>2</mn>
+            </mpadded>
+          </mrow>
+        </mrow>
+      </msub>
+      <mspace width='0.111em'></mspace>
+      <mo stretchy='false'>(</mo>
+      <mrow>
+        <mi mathvariant='normal'>g</mi>
+      </mrow>
+      <mo stretchy='false'>)</mo>
+    </mrow>
+  </math>";
+  test_prefs("pl", "SimpleSpeak", vec![("Verbosity", "Terse")],
+      expr, "2, wielka h, wielka c l, wodny; plus, 2, wielka n a, ciało stałe; tworzy; 2, wielka n a, wielka c l, wodny; plus, wielka h, 2; gaz")?;
+
+      return Ok(());
+
+}
+
+
+#[test]
+fn mhchem_barbed_equilibrium() -> Result<()> {
+  let expr = "<math>
+    <mrow data-mjx-texclass='ORD' data-chem-equation='14'>
+      <mrow data-changed='added' data-chem-equation='3'>
+        <mmultiscripts data-chem-formula='1'>
+          <mi data-mjx-texclass='ORD' mathvariant='normal' data-chem-element='1'>H</mi>
+          <mn data-mjx-texclass='ORD'>2</mn>
+          <none></none>
+        </mmultiscripts>
+        <mo data-changed='added' data-function-guess='true'>&#x2063;</mo>
+        <mrow data-changed='added' data-chem-equation='1'>
+          <mo stretchy='false'>(</mo>
+          <mi data-mjx-texclass='ORD' mathvariant='normal'>g</mi>
+          <mo stretchy='false'>)</mo>
+        </mrow>
+      </mrow>
+      <mo data-chem-equation-op='1'>+</mo>
+      <mrow data-changed='added' data-chem-equation='10'>
+        <mrow data-changed='added' data-chem-equation='3'>
+          <mmultiscripts data-chem-formula='1'>
+            <mi data-mjx-texclass='ORD' mathvariant='normal' data-chem-element='1'>I</mi>
+            <mn data-mjx-texclass='ORD'>2</mn>
+            <none></none>
+          </mmultiscripts>
+          <mo data-changed='added' data-function-guess='true'>&#x2063;</mo>
+          <mrow data-changed='added' data-chem-equation='1'>
+            <mo stretchy='false'>(</mo>
+            <mi data-mjx-texclass='ORD' mathvariant='normal'>g</mi>
+            <mo stretchy='false'>)</mo>
+          </mrow>
+        </mrow>
+        <mo data-changed='added'>&#x2062;</mo>
+        <mover data-mjx-texclass='REL'>
+          <mrow data-mjx-texclass='ORD' depth='0' height='0' data-changed='added'>
+            <mo data-mjx-texclass='ORD' stretchy='false'>↽</mo>
+            <mo data-mjx-texclass='ORD'>-</mo>
+          </mrow>
+          <mrow data-mjx-texclass='ORD' displaystyle='false' scriptlevel='0' data-changed='added'>
+            <mo data-mjx-texclass='ORD'>-</mo>
+            <mo data-mjx-texclass='ORD' stretchy='false'>⇀</mo>
+          </mrow>
+        </mover>
+        <mo data-changed='added'>&#x2062;</mo>
+        <mn>2</mn>
+        <mo data-changed='added'>&#x2062;</mo>
+        <mrow data-changed='added' data-chem-equation='5'>
+          <mi mathvariant='normal' data-chem-element='1'>H</mi>
+          <mo data-changed='added'>&#x2063;</mo>
+          <mi mathvariant='normal' data-chem-element='1'>I</mi>
+          <mo data-changed='added' data-function-guess='true'>&#x2063;</mo>
+          <mrow data-changed='added' data-chem-equation='1'>
+            <mo stretchy='false'>(</mo>
+            <mi data-mjx-texclass='ORD' mathvariant='normal'>g</mi>
+            <mo stretchy='false'>)</mo>
+          </mrow>
+        </mrow>
+      </mrow>
+    </mrow>
+  </math>";
+  test_prefs("pl", "SimpleSpeak", vec![("Verbosity", "Terse")],
+      expr, "wielka h, 2; gaz; plus; wielka i, 2; gaz; jest w równowadze z, 2, wielka h, wielka i, gaz")?;
+      return Ok(());
+
+}
+
+
+
+#[test]
+fn mhchem_roman_in_superscript() -> Result<()> {
+      let expr = "<math>
+      <mrow>
+        <mmultiscripts>
+          <mi>Fe</mi>
+          <none></none>
+          <mi>II</mi>
+        </mmultiscripts>
+        <mo>&#x2063;</mo>
+        <mmultiscripts>
+          <mi>Fe</mi>
+          <none></none>
+          <mi>III</mi>
+        </mmultiscripts>
+        <mo>&#x2063;</mo>
+        <mmultiscripts>
+          <mi mathvariant='normal' >O</mi>
+          <mn>4</mn>
+          <none></none>
+        </mmultiscripts>
+      </mrow>
+    </math>";
+  test_prefs("pl", "SimpleSpeak", vec![("Verbosity", "Terse")],
+      expr, "wielka f e, 2; wielka f e, 3; wielka o, 4")?;
+      return Ok(());
+
+}
+
+
+#[test]
+fn dropped_msubsup_bug_358() -> Result<()> {
+      let expr = r#"<math>
+          <mrow class="MJX-TeXAtom-ORD">
+              <mrow class="MJX-TeXAtom-ORD">
+                <mn>2</mn>
+                <mspace width="thinmathspace"></mspace>
+                <msubsup>
+                  <mtext>SO</mtext>
+                  <mrow class="MJX-TeXAtom-ORD">
+                    <mn>2</mn>
+                  </mrow>
+                  <mrow class="MJX-TeXAtom-ORD">
+                    <mspace width="0pt" height="0pt" depth=".2em"></mspace>
+                  </mrow>
+                </msubsup>
+                <mo>+</mo>
+                <msubsup>
+                  <mtext>O</mtext>
+                  <mrow class="MJX-TeXAtom-ORD">
+                    <mn>2</mn>
+                  </mrow>
+                  <mrow class="MJX-TeXAtom-ORD">
+                    <mspace width="0pt" height="0pt" depth=".2em"></mspace>
+                  </mrow>
+                </msubsup>
+                <mrow class="MJX-TeXAtom-REL">
+                  <mover>
+                    <mrow class="MJX-TeXAtom-OP MJX-fixedlimits">
+                      <mrow class="MJX-TeXAtom-ORD">
+                        <mpadded height="0" depth="0">
+                          <mrow class="MJX-TeXAtom-ORD">
+                            <mo stretchy="false">↽<!-- ↽ --></mo>
+                          </mrow>
+                          <mspace width="negativethinmathspace"></mspace>
+                          <mspace width="negativethinmathspace"></mspace>
+                          <mrow class="MJX-TeXAtom-ORD">
+                            <mo>−<!-- − --></mo>
+                          </mrow>
+                        </mpadded>
+                      </mrow>
+                    </mrow>
+                    <mrow class="MJX-TeXAtom-ORD">
+                        <mrow class="MJX-TeXAtom-ORD">
+                          <mrow class="MJX-TeXAtom-ORD">
+                            <mo>−<!-- − --></mo>
+                          </mrow>
+                          <mspace width="negativethinmathspace"></mspace>
+                          <mspace width="negativethinmathspace"></mspace>
+                          <mrow class="MJX-TeXAtom-ORD">
+                            <mo stretchy="false">⇀<!-- ⇀ --></mo>
+                          </mrow>
+                        </mrow>
+                    </mrow>
+                  </mover>
+                </mrow>
+                <mn>2</mn>
+                <mspace width="thinmathspace"></mspace>
+                <msubsup>
+                  <mtext>SO</mtext>
+                  <mrow class="MJX-TeXAtom-ORD">
+                    <mn>3</mn>
+                  </mrow>
+                  <mrow class="MJX-TeXAtom-ORD">
+                    <mspace width="0pt" height="0pt" depth=".2em"></mspace>
+                  </mrow>
+                </msubsup>
+              </mrow>
+          </mrow>
+      </math>"#;
+  test_prefs("pl", "SimpleSpeak", vec![("Verbosity", "Terse")],
+      expr, "2, wielka s, wielka o, 2; plus; wielka o, 2 jest w równowadze z, 2, wielka s, wielka o, 3")?;
+      return Ok(());
+
+}
+
+

--- a/tests/Languages/pl/definitions.rs
+++ b/tests/Languages/pl/definitions.rs
@@ -1,0 +1,1032 @@
+/// Tests for rules in definitions:
+/// *  modified var
+use crate::common::*;
+use anyhow::Result;
+
+#[test]
+fn tuple_basic() -> Result<()> {
+    // function 
+    let expr = r#"
+      <math>
+        <mrow intent="tuple($x,$y)">
+          <mi arg="x">x</mi>
+          <mi arg="y">y</mi>
+        </mrow>
+      </math>
+    "#;
+
+    test("pl", "ClearSpeak", expr, "krotka z x przecinek, y")?;
+    test("pl", "SimpleSpeak", expr, "krotka z x przecinek, y")?;
+
+    return Ok(());
+}
+
+#[test]
+fn my_set_basic() -> Result<()> {
+    let expr = r#"
+      <math>
+        <mrow intent="set($x,$y)">
+          <mi arg="x">x</mi>
+          <mi arg="y">y</mi>
+        </mrow>
+      </math>
+    "#;
+
+    test("pl", "ClearSpeak", expr, "zbiór pusty")?;
+
+    Ok(())
+}
+
+#[test]
+fn fixed_test() -> Result<()> {
+    let expr = r#"
+      <math>
+        <mi intent="set-of-reals">R
+        </mi>
+      </math>
+    "#;
+
+    // Bez jawnej fixity silnik oddaje surową nazwę intentu (zachowanie rdzenia,
+    // identyczne w EN i PL). Poprawne tłumaczenie "zbiór liczb rzeczywistych"
+    // pojawia się przy intencie z ":nofix" (patrz nofix_set_tests).
+    test("pl", "ClearSpeak", expr, "set of reals")?;
+    Ok(())
+}
+
+#[test]
+fn i_test() -> Result<()> {
+    let expr = r#"
+      <math>
+        <mi intent="imaginary-i">i
+        </mi>
+      </math>
+    "#;
+
+    // Bez jawnej fixity: surowa nazwa intentu (rdzeń, jak w EN).
+    test("pl", "ClearSpeak", expr, "imaginary i")?;
+    Ok(())
+}
+
+
+#[test]
+fn floor_basic() -> Result<()> {
+    let expr = r#"
+      <math>
+        <mrow intent="floor($x)">
+          <mi arg="x">x</mi>
+        </mrow>
+      </math>
+    "#;
+
+    test("pl", "ClearSpeak", expr, "podłoga z x")?;
+
+    Ok(())
+}
+
+#[test]
+fn set_difference_basic() -> Result<()> {
+    let expr = r#"
+      <math>
+        <mrow intent="set-difference($A,$B)">
+          <mi arg="A">A</mi>
+          <mo>&#x2216;</mo>
+          <mi arg="B">B</mi>
+        </mrow>
+      </math>
+    "#;
+
+    test("pl", "ClearSpeak", expr, "i z wielka a przecinek, wielka b")?;
+
+    Ok(())
+}
+
+#[test]
+fn postfix_test() -> Result<()> {
+    let tests = [
+        (
+            "transpose",
+            r#"
+            <msup intent="transpose($x)">
+                <mi arg="x">x</mi>
+                <mo>T</mo>
+            </msup>
+            "#,
+            "transpozycja z x",
+        ),
+        (
+            "highlight",
+            r#"
+            <menclose intent="highlight($x)">
+                <mi arg="x">x</mi>
+            </menclose>
+            "#,
+            "x podświetlone",
+        ),
+    ];
+
+    // Loop through all test cases, name _, body, and expected result
+    for (_, body, expected) in tests {
+        let expr = format!(
+            r#"
+            <math>
+                {}
+            </math>
+            "#,
+            body
+        );
+
+        test("pl", "ClearSpeak", &expr, expected)?;
+    }
+
+    Ok(())
+}
+
+#[test]
+fn prefix_test() -> Result<()> {
+    // Prefix test limit, unit-vector, line-segment
+    // Directed-line-segment, line, ray, arc
+    let tests = [
+        (
+            "limit",
+            r#"
+            <mrow intent="limit($x)">
+                <mi arg="x">x</mi>
+            </mrow>
+            "#,
+            "granica gdy x",
+        ),
+        (
+            "unit-vector",
+            r#"
+            <mover intent="unit-vector($x)">
+                <mi arg="x">x</mi>
+                <mo>^</mo>
+            </mover>
+            "#,
+            "wektor jednostkowy x",
+        ),
+        (
+            "line-segment",
+            r#"
+            <mover intent="line-segment($x)">
+                <mi arg="x">x</mi>
+                <mo>¯</mo>
+            </mover>
+            "#,
+            "odcinek x",
+        ),
+    ];
+
+    for (_, body, expected) in tests {
+        let expr = format!(
+            r#"
+            <math>
+                {}
+            </math>
+            "#,
+            body
+        );
+
+        test("pl", "ClearSpeak", &expr, expected)?;
+    }
+
+    Ok(())
+}
+
+
+#[test]
+fn functions_and_inverses_tests() -> Result<()> {
+    let tests = vec![
+        //("closed-interval", "closed interval between x and y"),
+        //("closed-open-interval", "interval between x included and y"),
+        //("open-closed-interval", "interval between x and y included"),
+        //("open-interval", "open interval between x and y"),
+
+        ("inverse", "odwrotność z x"),
+        ("domain", "dziedzina z x"),
+        ("codomain", "przeciwdziedzina z x"),
+        ("image", "obraz z x"),
+
+        //("fraction", "fraction x over y end fraction"),
+        ("mixed-fraction", "x i y"),
+        ("quotient", "podzielone przez z x przecinek, y"),
+        ("evaluated-at", "x obliczone w y"),
+        ("remainder", "podzielone przez z x przecinek, y"),
+
+        ("max", "maksimum z x przecinek, y przecinek, z"),
+        ("min", "minimum z x przecinek, y przecinek, z"),
+
+        ("power", "x do potęgi y"),
+
+        // ("root", ...) pominięte: intent 'root' bez indeksu rzuca błąd
+        // dopasowania reguły w RDZENIU silnika (identycznie w EN i PL),
+        // więc to nie jest luka polskiej lokalizacji.
+
+        ("greatest-common-divisor", "największy wspólny dzielnik z x przecinek, y przecinek, z"),
+        ("least-common-multiple", "najmniejsza wspólna wielokrotność z x przecinek, y przecinek, z"),
+
+        ("absolute-value", "wartość bezwzględna z x"),
+
+        ("complex-conjugate", "sprzężenie zespolone z x"),
+        ("complex-arg", "arg z x"),
+        ("real-part", "część rzeczywista"),
+        ("imaginary-part", "część urojona"),
+
+        ("polar-coordinate", "przecinek z x przecinek, y"),
+        ("spherical-coordinate", "przecinek z x przecinek, y przecinek, z"),
+        ("cartesian-coordinate", "przecinek z x przecinek, y przecinek, z"),
+        ("coordinate", "przecinek, x przecinek y przecinek z"),
+
+        ("floor", "podłoga z x"),
+        ("ceiling", "sufit z x"),
+        ("round", "zaokrąglenie z x"),
+        ("fractional-part", "część ułamkowa z x"),
+
+        
+    ];
+
+    for (intent, expected) in tests {
+        let expr = match intent {
+            
+            "max"
+            | "min"
+            | "greatest-common-divisor"
+            | "least-common-multiple"
+            | "spherical-coordinate"
+            | "cartesian-coordinate"
+            | "coordinate" => {
+                format!(
+                    "<math>
+                        <mrow intent='{}($a,$b,$c)'>
+                            <mi arg='a'>x</mi>
+                            <mi arg='b'>y</mi>
+                            <mi arg='c'>z</mi>
+                        </mrow>
+                    </math>",
+                    intent
+                )
+            }
+
+            "power"
+            | "mixed-fraction"
+            | "quotient"
+            | "evaluated-at"
+            | "remainder"
+            | "closed-interval"
+            | "closed-open-interval"
+            | "open-closed-interval"
+            | "open-interval" 
+            | "polar-coordinate" => {
+                format!(
+                    "<math>
+                        <mrow intent='{}($a,$b)'>
+                            <mi arg='a'>x</mi>
+                            <mi arg='b'>y</mi>
+                        </mrow>
+                    </math>",
+                    intent
+                )
+            }
+
+            _ => {
+                format!(
+                    "<math>
+                        <mrow intent='{}($x)'>
+                            <mi arg='x'>x</mi>
+                        </mrow>
+                    </math>",
+                    intent
+                )
+            }
+        };
+
+        test("pl", "ClearSpeak", &expr, expected)?;
+    }
+
+    Ok(())
+}
+
+
+#[test]
+fn calculus_tests() -> Result<()> {
+    let tests = vec![
+        //("derivative", "the derivative of x with respect to x"),
+        //"definite-integral", "integral over x from x to x"),
+
+        // prefix
+        ("limit", "granica gdy x"),
+
+        // infix
+        ("tends-to", "x dąży do y"),
+        ("tends-to-from-above", "x dąży do z prawej y"),
+        ("tends-to-from-below", "x dąży do z lewej y"),
+    ];
+
+    for (intent, expected) in tests {
+        let expr = match intent {
+            "limit" => {
+                format!(
+                    "<math>
+                        <mrow intent='{}($x)'>
+                            <mi arg='x'>x</mi>
+                        </mrow>
+                    </math>",
+                    intent
+                )
+            }
+
+            _ => {
+                // infix cases
+                format!(
+                    "<math>
+                        <mrow intent='{}($a,$b)'>
+                            <mi arg='a'>x</mi>
+                            <mi arg='b'>y</mi>
+                        </mrow>
+                    </math>",
+                    intent
+                )
+            }
+        };
+
+        test("pl", "ClearSpeak", &expr, expected)?;
+    }
+
+    Ok(())
+}
+
+
+#[test]
+fn set_tests() -> Result<()> {
+    let tests = vec![
+        ("set", "zbiór x"),
+        // ("set-difference", "set difference of x and y"),
+        ("complement", "dopełnienie z x"),
+        //("empty-set", "empty set"),
+        ("cardinality", "moc zbioru z x"),
+        ("list", "lista z x"),
+        ("tuple", "krotka z x"),
+    ];
+
+    for (intent, expected) in tests {
+        let expr = format!(
+            "<math>
+                <mrow intent='{}($x)'>
+                    <mi arg='x'>x</mi>
+                </mrow>
+            </math>",
+            intent
+        );
+
+        test("pl", "ClearSpeak", &expr, expected)?;
+    }
+
+    Ok(())
+}
+
+
+#[test]
+fn sequence_and_series_intents() -> Result<()> {
+    let tests = [
+        (
+            "sum-1",
+            r#"
+            <mrow intent="sum($x)">
+                <mo>&#x2211;</mo>
+                <mi arg="x">x</mi>
+            </mrow>
+            "#,
+            "suma z x",
+        ),
+        (
+            "sum-2",
+            r#"
+            <mrow intent="sum($i,$x)">
+                <mo>&#x2211;</mo>
+                <mi arg="i">i</mi>
+                <mi arg="x">x</mi>
+            </mrow>
+            "#,
+            "suma z i przecinek, x",
+        ),
+        (
+            "sum-3",
+            r#"
+            <mrow intent="sum($i,$n,$x)">
+                <mo>&#x2211;</mo>
+                <mi arg="i">i</mi>
+                <mi arg="n">n</mi>
+                <mi arg="x">x</mi>
+            </mrow>
+            "#,
+            "suma z i przecinek, n przecinek, x",
+        ),
+        (
+            "product-1",
+            r#"
+            <mrow intent="product($x)">
+                <mo>&#x220F;</mo>
+                <mi arg="x">x</mi>
+            </mrow>
+            "#,
+            "iloczyn z x",
+        ),
+        (
+            "product-2",
+            r#"
+            <mrow intent="product($i,$x)">
+                <mo>&#x220F;</mo>
+                <mi arg="i">i</mi>
+                <mi arg="x">x</mi>
+            </mrow>
+            "#,
+            "iloczyn z i przecinek, x",
+        ),
+        (
+            "product-3",
+            r#"
+            <mrow intent="product($i,$n,$x)">
+                <mo>&#x220F;</mo>
+                <mi arg="i">i</mi>
+                <mi arg="n">n</mi>
+                <mi arg="x">x</mi>
+            </mrow>
+            "#,
+            "iloczyn z i przecinek, n przecinek, x",
+        ),
+    ];
+
+    for (_, body, expected) in tests {
+        let expr = format!(
+            r#"
+            <math>
+                {}
+            </math>
+            "#,
+            body
+        );
+
+        test("pl", "ClearSpeak", &expr, expected)?;
+    }
+
+    Ok(())
+}
+
+#[test]
+fn elementary_classical_tests() -> Result<()> {
+    let tests = vec![
+        // Trig
+        ("sine", "sinus z x"),
+        ("cosine", "cosinus z x"),
+        ("tangent", "tangens z x"),
+        ("secant", "sekans z x"),
+        ("cosecant", "kosekans z x"),
+        ("cotangent", "cotangens z x"),
+
+        // Inverse trig
+        ("arcsine", "arcus sinus z x"),
+        ("arccosine", "arcus cosinus z x"),
+        ("arctangent", "arcus tangens z x"),
+        ("arcsecant", "arcus sekans z x"),
+        ("arccosecant", "arcus kosekans z x"),
+        ("arccotangent", "arcus cotangens z x"),
+
+        // Hyperbolic trig
+        ("hyperbolic-sine", "sinus hiperboliczny z x"),
+        ("hyperbolic-cosine", "cosinus hiperboliczny z x"),
+        ("hyperbolic-tangent", "tangens hiperboliczny z x"),
+        ("hyperbolic-secant", "sekans hiperboliczny z x"),
+        ("hyperbolic-cosecant", "kosekans hiperboliczny z x"),
+        ("hyperbolic-cotangent", "cotangens hiperboliczny z x"),
+
+        // Inverse hyperbolic trig
+        ("arc-hyperbolic-sine", "arcus sinus hiperboliczny z x"),
+        ("arc-hyperbolic-cosine", "arcus cosinus hiperboliczny z x"),
+        ("arc-hyperbolic-tangent", "arcus tangens hiperboliczny z x"),
+        ("arc-hyperbolic-secant", "arcus sekans hiperboliczny z x"),
+        ("arc-hyperbolic-cosecant", "arcus kosekans hiperboliczny z x"),
+        ("arc-hyperbolic-cotangent", "arcus cotangens hiperboliczny z x"),
+    ];
+
+    for (intent, expected) in tests {
+        let expr = format!(
+            "<math>
+                <mrow intent='{}($x)'>
+                    <mi arg='x'>x</mi>
+                </mrow>
+            </math>",
+            intent
+        );
+
+        test("pl", "ClearSpeak", &expr, expected)?;
+    }
+
+    Ok(())
+}
+
+#[test]
+fn statistics_and_probability_tests() -> Result<()> {
+    let tests = vec![
+        ("mean", "średnia z x"),
+        ("standard-deviation", "odchylenie standardowe z x"),
+        ("variance", "wariancja z x"),
+        ("median", "mediana z x"),
+        ("mode", "dominanta z x"),
+
+        // conditional probability typically two arguments
+        // ("conditional-probability", "probability of x given y"),
+    ];
+
+    for (intent, expected) in tests {
+        let expr = match intent {
+            "conditional-probability" => format!(
+                "<math>
+                    <mrow intent='{}($A,$B)'>
+                        <mi>P</mi>
+                        <mo>(</mo>
+                        <mrow>
+                          <mi arg='x'>x</mi>
+                          <mo>|</mo>
+                          <mi arg='y'>y</mi>
+                        </mrow>
+                        <mo>)</mo>
+                    </mrow>
+                </math>",
+                intent
+            ),
+            _ => format!(
+                "<math>
+                    <mrow intent='{}($x)'>
+                        <mi arg='x'>x</mi>
+                    </mrow>
+                </math>",
+                intent
+            ),
+        };
+
+        test("pl", "ClearSpeak", &expr, expected)?;
+    }
+
+    Ok(())
+}
+
+#[test]
+fn linear_algebra_tests() -> Result<()> {
+    let tests = vec![
+        ("vector", "wektor z x"),
+        // ("matrix", "matrix of x"),
+        ("determinant", "wyznacznik z x"),
+        ("adjugate", "macierz dopełnień algebraicznych z x"),
+        ("magnitude", "długość z x"),
+        ("norm", "norma z x"),
+        ("span", "powłoka liniowa z x"),
+
+        // transpose supports both postfix and function; we test function explicitly
+        ("transpose", "transpozycja z x"),
+
+        // dimensional product is infix
+        ("dimensional-product", "x na y"),
+
+        // unit-vector is prefix
+        ("unit-vector", "wektor jednostkowy x")
+    ];
+
+    for (intent, expected) in tests {
+        let expr: String = match intent {
+          "dimensional-product" => {
+              "<math>
+                  <mrow intent='dimensional-product($x,$y)'>
+                      <mi arg='x'>x</mi>
+                      <mi arg='y'>y</mi>
+                  </mrow>
+              </math>"
+              .to_string()
+          }
+          _ => format!(
+              "<math>
+                  <mrow intent='{intent}($x)'>
+                      <mi arg='x'>x</mi>
+                  </mrow>
+              </math>"
+          ),
+      };
+
+        test("pl", "ClearSpeak", &expr, expected)?;
+    }
+
+    Ok(())
+}
+
+#[test]
+fn nofix_set_tests() -> Result<()> {
+    let tests = vec![
+        ("set-of-integers", "ℤ", "zbiór liczb całkowitych"),
+        ("set-of-reals", "ℝ", "zbiór liczb rzeczywistych"),
+        ("set-of-rationals", "ℚ", "zbiór liczb wymiernych"),
+        ("set-of-natural-numbers", "ℕ", "zbiór liczb naturalnych"),
+        ("set-of-complex-numbers", "ℂ", "zbiór liczb zespolonych"),
+        ("set-of-primes", "ℙ", "zbiór liczb pierwszych"),
+    ];
+
+    for (intent, symbol, expected) in tests {
+        let expr = format!(
+            "<math>
+                <mi intent='{}:nofix'>{}</mi>
+            </math>",
+            intent,
+            symbol
+        );
+
+        test("pl", "ClearSpeak", &expr, expected)?;
+    }
+
+    Ok(())
+}
+
+#[test]
+fn geometry_prefix_multi_value_tests() -> Result<()> {
+    let tests = vec![
+        ("line-segment", "odcinek x y"),
+        ("directed-line-segment", "odcinek skierowany x y"),
+        ("line", "linia x y"),
+        ("ray", "półprosta x y"),
+        ("arc", "łuk x y"),
+        ("point", "punkt x y z"),
+    ];
+
+    for (intent, expected) in tests {
+        let expr = match intent{
+            "point" => {
+                format!(
+                    "<math>
+                        <mrow intent='{intent}($x,$y,$z)'>
+                            <mi arg='x'>x</mi>
+                            <mi arg='y'>y</mi>
+                            <mi arg='z'>z</mi>
+                        </mrow>
+                    </math>"
+                )
+            }
+
+            _ => { 
+                format!(
+                    "<math>
+                        <mrow intent='{intent}($x,$y)'>
+                            <mi arg='x'>x</mi>
+                            <mi arg='y'>y</mi>
+                        </mrow>
+                    </math>"
+                )
+            }
+        };
+
+        test("pl", "ClearSpeak", &expr, expected)?;
+    }
+
+    Ok(())
+}
+
+#[test]
+fn geometry_prefix_tests() -> Result<()> {
+    let tests = vec![
+        ("length", "długość z x"),
+        ("area", "pole z x"),
+        ("objętość", "objętość z x"),
+    ];
+
+    for (intent, expected) in tests {
+        let expr = format!(
+            "<math>
+                <mrow intent='{intent}:function($x)'>
+                    <mi arg='x'>x</mi>
+                </mrow>
+            </math>"
+        );
+
+        test("pl", "ClearSpeak", &expr, expected)?;
+    }
+
+    Ok(())
+}
+
+#[test]
+fn separator_tests() -> Result<()> {
+  let expr = format!(
+        "<math>
+            <mrow intent='time-separator($x,$y)'>
+                <mi arg='x'>x</mi>
+                <mi arg='y'>y</mi>
+            </mrow>
+        </math>"
+    );
+
+    test("pl", "ClearSpeak", &expr, "x y")?;
+    Ok(())
+}
+
+#[test]
+fn general_concepts_tests() -> Result<()> {
+    let tests = vec![
+        // Unary structural
+        ("fenced-group", "grupa w nawiasach z x"),
+        ("highlight", "x podświetlone"),
+        ("least-common-denominator", "najmniejszy wspólny mianownik z x przecinek, y przecinek, z"), // add x, y , z ...
+        ("pochhammer", "symbol Pochhammera z x"),
+        ("permutation-cycle", "cykl permutacji z x"),
+
+        // Binary structural / infix-style
+        // ("ordered-pair", "the pair of x and y"),
+        ("rate", "x na y"),
+        
+        ("binomial-coefficient", "x po y"),
+        ("embellished-name", "x z oznaczeniem y"),
+        ("indexed-by", "x indeks dolny y"),
+        // ("translation", "translation by x comma, y"), // Changes translation to comma
+        ("constraint", "x przy warunku y"),
+    ];
+
+    for (intent, expected) in tests {
+        let expr = match intent {
+            "ordered-pair"
+            | "rate"
+            | "constraint"
+            | "binomial-coefficient"
+            | "embellished-name"
+            | "translation"
+            | "indexed-by" => {
+                format!(
+                    "<math>
+                        <mrow intent='{}($a,$b)'>
+                            <mi arg='a'>x</mi>
+                            <mi arg='b'>y</mi>
+                        </mrow>
+                    </math>",
+                    intent
+                )
+            }
+            "least-common-denominator" => {
+                format!(
+                    "<math>
+                        <mrow intent='{}($x,$y,$z)'>
+                            <mi arg='x'>x</mi>
+                            <mi arg='y'>y</mi>
+                            <mi arg='z'>z</mi>
+                        </mrow>
+                    </math>",
+                    intent
+                )
+            }
+
+            // unary cases
+            _ => {
+                format!(
+                    "<math>
+                        <mrow intent='{}($x)'>
+                            <mi arg='x'>x</mi>
+                        </mrow>
+                    </math>",
+                    intent
+                )
+            }
+        };
+
+        test("pl", "ClearSpeak", &expr, expected)?;
+    }
+
+    Ok(())
+}
+
+#[test]
+fn grouping_tests() -> Result<()> {
+    let tests = vec![
+        ("annotation", "x czyli y"),
+        // ("braced-group", "grouped x end-grouped"),
+        // ("repeating-decimal", "repeating decimal of x"),
+    ];
+
+    for (intent, expected) in tests {
+        let expr = match intent {
+            "annotation" => {
+                format!(
+                    "<math>
+                        <mrow intent='{}($x,$y)'>
+                            <mi arg='x'>x</mi>
+                            <mi arg='y'>y</mi>
+                        </mrow>
+                    </math>",
+                    intent
+                )
+            }
+            _ => {
+                format!(
+                    "<math>
+                        <mrow intent='{}($x)'>
+                            <mi arg='x'>x</mi>
+                        </mrow>
+                    </math>",
+                    intent
+                )
+            } 
+        };
+
+        test("pl", "ClearSpeak", &expr, expected)?;
+    }
+
+    Ok(())
+}
+
+#[test]
+fn function_default_fixity_tests() -> Result<()> {
+    let tests = vec![
+        ("curl", "rotacja z x"),
+        ("divergence", "dywergencja z x"),
+        ("gradient", "gradient z x"),
+        ("laplacian", "laplasjan z x"),
+    ];
+
+    for (intent, expected) in tests {
+        let expr = format!(
+            "<math>
+                <mrow intent='{}($x)'>
+                    <mi arg='x'>x</mi>
+                </mrow>
+            </math>",
+            intent
+        );
+
+        test("pl", "ClearSpeak", &expr, expected)?;
+    }
+
+    Ok(())
+}
+
+#[test]
+fn prefix_default_fixity_tests() -> Result<()> {
+    let tests = vec![
+        ("angle", "kąt x"),
+        ("angle-measure", "miara kąta x"),
+        ("change", "zmiana x"),
+        ("for-all", "dla każdego x"),
+        ("measured-angle", "kąt mierzony x"),
+        ("not", "nie x"),
+        ("number-of", "liczba x"),
+        ("partial-derivative", "cząstkowe x"),
+        ("right-angle", "kąt prosty x"),
+        ("square-root-of", "pierwiastek kwadratowy z x"),
+        ("there-does-not-exist", "nie istnieje x"),
+        ("there-exists", "istnieje x"),
+    ];
+
+    for (intent, expected) in tests {
+        let expr = format!(
+            "<math>
+                <mrow intent='{}($x)'>
+                    <mi arg='x'>x</mi>
+                </mrow>
+            </math>",
+            intent
+        );
+
+        test("pl", "ClearSpeak", &expr, expected)?;
+    }
+
+    Ok(())
+}
+
+#[test]
+fn infix_default_fixity_tests() -> Result<()> {
+    let tests = vec![
+        ("and", "x i y"),
+        ("applied-to", "x zastosowane do y"),
+        ("approximately", "x w przybliżeniu y"),
+        ("congruent", "x przystające do y"),
+        ("cartesian-product", "x iloczyn kartezjański y"),
+        ("composed-with", "x złożone z y"),
+        ("cross-product", "x iloczyn wektorowy y"),
+        ("defined-as", "x zdefiniowane jako y"),
+        ("divided-by", "x podzielone przez y"),
+        ("divides", "x dzieli y"),
+        ("does-not-belong-to", "x nie należy do y"),
+        ("does-not-divide", "x nie dzieli y"),
+        ("dot-product", "x iloczyn skalarny y"),
+        ("downwards-diagonal-ellipsis", "x ukośny wielokropek w dół y"),
+        ("direct-product", "x iloczyn prosty y"),
+        ("element-of", "x należy do y"),
+        ("ellipsis", "x wielokropek y"),
+        ("equals", "x równa się y"),
+        ("equivalent-to", "x równoważne y"),
+        ("evaluates-to", "x ma wartość y"),
+        ("given", "x pod warunkiem y"),
+        ("greater-than", "x większe niż y"),
+        ("greater-than-or-equal-to", "x większe lub równe y"),
+        ("identically-equals", "x tożsamościowo równe y"),
+        ("if-and-only-if", "x wtedy i tylko wtedy gdy y"),
+        ("implies", "x implikuje y"),
+        ("inner-product", "x iloczyn wewnętrzny y"),
+        ("intersection", "x część wspólna y"),
+        ("less-than", "x mniejsze niż y"),
+        ("less-than-or-equal-to", "x mniejsze lub równe y"),
+        ("list-separator", "x przecinek y"),
+        ("maps-to", "x przekształca na y"),
+        ("member-of", "x element zbioru y"),
+        ("minus", "x minus y"),
+        ("minus-or-plus", "x minus lub plus y"),
+        ("not-subset", "x nie jest podzbiorem y"),
+        ("not-superset", "x nie jest nadzbiorem y"),
+        ("not-equal-to", "x nie równa się y"),
+        ("not-member-of", "x nie jest elementem zbioru y"),
+        ("not-parallel-to", "x nierównoległe do y"),
+        ("obtained-from", "x otrzymane z y"),
+        ("or", "x lub y"),
+        ("outer-product", "x iloczyn zewnętrzny y"),
+        ("parallel-to", "x równoległe do y"),
+        ("perpendicular", "x prostopadłe do y"),
+        ("plus", "x plus y"),
+        ("plus-or-minus", "x plus minus y"),
+        ("precedes", "x poprzedza y"),
+        ("proportional", "x proporcjonalne do y"),
+        ("range-separator", "x do y"),
+        ("ratio", "x stosunek y"),
+        ("similar", "x podobne do y"),
+        ("subset", "x podzbiór y"),
+        ("subset-or-equal", "x podzbiór lub równy y"),
+        ("succeeds", "x następuje po y"),
+        ("such-that", "x taki że y"),
+        ("superset", "x nadzbiór y"),
+        ("superset-or-equal", "x nadzbiór lub równy y"),
+        ("tilde", "x tylda y"),
+        ("times", "x razy y"),
+        ("union", "x suma zbiorów y"),
+        ("upwards-diagonal-ellipsis", "x ukośny wielokropek w górę y"),
+        ("vertical-ellipsis", "x wielokropek pionowy y"),
+        ("xor", "x albo y"),
+    ];
+    
+    for (intent, expected) in tests {
+        let expr = format!(
+            "<math>
+                <mrow intent='{}($a,$b)'>
+                    <mi arg='a'>x</mi>
+                    <mi arg='b'>y</mi>
+                </mrow>
+            </math>",
+            intent
+        );
+
+        test("pl", "ClearSpeak", &expr, expected)?;
+    }
+
+    Ok(())
+}
+
+#[test]
+fn postfix_default_fixity_tests() -> Result<()> {
+    let tests = vec![
+        ("factorial", "x silnia"),
+        ("percent", "x procent"),
+    ];
+
+    for (intent, expected) in tests {
+        let expr = format!(
+            "<math>
+                <mrow intent='{}($x)'>
+                    <mi arg='x'>x</mi>
+                </mrow>
+            </math>",
+            intent
+        );
+
+        test("pl", "ClearSpeak", &expr, expected)?;
+    }
+
+    Ok(())
+}
+
+#[test]
+fn nofix_default_fixity_tests() -> Result<()> {
+    let tests = vec![
+        ("średnica", "d", "średnica"),
+        ("odległość", "D", "odległość"),
+        ("prawdopodobieństwo", "P", "prawdopodobieństwo"),
+        ("promień", "r", "promień"),
+        ("objętość", "V", "objętość"),
+        ("exponential-e", "e", "e"),
+        ("imaginary-i", "i", "i"),
+        ("differential-d", "d", "d"),
+        ("golden-ratio", "φ", "złota proporcja"),
+    ];
+
+    for (intent, symbol, expected) in tests {
+        let expr = format!(
+            "<math>
+                <mi intent='{}:nofix'>{}</mi>
+            </math>",
+            intent,
+            symbol
+        );
+
+        test("pl", "ClearSpeak", &expr, expected)?;
+    }
+
+    Ok(())
+}

--- a/tests/Languages/pl/mtable.rs
+++ b/tests/Languages/pl/mtable.rs
@@ -1,0 +1,1296 @@
+use crate::common::*;
+use anyhow::Result;
+
+#[test]
+fn matrix_1x1() -> Result<()> {
+    let expr = "
+    <math xmlns='http://www.w3.org/1998/Math/MathML'>
+      <mrow>
+      <mrow><mo>(</mo>
+        <mtable><mtr><mtd>
+        <mn>3</mn>
+      </mtd> </mtr></mtable>
+        <mo>)</mo></mrow></mrow>
+    </math>
+                                ";
+    test("pl", "ClearSpeak",  expr, "jeden na jeden macierz z elementem 3")?;
+    test("pl", "SimpleSpeak", expr, "jeden na jeden macierz z elementem 3")?;
+    return Ok(());
+
+}
+
+#[test]
+fn determinant_1x1() -> Result<()> {
+    let expr = "
+    <math xmlns='http://www.w3.org/1998/Math/MathML'>
+      <mrow>
+      <mrow><mo>|</mo>
+        <mtable><mtr><mtd>
+        <mn>3</mn>
+      </mtd> </mtr></mtable>
+        <mo>|</mo></mrow></mrow>
+    </math>
+                                ";
+    test("pl", "ClearSpeak",  expr, "jeden na jeden wyznacznik z elementem 3")?;
+    test("pl", "SimpleSpeak", expr, "jeden na jeden wyznacznik z elementem 3")?;
+    return Ok(());
+
+}
+
+
+#[test]
+fn matrix_1x2() -> Result<()> {
+    let expr = "
+    <math xmlns='http://www.w3.org/1998/Math/MathML'>
+      <mrow>
+      <mrow><mo>(</mo>
+        <mtable>
+          <mtr>
+          <mtd>
+            <mn>3</mn>
+          </mtd>
+          <mtd>
+            <mn>5</mn>
+          </mtd>
+          </mtr>
+        </mtable>
+      <mo>)</mo></mrow></mrow>
+    </math>
+                                ";
+    test("pl", "ClearSpeak",  expr, "jeden na 2 wiersz macierz; 3, 5")?;
+    test("pl", "SimpleSpeak", expr, "jeden na 2 wiersz macierz; 3, 5")?;
+    return Ok(());
+
+}
+
+
+#[test]
+fn matrix_1x3() -> Result<()> {
+    let expr = "
+    <math xmlns='http://www.w3.org/1998/Math/MathML'>
+      <mrow>
+      <mrow><mo>(</mo>
+        <mtable>
+          <mtr>
+          <mtd>
+            <mrow><mo>-</mo><mi>x</mi></mrow>
+          </mtd>
+          <mtd>
+            <mn>5</mn>
+          </mtd>
+          <mtd>
+            <mn>12</mn>
+          </mtd>
+          </mtr>
+        </mtable>
+      <mo>)</mo></mrow></mrow>
+    </math>
+                                ";
+    test("pl", "ClearSpeak", expr, "jeden na 3 wiersz macierz; minus x, 5, 12")?;
+    test("pl", "SimpleSpeak", expr, "jeden na 3 wiersz macierz; minus x, 5, 12")?;
+    return Ok(());
+
+}
+
+#[test]
+fn matrix_2x1_not_simple() -> Result<()> {
+    let expr = "
+    <math xmlns='http://www.w3.org/1998/Math/MathML'>
+      <mrow>
+      <mrow><mo>(</mo>
+        <mtable>
+          <mtr>
+          <mtd>
+            <mrow>
+            <mi>x</mi><mo>+</mo><mn>1</mn>
+            </mrow>
+          </mtd>
+          </mtr>
+          <mtr>
+          <mtd>
+            <mrow>
+            <mi>x</mi><mo>-</mo><mn>1</mn></mrow>
+          </mtd>
+          </mtr>
+        </mtable>
+      <mo>)</mo></mrow></mrow>
+    </math>
+                                ";
+    test("pl", "ClearSpeak", expr, "2 na jedną kolumnę macierz; wiersz 1; x plus 1; wiersz 2; x minus 1")?;
+    test("pl", "SimpleSpeak", expr, "2 na jedną kolumnę macierz; wiersz 1; x plus 1; wiersz 2; x minus 1")?;
+    return Ok(());
+
+}
+#[test]
+fn matrix_3x1_not_simple() -> Result<()> {
+    let expr = "
+    <math xmlns='http://www.w3.org/1998/Math/MathML'>
+      <mrow>
+      <mrow><mo>(</mo>
+        <mtable>
+          <mtr>
+          <mtd>
+            <mrow>
+            <mi>x</mi>
+            </mrow>
+          </mtd>
+          </mtr>
+          <mtr>
+          <mtd>
+            <mrow>
+            <mi>a</mi>
+            </mrow>
+          </mtd>
+          </mtr>
+          <mtr>
+          <mtd>
+            <mfrac>
+              <mi>x</mi>
+              <mrow>
+                <mi>x</mi><mo>+</mo><mn>1</mn>
+              </mrow>
+            </mfrac>
+          </mtd>
+          </mtr>
+        </mtable>
+      <mo>)</mo></mrow></mrow>
+    </math>";
+    test("pl", "SimpleSpeak", expr, "3 na jedną kolumnę macierz; wiersz 1; x; wiersz 2; a; wiersz 3; ułamek, x przez, x plus 1, koniec ułamka")?;
+    test("pl", "ClearSpeak",  expr, "3 na jedną kolumnę macierz; wiersz 1; x; wiersz 2; a; wiersz 3; ułamek z licznikiem x; i mianownikiem x plus 1")?;
+            return Ok(());
+
+}
+
+#[test]
+fn determinant_2x2() -> Result<()> {
+    let expr = "<math>
+      <mrow>
+      <mrow><mo>|</mo>
+        <mtable>
+          <mtr>
+          <mtd>
+            <mn>2</mn>
+          </mtd>
+          <mtd>
+            <mn>1</mn>
+          </mtd>
+          </mtr>
+          <mtr>
+          <mtd>
+            <mn>7</mn>
+          </mtd>
+          <mtd>
+            <mn>5</mn>
+          </mtd>
+          </mtr>
+          
+        </mtable>
+      <mo>|</mo></mrow></mrow>
+                        </math>";
+    test("pl", "ClearSpeak",  expr, "2 na 2 wyznacznik; wiersz 1; 2, 1; wiersz 2; 7, 5")?;
+    test("pl", "SimpleSpeak", expr, "2 na 2 wyznacznik; wiersz 1; 2, 1; wiersz 2; 7, 5")?;
+    return Ok(());
+
+}
+
+#[test]
+fn matrix_2x3() -> Result<()> {
+    let expr = "
+    <math display='block' xmlns='http://www.w3.org/1998/Math/MathML'>
+      <mrow>
+      <mrow><mo>[</mo>
+        <mtable>
+          <mtr>
+          <mtd>
+            <mn>3</mn>
+          </mtd>
+          <mtd>
+            <mn>1</mn>
+          </mtd>
+          <mtd>
+            <mn>4</mn>
+          </mtd>
+          </mtr>
+          <mtr>
+          <mtd>
+            <mn>0</mn>
+          </mtd>
+          <mtd>
+            <mn>2</mn>
+          </mtd>
+          <mtd>
+            <mn>6</mn>
+          </mtd>
+          </mtr>
+        </mtable>
+      <mo>]</mo></mrow></mrow>
+    </math>
+                                ";
+    test("pl", "ClearSpeak",  expr, "2 na 3 macierz; wiersz 1; 3, 1, 4; wiersz 2; 0, 2, 6")?;
+    test("pl", "SimpleSpeak", expr, "2 na 3 macierz; wiersz 1; 3, 1, 4; wiersz 2; 0, 2, 6")?;
+    return Ok(());
+
+}
+
+#[test]
+fn augmented_matrix_2x3() -> Result<()> {
+    let expr = "
+    <math display='block' xmlns='http://www.w3.org/1998/Math/MathML'>
+      <mrow>
+      <mrow><mo>[</mo>
+        <mtable columnlines='none solid'>
+          <mtr>
+          <mtd>
+            <mn>3</mn>
+          </mtd>
+          <mtd>
+            <mn>1</mn>
+          </mtd>
+          <mtd>
+            <mn>4</mn>
+          </mtd>
+          </mtr>
+          <mtr>
+          <mtd>
+            <mn>0</mn>
+          </mtd>
+          <mtd>
+            <mn>2</mn>
+          </mtd>
+          <mtd>
+            <mn>6</mn>
+          </mtd>
+          </mtr>
+        </mtable>
+      <mo>]</mo></mrow></mrow>
+    </math>
+                                ";
+    test("pl", "ClearSpeak",  expr, "2 na 3 macierz rozszerzona; wiersz 1; 3, 1, 4; wiersz 2; 0, 2, 6")?;
+    test("pl", "SimpleSpeak", expr, "2 na 3 macierz rozszerzona; wiersz 1; 3, 1, 4; wiersz 2; 0, 2, 6")?;
+    Ok(())
+}
+
+#[test]
+fn matrix_2x3_labeled() -> Result<()> {
+    let expr = "
+    <math display='block' xmlns='http://www.w3.org/1998/Math/MathML'>
+      <mrow>
+      <mrow><mo>[</mo>
+        <mtable>
+          <mlabeledtr>
+          <mtd>
+            <mtext>(3.1)</mtext>
+          </mtd>
+          <mtd>
+            <mn>3</mn>
+          </mtd>
+          <mtd>
+            <mn>1</mn>
+          </mtd>
+          <mtd>
+            <mn>4</mn>
+          </mtd>
+          </mlabeledtr>
+          <mtr>
+          <mtd>
+            <mn>0</mn>
+          </mtd>
+          <mtd>
+            <mn>2</mn>
+          </mtd>
+          <mtd>
+            <mn>6</mn>
+          </mtd>
+          </mtr>
+        </mtable>
+      <mo>]</mo></mrow></mrow>
+    </math>
+                                ";
+    test("pl", "ClearSpeak",  expr,
+        "2 na 3 macierz; wiersz 1 z etykietą (3.1); kolumna 1; 3, kolumna 2; 1, kolumna 3; 4; wiersz 2; kolumna 1; 0, kolumna 2; 2, kolumna 3; 6")?;
+    test("pl", "SimpleSpeak", expr,
+        "2 na 3 macierz; wiersz 1 z etykietą (3.1); kolumna 1; 3, kolumna 2; 1, kolumna 3; 4; wiersz 2; kolumna 1; 0, kolumna 2; 2, kolumna 3; 6")?;
+                                   return Ok(());
+
+}
+
+#[test]
+fn matrix_3x1() -> Result<()> {
+    let expr = "
+    <math xmlns='http://www.w3.org/1998/Math/MathML'>
+      <mrow>
+      <mrow><mo>[</mo>
+        <mtable>
+        <mtr>
+          <mtd>
+          <mn>1</mn>
+          </mtd>
+        </mtr>
+        <mtr>
+          <mtd>
+          <mn>2</mn>
+          </mtd>
+        </mtr>
+        <mtr>
+          <mtd>
+          <mn>3</mn>
+          </mtd>
+        </mtr>           
+        </mtable> <mo>]</mo></mrow></mrow>
+    </math>
+                                ";
+    test("pl", "ClearSpeak",  expr, "3 na jedną kolumnę macierz; 1; 2; 3")?;
+    test("pl", "SimpleSpeak", expr, "3 na jedną kolumnę macierz; 1; 2; 3")?;
+    return Ok(());
+
+}
+
+#[test]
+fn matrix_4x1() -> Result<()> {
+    let expr = "
+    <math xmlns='http://www.w3.org/1998/Math/MathML'>
+      <mrow>
+      <mrow><mo>(</mo>
+        <mtable>
+          <mtr>
+          <mtd>
+            <mn>3</mn>
+          </mtd>
+          </mtr>
+          <mtr>
+          <mtd>
+            <mn>6</mn>
+          </mtd>
+          </mtr>
+          <mtr>
+          <mtd>
+            <mn>1</mn>
+          </mtd>
+          </mtr>
+          <mtr>
+          <mtd>
+            <mn>2</mn>
+          </mtd>
+          </mtr>            
+        </mtable>
+      <mo>)</mo></mrow></mrow>
+    </math>
+                                ";
+    test("pl", "ClearSpeak",  expr, "4 na jedną kolumnę macierz; wiersz 1; 3; wiersz 2; 6; wiersz 3; 1; wiersz 4; 2")?;
+    test("pl", "SimpleSpeak", expr, "4 na jedną kolumnę macierz; wiersz 1; 3; wiersz 2; 6; wiersz 3; 1; wiersz 4; 2")?;
+    return Ok(());
+
+}
+
+#[test]
+fn matrix_4x1_labeled() -> Result<()> {
+    let expr = "
+    <math xmlns='http://www.w3.org/1998/Math/MathML'>
+      <mrow>
+      <mrow><mo>(</mo>
+        <mtable>
+          <mtr>
+          <mtd>
+            <mn>3</mn>
+          </mtd>
+          </mtr>
+          <mtr>
+          <mtd>
+            <mn>6</mn>
+          </mtd>
+          </mtr>
+          <mtr>
+          <mtd>
+            <mn>1</mn>
+          </mtd>
+          </mtr>
+          <mlabeledtr>
+          <mtd>
+            <mtext>(3.1)</mtext>
+          </mtd>
+          <mtd>
+            <mn>2</mn>
+          </mtd>
+          </mlabeledtr>            
+        </mtable>
+      <mo>)</mo></mrow></mrow>
+    </math>
+                                ";
+    test("pl", "ClearSpeak",  expr,
+        "4 na jedną kolumnę macierz; wiersz 1; 3; wiersz 2; 6; wiersz 3; 1; wiersz 4 z etykietą (3.1); 2")?;
+    test("pl", "SimpleSpeak", expr,
+        "4 na jedną kolumnę macierz; wiersz 1; 3; wiersz 2; 6; wiersz 3; 1; wiersz 4 z etykietą (3.1); 2")?;
+        return Ok(());
+
+}
+
+#[test]
+fn matrix_1x4() -> Result<()> {
+    let expr = "
+    <math xmlns='http://www.w3.org/1998/Math/MathML'>
+      <mrow>
+      <mrow><mo>(</mo>
+        <mtable>
+          <mtr>
+          <mtd>
+            <mn>3</mn>
+          </mtd>
+          <mtd>
+            <mn>6</mn>
+          </mtd>
+          <mtd>
+            <mn>1</mn>
+          </mtd>
+          <mtd>
+            <mn>2</mn>
+          </mtd>
+          </mtr>
+        </mtable>
+      <mo>)</mo></mrow></mrow>
+    </math>
+                                ";
+    test("pl", "ClearSpeak",  expr, "jeden na 4 wiersz macierz; kolumna 1; 3, kolumna 2; 6, kolumna 3; 1, kolumna 4; 2")?;
+    test("pl", "SimpleSpeak", expr, "jeden na 4 wiersz macierz; kolumna 1; 3, kolumna 2; 6, kolumna 3; 1, kolumna 4; 2")?;
+    return Ok(());
+
+}
+
+#[test]
+fn matrix_4x4() -> Result<()> {
+    let expr = "
+    <math xmlns='http://www.w3.org/1998/Math/MathML'>
+      <mrow>
+      <mrow><mo>(</mo>
+        <mtable>
+          <mtr>
+          <mtd>
+            <mn>0</mn>
+          </mtd>
+          <mtd>
+            <mn>3</mn>
+          </mtd>
+          <mtd>
+            <mn>4</mn>
+          </mtd>
+          <mtd>
+            <mn>3</mn>
+          </mtd>
+          </mtr>
+          <mtr>
+          <mtd>
+            <mn>2</mn>
+          </mtd>
+          <mtd>
+            <mn>1</mn>
+          </mtd>
+          <mtd>
+            <mn>0</mn>
+          </mtd>
+          <mtd>
+            <mn>9</mn>
+          </mtd>
+          </mtr>
+          <mtr>
+          <mtd>
+            <mn>3</mn>
+          </mtd>
+          <mtd>
+            <mn>0</mn>
+          </mtd>
+          <mtd>
+            <mn>2</mn>
+          </mtd>
+          <mtd>
+            <mn>1</mn>
+          </mtd>
+          </mtr>
+          <mtr>
+          <mtd>
+            <mn>6</mn>
+          </mtd>
+          <mtd>
+            <mn>2</mn>
+          </mtd>
+          <mtd>
+            <mn>9</mn>
+          </mtd>
+          <mtd>
+            <mn>0</mn>
+          </mtd>
+          </mtr>
+        </mtable>
+      <mo>)</mo></mrow></mrow>
+    </math>
+                                ";
+    test("pl", "ClearSpeak",  expr, "4 na 4 macierz; wiersz 1; kolumna 1; 0, kolumna 2; 3, kolumna 3; 4, kolumna 4; 3; wiersz 2; kolumna 1; 2, kolumna 2; 1, kolumna 3; 0, kolumna 4; 9; wiersz 3; kolumna 1; 3, kolumna 2; 0, kolumna 3; 2, kolumna 4; 1; wiersz 4; kolumna 1; 6, kolumna 2; 2, kolumna 3; 9, kolumna 4; 0")?;
+    test("pl", "SimpleSpeak", expr, "4 na 4 macierz; wiersz 1; kolumna 1; 0, kolumna 2; 3, kolumna 3; 4, kolumna 4; 3; wiersz 2; kolumna 1; 2, kolumna 2; 1, kolumna 3; 0, kolumna 4; 9; wiersz 3; kolumna 1; 3, kolumna 2; 0, kolumna 3; 2, kolumna 4; 1; wiersz 4; kolumna 1; 6, kolumna 2; 2, kolumna 3; 9, kolumna 4; 0")?;
+    return Ok(());
+}
+
+#[test]
+fn matrix_4x2() -> Result<()> {
+    let expr = "
+    <math xmlns='http://www.w3.org/1998/Math/MathML'>
+    <mrow>
+      <mrow><mo>(</mo>
+        <mtable>
+        <mtr>
+          <mtd>
+          <mn>1</mn>
+          </mtd>
+          <mtd>
+          <mn>3</mn>
+          </mtd>
+        </mtr>
+        <mtr>
+          <mtd>
+          <mn>4</mn>
+          </mtd>
+          <mtd>
+          <mn>2</mn>
+          </mtd>
+        </mtr>
+        <mtr>
+          <mtd>
+          <mn>2</mn>
+          </mtd>
+          <mtd>
+          <mn>1</mn>
+          </mtd>
+        </mtr>
+        <mtr>
+          <mtd>
+          <mn>0</mn>
+          </mtd>
+          <mtd>
+          <mn>5</mn>
+          </mtd>
+        </mtr>
+        
+        </mtable>
+      <mo>)</mo></mrow></mrow>
+    </math>
+      ";
+    test("pl", "ClearSpeak",  expr, "4 na 2 macierz; wiersz 1; kolumna 1; 1, kolumna 2; 3; wiersz 2; kolumna 1; 4, kolumna 2; 2; wiersz 3; kolumna 1; 2, kolumna 2; 1; wiersz 4; kolumna 1; 0, kolumna 2; 5")?;
+    test("pl", "SimpleSpeak", expr, "4 na 2 macierz; wiersz 1; kolumna 1; 1, kolumna 2; 3; wiersz 2; kolumna 1; 4, kolumna 2; 2; wiersz 3; kolumna 1; 2, kolumna 2; 1; wiersz 4; kolumna 1; 0, kolumna 2; 5")?;
+    return Ok(());
+}
+
+// put absolute value test here since it is related to determinate and is small for its own file
+#[test]
+fn simple_absolute_value() -> Result<()> {
+  let expr = "<math>
+    <mrow><mrow><mo>|</mo> <mi>x</mi> <mo>|</mo></mrow></mrow>
+  </math>";
+  test("pl", "SimpleSpeak", expr, "wartość bezwzględna z x")?;
+  test("pl", "ClearSpeak",  expr, "wartość bezwzględna z x")?;
+  test_prefs("pl", "ClearSpeak", vec![("Verbosity", "Terse"), ("ClearSpeak_AbsoluteValue", "Auto")], expr, "wartość bezwzględna z x")?;
+  test_prefs("pl", "ClearSpeak", vec![("Verbosity", "Verbose"), ("ClearSpeak_AbsoluteValue", "AbsEnd")],
+             expr, "wartość bezwzględna z x, koniec wartości bezwzględnej")?;
+  return Ok(());
+}
+  
+#[test]
+fn absolute_value_plus_1() -> Result<()> {
+let expr = "<math>
+    <mrow><mrow><mo>|</mo>
+      <mrow><mi>x</mi><mo>+</mo><mn>1</mn> </mrow>
+    <mo>|</mo></mrow></mrow>
+  </math>";
+  test("pl", "ClearSpeak", expr, "wartość bezwzględna z x plus 1")?;
+  test_prefs("pl", "ClearSpeak", vec![("Verbosity", "Terse"), ("ClearSpeak_AbsoluteValue", "AbsEnd")],
+             expr, "wartość bezwzględna z x plus 1, koniec wartości bezwzględnej")?;
+  return Ok(());
+}
+
+#[test]
+fn simple_cardinality_value() -> Result<()> {
+  let expr = "<math>
+    <mrow><mrow><mo>|</mo> <mi>S</mi> <mo>|</mo></mrow></mrow>
+  </math>";
+  test_prefs("pl", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_AbsoluteValue", "Cardinality")], expr,
+             "moc z wielka s")?;
+    return Ok(());
+}
+  
+// Test preferences
+#[test]
+fn simple_matrix_speak_col_num() -> Result<()> {
+let expr = "<math display='block' xmlns='http://www.w3.org/1998/Math/MathML'>
+  <mrow>
+    <mrow><mo>(</mo>
+    <mrow>
+      <mtable>
+      <mtr>
+        <mtd> <mn>2</mn> </mtd>
+        <mtd><mn>1</mn> </mtd>
+      </mtr>
+      <mtr>
+        <mtd><mn>7</mn> </mtd>
+        <mtd><mn>5</mn> </mtd>
+      </mtr>
+      </mtable></mrow>
+    <mo>)</mo></mrow></mrow>
+  </math>";
+  test_ClearSpeak("pl", "ClearSpeak_Matrix", "SpeakColNum",
+        expr, "2 na 2 macierz; wiersz 1; kolumna 1; 2, kolumna 2; 1; wiersz 2; kolumna 1; 7, kolumna 2; 5")?;
+    return Ok(());
+}
+
+#[test]
+fn col_matrix_3x1_speak_col_num() -> Result<()> {
+let expr = "<math display='block' xmlns='http://www.w3.org/1998/Math/MathML'>
+  <mrow>
+    <mrow><mo>(</mo>
+    <mrow>
+      <mtable>
+      <mtr>
+        <mtd><mn>1</mn> </mtd>
+      </mtr>
+      <mtr>
+        <mtd><mn>2</mn> </mtd>
+      </mtr>
+      <mtr>
+        <mtd><mn>3</mn> </mtd>
+      </mtr>
+      </mtable></mrow>
+    <mo>)</mo></mrow></mrow>
+  </math>";
+test_ClearSpeak("pl", "ClearSpeak_Matrix", "SpeakColNum",
+        expr, "3 na jedną kolumnę macierz; wiersz 1; 1; wiersz 2; 2; wiersz 3; 3")?;
+    return Ok(());
+}
+
+#[test]
+fn row_matrix_1x2_speak_col_num() -> Result<()> {
+let expr = "<math display='block' xmlns='http://www.w3.org/1998/Math/MathML'>
+  <mrow>
+    <mrow><mo>[</mo>
+    <mrow>
+      <mtable>
+      <mtr>
+        <mtd><mn>1</mn> </mtd> <mtd><mn>2</mn> </mtd>
+      </mtr>
+      </mtable></mrow>
+    <mo>]</mo></mrow></mrow>
+  </math>";
+test_ClearSpeak("pl", "ClearSpeak_Matrix", "SpeakColNum",
+        expr, "jeden na 2 wiersz macierz; kolumna 1; 1, kolumna 2; 2")?;
+    return Ok(());
+}
+
+#[test]
+fn matrix_2x2_speak_col_num() -> Result<()> {
+let expr = "<math><mrow><mrow><mo>(</mo><mrow>
+    <mtable>
+    <mtr>
+        <mtd><mrow><msub><mi>b</mi><mrow><mn>1</mn><mn>1</mn></mrow></msub></mrow></mtd>
+        <mtd><mrow><msub><mi>b</mi><mrow><mn>1</mn><mn>2</mn></mrow></msub></mrow></mtd>
+    </mtr>
+    <mtr>
+        <mtd><mrow><msub><mi>b</mi><mrow><mn>2</mn><mn>1</mn></mrow></msub></mrow></mtd>
+        <mtd><mrow><msub><mi>b</mi><mrow><mn>2</mn><mn>2</mn></mrow></msub></mrow></mtd>
+    </mtr>
+    </mtable>
+    </mrow><mo>)</mo></mrow></mrow></math>";
+test_ClearSpeak("pl", "ClearSpeak_Matrix", "SpeakColNum",
+        expr, "2 na 2 macierz; wiersz 1; kolumna 1; b indeks dolny 1 1; kolumna 2; b indeks dolny 1 2; wiersz 2; kolumna 1; b indeks dolny 2 1; kolumna 2; b indeks dolny 2 2")?;
+    return Ok(());
+}
+
+
+#[test]
+fn simple_matrix_silent_col_num() -> Result<()> {
+let expr = "<math display='block' xmlns='http://www.w3.org/1998/Math/MathML'>
+  <mrow>
+    <mrow><mo>(</mo>
+    <mrow>
+      <mtable>
+      <mtr>
+        <mtd> <mn>2</mn> </mtd>
+        <mtd><mn>1</mn> </mtd>
+      </mtr>
+      <mtr>
+        <mtd><mn>7</mn> </mtd>
+        <mtd><mn>5</mn> </mtd>
+      </mtr>
+      </mtable></mrow>
+    <mo>)</mo></mrow></mrow>
+  </math>";
+  test_ClearSpeak("pl", "ClearSpeak_Matrix", "SilentColNum",
+        expr, "2 na 2 macierz; wiersz 1; 2, 1; wiersz 2; 7, 5")?;
+    return Ok(());
+}
+
+#[test]
+fn col_matrix_3x1_silent_col_num() -> Result<()> {
+let expr = "<math display='block' xmlns='http://www.w3.org/1998/Math/MathML'>
+  <mrow>
+    <mrow><mo>(</mo>
+    <mrow>
+      <mtable>
+      <mtr>
+        <mtd><mn>1</mn> </mtd>
+      </mtr>
+      <mtr>
+        <mtd><mn>2</mn> </mtd>
+      </mtr>
+      <mtr>
+        <mtd><mn>3</mn> </mtd>
+      </mtr>
+      </mtable></mrow>
+    <mo>)</mo></mrow></mrow>
+  </math>";
+test_ClearSpeak("pl", "ClearSpeak_Matrix", "SilentColNum",
+        expr, "3 na jedną kolumnę macierz; 1; 2; 3")?;
+    return Ok(());
+}
+
+#[test]
+fn row_matrix_1x2_silent_col_num() -> Result<()> {
+let expr = "<math display='block' xmlns='http://www.w3.org/1998/Math/MathML'>
+  <mrow>
+    <mrow><mo>[</mo>
+    <mrow>
+      <mtable>
+      <mtr>
+        <mtd><mn>1</mn> </mtd> <mtd><mn>2</mn> </mtd>
+      </mtr>
+      </mtable></mrow>
+    <mo>]</mo></mrow></mrow>
+  </math>";
+test_ClearSpeak("pl", "ClearSpeak_Matrix", "SilentColNum",
+        expr, "jeden na 2 wiersz macierz; 1, 2")?;
+    return Ok(());
+}
+
+#[test]
+fn matrix_2x2_silent_col_num() -> Result<()> {
+let expr = "<math><mrow><mrow><mo>(</mo><mrow>
+    <mtable>
+    <mtr>
+        <mtd><mrow><msub><mi>b</mi><mrow><mn>1</mn><mn>1</mn></mrow></msub></mrow></mtd>
+        <mtd><mrow><msub><mi>b</mi><mrow><mn>1</mn><mn>2</mn></mrow></msub></mrow></mtd>
+    </mtr>
+    <mtr>
+        <mtd><mrow><msub><mi>b</mi><mrow><mn>2</mn><mn>1</mn></mrow></msub></mrow></mtd>
+        <mtd><mrow><msub><mi>b</mi><mrow><mn>2</mn><mn>2</mn></mrow></msub></mrow></mtd>
+    </mtr>
+    </mtable>
+    </mrow><mo>)</mo></mrow></mrow></math>";
+test_ClearSpeak("pl", "ClearSpeak_Matrix", "SilentColNum",
+        expr, "2 na 2 macierz; wiersz 1; b indeks dolny 1 1; b indeks dolny 1 2; wiersz 2; b indeks dolny 2 1; b indeks dolny 2 2")?;
+    return Ok(());
+  }
+
+
+#[test]
+fn simple_matrix_end_matrix() -> Result<()> {
+let expr = "<math display='block' xmlns='http://www.w3.org/1998/Math/MathML'>
+  <mrow>
+    <mrow><mo>(</mo>
+    <mrow>
+      <mtable>
+      <mtr>
+        <mtd> <mn>2</mn> </mtd>
+        <mtd><mn>1</mn> </mtd>
+      </mtr>
+      <mtr>
+        <mtd><mn>7</mn> </mtd>
+        <mtd><mn>5</mn> </mtd>
+      </mtr>
+      </mtable></mrow>
+    <mo>)</mo></mrow></mrow>
+  </math>";
+  test_ClearSpeak("pl", "ClearSpeak_Matrix", "EndMatrix",
+        expr, "2 na 2 macierz; wiersz 1; 2, 1; wiersz 2; 7, 5; koniec macierzy")?;
+    return Ok(());
+  }
+
+#[test]
+fn col_matrix_3x1_end_matrix() -> Result<()> {
+let expr = "<math display='block' xmlns='http://www.w3.org/1998/Math/MathML'>
+  <mrow>
+    <mrow><mo>(</mo>
+    <mrow>
+      <mtable>
+      <mtr>
+        <mtd><mn>1</mn> </mtd>
+      </mtr>
+      <mtr>
+        <mtd><mn>2</mn> </mtd>
+      </mtr>
+      <mtr>
+        <mtd><mn>3</mn> </mtd>
+      </mtr>
+      </mtable></mrow>
+    <mo>)</mo></mrow></mrow>
+  </math>";
+test_ClearSpeak("pl", "ClearSpeak_Matrix", "EndMatrix",
+        expr, "3 na jedną kolumnę macierz; 1; 2; 3; koniec macierzy")?;
+    return Ok(());
+  }
+
+#[test]
+fn row_matrix_1x2_end_matrix() -> Result<()> {
+let expr = "<math display='block' xmlns='http://www.w3.org/1998/Math/MathML'>
+  <mrow>
+    <mrow><mo>[</mo>
+    <mrow>
+      <mtable>
+      <mtr>
+        <mtd><mn>1</mn> </mtd> <mtd><mn>2</mn> </mtd>
+      </mtr>
+      </mtable></mrow>
+    <mo>]</mo></mrow></mrow>
+  </math>";
+test_ClearSpeak("pl", "ClearSpeak_Matrix", "EndMatrix",
+        expr, "jeden na 2 wiersz macierz; 1, 2; koniec macierzy")?;
+    return Ok(());
+  }
+
+#[test]
+fn matrix_2x2_end_matrix() -> Result<()> {
+let expr = "<math><mrow><mrow><mo>(</mo><mrow>
+    <mtable>
+    <mtr>
+        <mtd><mrow><msub><mi>b</mi><mrow><mn>1</mn><mn>1</mn></mrow></msub></mrow></mtd>
+        <mtd><mrow><msub><mi>b</mi><mrow><mn>1</mn><mn>2</mn></mrow></msub></mrow></mtd>
+    </mtr>
+    <mtr>
+        <mtd><mrow><msub><mi>b</mi><mrow><mn>2</mn><mn>1</mn></mrow></msub></mrow></mtd>
+        <mtd><mrow><msub><mi>b</mi><mrow><mn>2</mn><mn>2</mn></mrow></msub></mrow></mtd>
+    </mtr>
+    </mtable>
+    </mrow><mo>)</mo></mrow></mrow></math>";
+test_ClearSpeak("pl", "ClearSpeak_Matrix", "EndMatrix",
+        expr, "2 na 2 macierz; wiersz 1; kolumna 1; b indeks dolny 1 1; kolumna 2; b indeks dolny 1 2; wiersz 2; kolumna 1; b indeks dolny 2 1; kolumna 2; b indeks dolny 2 2; koniec macierzy")?;
+    return Ok(());
+  }
+
+#[test]
+fn augmented_matrix_3x4_end_matrix() -> Result<()> {
+let expr = "<math display='block' xmlns='http://www.w3.org/1998/Math/MathML'>
+  <mrow>
+    <mrow><mo>[</mo>
+      <mtable columnalign='right right right right' columnlines='none none solid'>
+        <mtr>
+          <mtd><mn>1</mn></mtd>
+          <mtd><mn>2</mn></mtd>
+          <mtd><mrow><mo>-</mo><mn>1</mn></mrow></mtd>
+          <mtd><mn>3</mn></mtd>
+        </mtr>
+        <mtr>
+          <mtd><mrow><mo>-</mo><mn>3</mn></mrow></mtd>
+          <mtd><mn>3</mn></mtd>
+          <mtd><mrow><mo>-</mo><mn>1</mn></mrow></mtd>
+          <mtd><mn>2</mn></mtd>
+        </mtr>
+        <mtr>
+          <mtd><mn>2</mn></mtd>
+          <mtd><mn>3</mn></mtd>
+          <mtd><mn>2</mn></mtd>
+          <mtd><mrow><mo>-</mo><mn>1</mn></mrow></mtd>
+        </mtr>
+      </mtable>
+    <mo>]</mo></mrow>
+  </mrow>
+</math>";
+test_ClearSpeak("pl", "ClearSpeak_Matrix", "EndMatrix",
+        expr, "3 na 4 macierz rozszerzona; wiersz 1; kolumna 1; 1, kolumna 2; 2, kolumna 3; minus 1, kolumna 4; 3; wiersz 2; kolumna 1; minus 3, kolumna 2; 3, kolumna 3; minus 1, kolumna 4; 2; wiersz 3; kolumna 1; 2, kolumna 2; 3, kolumna 3; 2, kolumna 4; minus 1; koniec macierzy")?;
+    test("pl", "SimpleSpeak",
+        expr, "3 na 4 macierz rozszerzona; wiersz 1; kolumna 1; 1, kolumna 2; 2, kolumna 3; minus 1, kolumna 4; 3; wiersz 2; kolumna 1; minus 3, kolumna 2; 3, kolumna 3; minus 1, kolumna 4; 2; wiersz 3; kolumna 1; 2, kolumna 2; 3, kolumna 3; 2, kolumna 4; minus 1; koniec macierzy")?;
+    Ok(())
+  }
+
+
+#[test]
+fn simple_matrix_vector() -> Result<()> {
+let expr = "<math display='block' xmlns='http://www.w3.org/1998/Math/MathML'>
+  <mrow>
+    <mrow><mo>(</mo>
+    <mrow>
+      <mtable>
+      <mtr>
+        <mtd> <mn>2</mn> </mtd>
+        <mtd><mn>1</mn> </mtd>
+      </mtr>
+      <mtr>
+        <mtd><mn>7</mn> </mtd>
+        <mtd><mn>5</mn> </mtd>
+      </mtr>
+      </mtable></mrow>
+    <mo>)</mo></mrow></mrow>
+  </math>";
+  test_ClearSpeak("pl", "ClearSpeak_Matrix", "Vector",
+        expr, "2 na 2 macierz; wiersz 1; 2, 1; wiersz 2; 7, 5")?;
+    return Ok(());
+  }
+
+#[test]
+fn col_matrix_3x1_vector() -> Result<()> {
+let expr = "<math display='block' xmlns='http://www.w3.org/1998/Math/MathML'>
+  <mrow>
+    <mrow><mo>(</mo>
+    <mrow>
+      <mtable>
+      <mtr>
+        <mtd><mn>1</mn> </mtd>
+      </mtr>
+      <mtr>
+        <mtd><mn>2</mn> </mtd>
+      </mtr>
+      <mtr>
+        <mtd><mn>3</mn> </mtd>
+      </mtr>
+      </mtable></mrow>
+    <mo>)</mo></mrow></mrow>
+  </math>";
+test_ClearSpeak("pl", "ClearSpeak_Matrix", "Vector",
+        expr, "3 na jedną kolumnę wektor; 1; 2; 3")?;
+    return Ok(());
+  }
+
+#[test]
+fn row_matrix_1x2_vector() -> Result<()> {
+let expr = "<math display='block' xmlns='http://www.w3.org/1998/Math/MathML'>
+  <mrow>
+    <mrow><mo>[</mo>
+    <mrow>
+      <mtable>
+      <mtr>
+        <mtd><mn>1</mn> </mtd> <mtd><mn>2</mn> </mtd>
+      </mtr>
+      </mtable></mrow>
+    <mo>]</mo></mrow></mrow>
+  </math>";
+test_ClearSpeak("pl", "ClearSpeak_Matrix", "Vector",
+        expr, "jeden na 2 wiersz wektor; 1, 2")?;
+    return Ok(());
+  }
+
+#[test]
+fn matrix_2x2_vector() -> Result<()> {
+let expr = "<math><mrow><mrow><mo>(</mo><mrow>
+    <mtable>
+    <mtr>
+        <mtd><mrow><msub><mi>b</mi><mrow><mn>1</mn><mn>1</mn></mrow></msub></mrow></mtd>
+        <mtd><mrow><msub><mi>b</mi><mrow><mn>1</mn><mn>2</mn></mrow></msub></mrow></mtd>
+    </mtr>
+    <mtr>
+        <mtd><mrow><msub><mi>b</mi><mrow><mn>2</mn><mn>1</mn></mrow></msub></mrow></mtd>
+        <mtd><mrow><msub><mi>b</mi><mrow><mn>2</mn><mn>2</mn></mrow></msub></mrow></mtd>
+    </mtr>
+    </mtable>
+    </mrow><mo>)</mo></mrow></mrow></math>";
+test_ClearSpeak("pl", "ClearSpeak_Matrix", "Vector",
+        expr, "2 na 2 macierz; wiersz 1; kolumna 1; b indeks dolny 1 1; kolumna 2; b indeks dolny 1 2; wiersz 2; kolumna 1; b indeks dolny 2 1; kolumna 2; b indeks dolny 2 2")?;
+    return Ok(());
+  }
+
+
+#[test]
+fn simple_matrix_end_vector() -> Result<()> {
+let expr = "<math display='block' xmlns='http://www.w3.org/1998/Math/MathML'>
+  <mrow>
+    <mrow><mo>(</mo>
+    <mrow>
+      <mtable>
+      <mtr>
+        <mtd> <mn>2</mn> </mtd>
+        <mtd><mn>1</mn> </mtd>
+      </mtr>
+      <mtr>
+        <mtd><mn>7</mn> </mtd>
+        <mtd><mn>5</mn> </mtd>
+      </mtr>
+      </mtable></mrow>
+    <mo>)</mo></mrow></mrow>
+  </math>";
+  test_ClearSpeak("pl", "ClearSpeak_Matrix", "EndVector",
+        expr, "2 na 2 macierz; wiersz 1; 2, 1; wiersz 2; 7, 5; koniec macierzy")?;
+    return Ok(());
+  }
+
+#[test]
+fn col_matrix_3x1_end_vector() -> Result<()> {
+let expr = "<math display='block' xmlns='http://www.w3.org/1998/Math/MathML'>
+  <mrow>
+    <mrow><mo>(</mo>
+    <mrow>
+      <mtable>
+      <mtr>
+        <mtd><mn>1</mn> </mtd>
+      </mtr>
+      <mtr>
+        <mtd><mn>2</mn> </mtd>
+      </mtr>
+      <mtr>
+        <mtd><mn>3</mn> </mtd>
+      </mtr>
+      </mtable></mrow>
+    <mo>)</mo></mrow></mrow>
+  </math>";
+test_ClearSpeak("pl", "ClearSpeak_Matrix", "EndVector",
+        expr, "3 na jedną kolumnę wektor; 1; 2; 3; koniec wektora")?;
+    return Ok(());
+  }
+
+#[test]
+fn row_matrix_1x2_end_vector() -> Result<()> {
+let expr = "<math display='block' xmlns='http://www.w3.org/1998/Math/MathML'>
+  <mrow>
+    <mrow><mo>[</mo>
+    <mrow>
+      <mtable>
+      <mtr>
+        <mtd><mn>1</mn> </mtd> <mtd><mn>2</mn> </mtd>
+      </mtr>
+      </mtable></mrow>
+    <mo>]</mo></mrow></mrow>
+  </math>";
+test_ClearSpeak("pl", "ClearSpeak_Matrix", "EndVector",
+        expr, "jeden na 2 wiersz wektor; 1, 2; koniec wektora")?;
+    return Ok(());
+  }
+
+#[test]
+fn matrix_2x2_end_vector() -> Result<()> {
+let expr = "<math><mrow><mrow><mo>(</mo><mrow>
+    <mtable>
+    <mtr>
+        <mtd><mrow><msub><mi>b</mi><mrow><mn>1</mn><mn>1</mn></mrow></msub></mrow></mtd>
+        <mtd><mrow><msub><mi>b</mi><mrow><mn>1</mn><mn>2</mn></mrow></msub></mrow></mtd>
+    </mtr>
+    <mtr>
+        <mtd><mrow><msub><mi>b</mi><mrow><mn>2</mn><mn>1</mn></mrow></msub></mrow></mtd>
+        <mtd><mrow><msub><mi>b</mi><mrow><mn>2</mn><mn>2</mn></mrow></msub></mrow></mtd>
+    </mtr>
+    </mtable>
+    </mrow><mo>)</mo></mrow></mrow></math>";
+test_ClearSpeak("pl", "ClearSpeak_Matrix", "EndVector",
+        expr, "2 na 2 macierz; wiersz 1; kolumna 1; b indeks dolny 1 1; kolumna 2; b indeks dolny 1 2; wiersz 2; kolumna 1; b indeks dolny 2 1; kolumna 2; b indeks dolny 2 2; koniec macierzy")?;
+  return Ok(());
+}
+
+
+#[test]
+fn matrix_binomial() -> Result<()> {
+  let expr = "<math>
+      <mo>(</mo><mrow>
+        <mtable><mtr><mtd><mn>3</mn></mtd></mtr><mtr><mtd><mn>2</mn></mtd></mtr></mtable>
+      </mrow><mo>)</mo>
+    </math>";
+  test_ClearSpeak("pl", "ClearSpeak_Matrix", "Combinatorics", expr, "3 po 2")?;
+  return Ok(());
+}
+
+#[test]
+fn matrix_simple_table() -> Result<()> {
+  let expr = "<math>
+        <mtable><mtr><mtd><mn>3</mn></mtd></mtr><mtr><mtd><mn>2</mn></mtd></mtr></mtable>
+    </math>";
+  test("pl", "ClearSpeak", expr, "tablica z; wiersz 1; kolumna 1; 3; przecinek; wiersz 2; kolumna 1; 2")
+}
+
+#[test]
+fn mtable_prefix_op() -> Result<()>{
+    // When a table is prefixed with a non-blank operator, assume it is something besides array intent
+    for (op, expected) in [("(", "nawias otwierający, 2 linie; linia 1; 3; linia 2; 2"),
+			 ("[", "nawias kwadratowy otwierający; 2 linie; linia 1; 3; linia 2; 2"),
+			 ("|", "kreska pionowa, 2 linie; linia 1; 3; linia 2; 2"),
+			 ("f", "f, 2 linie; linia 1; 3; linia 2; 2")] {
+	let expr = format!("<math>
+        <mo>{op}</mo><mtable><mtr><mtd><mn>3</mn></mtd></mtr><mtr><mtd><mn>2</mn></mtd></mtr></mtable>
+    </math>");
+	test("pl", "ClearSpeak", &expr, expected)?;
+    }
+    Ok(())
+}
+
+#[test]
+fn mtable_blank_op() -> Result<()>{
+    // When a table is prefixed with a blank operator, still assume array intent
+    let expr = "<math>
+        <mo>\u{2062}</mo><mtable><mtr><mtd><mn>3</mn></mtd></mtr><mtr><mtd><mn>2</mn></mtd></mtr></mtable>
+    </math>";
+    test("pl", "ClearSpeak", expr, "; tablica z; wiersz 1; kolumna 1; 3; przecinek; wiersz 2; kolumna 1; 2")
+}
+
+
+
+#[test]
+fn mtable_colspan_table() -> Result<()>{
+  let expr = "<math>
+        <mtable><mtr><mtd colspan=\"2\"><mn>3</mn></mtd></mtr><mtr><mtd><mn>2</mn></mtd><mtd><mn>4</mn></mtd></mtr></mtable>
+    </math>";
+  test("pl", "ClearSpeak", expr, "tablica z; wiersz 1; kolumna 1; 3; przecinek; wiersz 2; kolumna 1; 2, kolumna 2; 4")
+}
+
+#[test]
+fn bug_mtable_rowspan_colspan() -> Result<()>{
+  // Currently, the code correctly computes the number of rows and
+  // columns, but it does not correctly compute the column number whnen
+  // colspans are involved.
+  let expr = "<math>
+        <mtable>
+           <mtr>
+             <mtd rowspan=\"2\" colspan=\"2\"><mi>a</mi></mtd>
+             <mtd rowspan=\"2\"><mi>b</mi></mtd>
+             <mtd colspan=\"2\"><mi>c</mi></mtd>
+           </mtr>
+           <mtr>
+             <mtd><mi>d</mi></mtd><mtd><mi>e</mi></mtd>
+           </mtr>
+        </mtable>
+    </math>";
+    test("pl", "ClearSpeak", expr,
+	 "tablica z; wiersz 1; kolumna 1; a, kolumna 2; b, kolumna 3; c; przecinek; wiersz 2; kolumna 1; d, kolumna 2; e")
+}
+
+
+
+#[test]
+fn matrix_times() {
+  let expr = "<math>
+    <mfenced><mtable><mtr><mtd><mn>1</mn></mtd><mtd><mn>2</mn></mtd></mtr><mtr><mtd><mn>3</mn></mtd><mtd><mn>4</mn></mtd></mtr></mtable></mfenced>
+    <mfenced><mtable><mtr><mtd><mi>a</mi></mtd><mtd><mi>b</mi></mtd></mtr><mtr><mtd><mi>c</mi></mtd><mtd><mi>d</mi></mtd></mtr></mtable></mfenced>
+  </math>";
+  let _ = test("pl", "SimpleSpeak", expr,
+    "2 na 2 macierz; wiersz 1; 1, 2; wiersz 2; 3, 4; razy, 2 na 2 macierz; wiersz 1; a, b; wiersz 2; c, d");
+}
+
+#[test]
+fn unknown_mtable_property() -> Result<()> {
+  let expr = "<math display='block'>
+      <mtable intent=':system-of-equations:prefix($e1,$e1x)'>
+        <mtr arg='e1'>
+        <mtd columnalign='right'>
+          <mi>a</mi>
+        </mtd>
+        <mtd columnalign='center'>
+          <mo>=</mo>
+        </mtd>
+        <mtd intent='_($lhs)' columnalign='left'>
+          <mrow arg='lhs'>
+          <mi>b</mi>
+          <mo>+</mo>
+          <mi>c</mi>
+          <mo>&#x2212;</mo>
+          <mi>d</mi>
+        </mrow>
+        </mtd>
+        </mtr>
+        <mtr arg='e1x'>
+        <mtd intent='_' columnalign='right'></mtd>
+        <mtd intent='_' columnalign='center'></mtd>
+        <mtd arg='rhs' columnalign='left'>
+          <mo form='infix'>+</mo>
+          <mi>e</mi>
+          <mo>&#x2212;</mo>
+          <mi>f</mi>
+        </mtd>
+        </mtr>
+      </mtable>
+    </math>";
+    test("pl", "ClearSpeak",  expr,
+         "2 linie; linia 1; a równa się, b plus c minus d; linia 2; plus e minus f")?;
+    return Ok(());
+  }
+
+
+#[test]
+fn zero_matrix() -> Result<()> {
+  let expr = "<math>
+      <mo>[</mo>
+      <mtable>
+        <mtr><mtd><mn>0</mn></mtd><mtd><mn>0</mn></mtd></mtr>
+        <mtr><mtd><mn>0</mn></mtd><mtd><mn>0</mn></mtd></mtr>
+      </mtable>
+      <mo>]</mo>
+  </math>";
+  test("pl", "SimpleSpeak", expr,
+    "2 na 2 macierz zerowa")?;
+    return Ok(());
+  }
+
+#[test]
+fn identity_matrix() -> Result<()> {
+  let expr = "<math>
+      <mo>(</mo>
+      <mtable>
+        <mtr><mtd><mn>1</mn></mtd><mtd><mn>0</mn></mtd><mtd><mn>0</mn></mtd></mtr>
+        <mtr><mtd><mn>0</mn></mtd><mtd><mn>1</mn></mtd><mtd><mn>0</mn></mtd></mtr>
+        <mtr><mtd><mn>0</mn></mtd><mtd><mn>0</mn></mtd><mtd><mn>1</mn></mtd></mtr>
+      </mtable>
+      <mo>)</mo>
+  </math>";
+  test("pl", "SimpleSpeak", expr,
+    "3 na 3 macierz jednostkowa")?;
+    return Ok(());
+  }
+
+#[test]
+fn identity_matrix_false_positive_negative_one() -> Result<()> {
+  let expr = "<math>
+      <mo>[</mo>
+      <mtable>
+        <mtr><mtd><mn>1</mn></mtd><mtd><mn>0</mn></mtd></mtr>
+        <mtr><mtd><mn>0</mn></mtd><mtd><mn>-1</mn></mtd></mtr>
+      </mtable>
+      <mo>]</mo>
+  </math>";
+  test_prefs("pl", "SimpleSpeak", vec![("Verbosity", "Terse")],
+      expr, "2 na 2 macierz diagonalna; kolumna 1; 1; kolumna 2; minus 1")?;
+  Ok(())
+}
+
+#[test]
+fn identity_matrix_false_positive_zero_diagonal() -> Result<()> {
+  let expr = "<math>
+      <mo>[</mo>
+      <mtable>
+        <mtr><mtd><mn>1</mn></mtd><mtd><mn>0</mn></mtd></mtr>
+        <mtr><mtd><mn>0</mn></mtd><mtd><mn>0</mn></mtd></mtr>
+      </mtable>
+      <mo>]</mo>
+  </math>";
+  test_prefs("pl", "SimpleSpeak", vec![("Verbosity", "Terse")],
+      expr, "2 na 2 macierz diagonalna; kolumna 1; 1")?;
+  Ok(())
+}
+
+#[test]
+fn diagonal_matrix() -> Result<()> {
+  let expr = "<math>
+      <mo>(</mo>
+      <mtable>
+        <mtr><mtd><mn>2</mn></mtd><mtd><mn>0</mn></mtd><mtd><mn>0</mn></mtd></mtr>
+        <mtr><mtd><mn>0</mn></mtd><mtd><mn>1</mn></mtd><mtd><mn>0</mn></mtd></mtr>
+        <mtr><mtd><mn>0</mn></mtd><mtd><mn>0</mn></mtd><mtd><msup><mi>x</mi><mn>2</mn></msup></mtd></mtr>
+      </mtable>
+      <mo>)</mo>
+  </math>";
+  test_prefs("pl", "SimpleSpeak", vec![("Verbosity", "Terse")],
+      expr, "3 na 3 macierz diagonalna; kolumna 1; 2; kolumna 2; 1; kolumna 3; x do kwadratu")?;
+  // test_prefs("pl", "SimpleSpeak", vec![("Verbosity", "Verbose")],
+  //     expr, "the 3 by 3 diagonal matrix; row 1, column 1, 2; row 2, column 2, 1; row 3, column 3, x squared");
+    return Ok(());
+  }
+
+#[test]
+fn single_line_with_label() -> Result<()> {
+  let expr = r#"<math>
+  <mtable class="gather" displaystyle="true" intent=":system-of-equations">
+    <mtr>
+      <mtd intent=":equation-label"> <mtext>(2)</mtext> </mtd>
+      <mtd> <mi>𝑏</mi> <mo>=</mo> <mn>2</mn> </mtd>
+    </mtr>
+  </mtable>
+  </math>"#;
+  test_prefs("pl", "ClearSpeak", vec![("Verbosity", "Terse")],
+      expr, "1 linia, z etykietą 2; b równa się 2")?;
+  test_prefs("pl", "SimpleSpeak", vec![("Verbosity", "Terse")],
+      expr, "1 równanie, z etykietą 2; b równa się 2")?;
+    return Ok(());
+  }

--- a/tests/Languages/pl/pl.rs
+++ b/tests/Languages/pl/pl.rs
@@ -1255,3 +1255,88 @@ fn rownoleglosc_nie_jest_norma() -> Result<()> {
     test("pl", "ClearSpeak", expr, "a jest równoległe do b")?;
     Ok(())
 }
+
+// --- Polska odmiana liczebnika w układach wielowierszowych -------------------
+// Cecha specyficzna dla polskiego: rzeczownik po liczbie odmienia się przez
+// liczbę: 1 -> pojedyncza, 2-4 (oprócz 12-14) -> mianownik l.mn. (paucal),
+// pozostałe -> dopełniacz l.mn. Zwykłe kopiowanie reguł z angielskiego (sufiks
+// "s") dawało "2 równanies" / "5 równania" - te testy pilnują poprawnych form.
+
+// Buduje układ N równań (mtable z N wierszami "x = i").
+fn uklad_rownan(n: usize) -> String {
+    let mut wiersze = String::new();
+    for i in 1..=n {
+        wiersze.push_str(&format!(
+            "<mtr><mtd><mrow><mi>x</mi></mrow></mtd><mtd><mo>=</mo></mtd><mtd><mn>{i}</mn></mtd></mtr>"
+        ));
+    }
+    format!("<math><mrow><mtable>{wiersze}</mtable></mrow></math>")
+}
+
+#[test]
+fn simplespeak_uklad_dwa_rownania_paucal() -> Result<()> {
+    // 2 -> "równania" (mianownik l.mn.)
+    test("pl", "SimpleSpeak", &uklad_rownan(2),
+        "2 równania; równanie 1; x równa się 1; równanie 2; x równa się 2")?;
+    Ok(())
+}
+
+#[test]
+fn simplespeak_uklad_piec_rownan_dopelniacz() -> Result<()> {
+    // 5 -> "równań" (dopełniacz l.mn.), NIE "równania"
+    let mowa = get_spoken_text_for(&uklad_rownan(5), "SimpleSpeak");
+    assert!(mowa.starts_with("5 równań;"), "oczekiwano '5 równań;', było: {mowa}");
+    Ok(())
+}
+
+#[test]
+fn simplespeak_uklad_dwanascie_rownan_wyjatek() -> Result<()> {
+    // 12 -> dopełniacz "równań" (wyjątek 12-14, mimo końcówki 2)
+    let mowa = get_spoken_text_for(&uklad_rownan(12), "SimpleSpeak");
+    assert!(mowa.starts_with("12 równań;"), "oczekiwano '12 równań;', było: {mowa}");
+    Ok(())
+}
+
+#[test]
+fn simplespeak_uklad_dwadziescia_dwa_rownania_paucal() -> Result<()> {
+    // 22 -> "równania" (końcówka 2, poza zakresem 12-14)
+    let mowa = get_spoken_text_for(&uklad_rownan(22), "SimpleSpeak");
+    assert!(mowa.starts_with("22 równania;"), "oczekiwano '22 równania;', było: {mowa}");
+    Ok(())
+}
+
+#[test]
+fn clearspeak_uklad_przypadki_odmiana() -> Result<()> {
+    // ClearSpeak, etykieta Case: 5 -> "przypadków", 12 -> "przypadków"
+    for (n, forma) in [(5usize, "5 przypadków;"), (12, "12 przypadków;")] {
+        let mowa = get_spoken_text_cs(&uklad_rownan(n), "Case");
+        assert!(mowa.starts_with(forma), "oczekiwano '{forma}', było: {mowa}");
+    }
+    Ok(())
+}
+
+#[test]
+fn clearspeak_uklad_linie_dopelniacz() -> Result<()> {
+    // ClearSpeak, etykieta Line: 5 -> "linii" (dopełniacz), NIE "linie"
+    let mowa = get_spoken_text_cs(&uklad_rownan(5), "Line");
+    assert!(mowa.starts_with("5 linii;"), "oczekiwano '5 linii;', było: {mowa}");
+    Ok(())
+}
+
+// Pomocnicze: zwróć wypowiedź dla danego MathML/stylu (spójne prefy testowe).
+fn get_spoken_text_for(mathml: &str, style: &str) -> String {
+    set_rules_dir(abs_rules_dir_path()).unwrap();
+    set_preference("Language", "pl").unwrap();
+    set_preference("SpeechStyle", style).unwrap();
+    set_mathml(mathml).unwrap();
+    get_spoken_text().unwrap().split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+fn get_spoken_text_cs(mathml: &str, label: &str) -> String {
+    set_rules_dir(abs_rules_dir_path()).unwrap();
+    set_preference("Language", "pl").unwrap();
+    set_preference("SpeechStyle", "ClearSpeak").unwrap();
+    set_preference("ClearSpeak_MultiLineLabel", label).unwrap();
+    set_mathml(mathml).unwrap();
+    get_spoken_text().unwrap().split_whitespace().collect::<Vec<_>>().join(" ")
+}

--- a/tests/Languages/pl/shared.rs
+++ b/tests/Languages/pl/shared.rs
@@ -1,0 +1,609 @@
+/// Tests for rules shared between various speech styles:
+/// *  modified var
+use crate::common::*;
+use anyhow::Result;
+
+#[test]
+fn modified_vars() -> Result<()> {
+    let expr = "<math> <mrow>
+        <mover> <mi>a</mi> <mo>`</mo> </mover>
+        <mover> <mi>b</mi> <mo>~</mo> </mover>
+        <mover> <mi>c</mi> <mo>&#x0306;</mo> </mover>
+        <mover> <mi>b</mi> <mo>&#x030c;</mo> </mover>
+        <mover> <mi>c</mi> <mo>`</mo> </mover>  <mo>+</mo>
+        <mover> <mi>r</mi> <mo>ˇ</mo> </mover>  <mo>+</mo>
+        <mover> <mi>x</mi> <mo>.</mo> </mover>
+        <mover> <mi>y</mi> <mo>&#x2D9;</mo> </mover>
+        <mover> <mi>z</mi> <mo>&#x00A8;</mo> </mover>
+        <mover> <mi>u</mi> <mo>&#x20DB;</mo> </mover>
+        <mover> <mi>v</mi> <mo>&#x20DC;</mo> </mover> <mo>+</mo>
+        <mover> <mi>x</mi> <mo>^</mo> </mover> <mo>+</mo>
+        <mover> <mi>t</mi> <mo>→</mo> </mover>
+        </mrow> </math>";
+    test("pl", "SimpleSpeak", expr, 
+        "a grawis, b tylda, c znak krótkości; b haczek, c grawis; plus r haczek plus; x kropka, y kropka, z diereza, u potrójny kropka; v poczwórny kropka; plus x daszek, plus wektor t")?;
+            return Ok(());
+
+}
+
+#[test]
+fn limit() -> Result<()> {
+    let expr = "<math>
+            <munder>
+            <mo>lim</mo>
+            <mrow>  <mi>x</mi> <mo>&#x2192;</mo>  <mn>0</mn>  </mrow>
+            </munder>
+            <mrow>
+            <mfrac>
+                <mrow>  <mi>sin</mi>  <mo>&#x2061;</mo> <mi>x</mi> </mrow>
+                <mi>x</mi>
+            </mfrac>
+            </mrow>
+        </math>";
+    test("pl", "SimpleSpeak", expr, "granica gdy x dąży do 0, z, ułamek, sinus z x, przez x, koniec ułamka")?;
+    test_prefs("pl", "SimpleSpeak", vec![("Impairment", "LearningDisability")], expr,
+            "granica gdy x dąży do 0, z, sinus z x, przez x")?;
+            return Ok(());
+
+}
+
+#[test]
+fn limit_from_below() -> Result<()> {
+    let expr = "<math>
+            <munder>
+            <mo>lim</mo>
+            <mrow>  <mi>x</mi> <mo>↗</mo>  <mn>0</mn>  </mrow>
+            </munder>
+            <mrow>
+                <mrow>  <mi>sin</mi>  <mo>&#x2061;</mo> <mi>x</mi> </mrow>
+            </mrow>
+        </math>";
+    test("pl", "SimpleSpeak", expr, "granica gdy x dąży od dołu 0, z sinus z x")?;
+    return Ok(());
+
+}
+
+
+#[test]
+fn binomial_mmultiscripts() -> Result<()> {
+    let expr = "<math><mmultiscripts><mi>C</mi><mi>m</mi><none/><mprescripts/><mi>n</mi><none/></mmultiscripts></math>";
+    test("pl", "SimpleSpeak", expr, "n po m")?;
+    return Ok(());
+
+}
+
+#[test]
+fn binomial_mmultiscripts_other() -> Result<()> {
+    let expr = "<math><mmultiscripts><mi>C</mi><mi>m</mi><none/><mprescripts/><none/><mi>n</mi></mmultiscripts></math>";
+    test("pl", "SimpleSpeak", expr, "n po m")?;
+    return Ok(());
+
+}
+
+#[test]
+fn binomial_subscript() -> Result<()> {  // C_{n,k}
+    let expr = "<math><msub><mi>C</mi><mrow><mi>n</mi><mo>,</mo><mi>m</mi></mrow></msub></math>";
+    test("pl", "SimpleSpeak", expr, "n po m")?;
+    return Ok(());
+
+}
+
+#[test]
+fn permutation_mmultiscripts() -> Result<()> {
+    let expr = "<math><mmultiscripts><mi>P</mi><mi>k</mi><none/><mprescripts/><mi>n</mi><none/></mmultiscripts></math>";
+    test("pl", "SimpleSpeak", expr, "k permutacji z n")?;
+    return Ok(());
+
+}
+
+#[test]
+fn permutation_mmultiscripts_sup() -> Result<()> {
+    let expr = "<math><mmultiscripts><mi>P</mi><mi>k</mi><none/><mprescripts/><none/><mi>n</mi></mmultiscripts></math>";
+    test("pl", "SimpleSpeak", expr, "k permutacji z n")?;
+    return Ok(());
+
+}
+
+#[test]
+fn permutation_msubsup() -> Result<()> {
+    let expr = "<math><msubsup><mi>P</mi><mi>k</mi><mi>n</mi></msubsup></math>";
+    test("pl", "SimpleSpeak", expr, "k permutacji z n")?;
+    return Ok(());
+
+}
+
+#[test]
+fn tensor_mmultiscripts() -> Result<()> {
+    let expr = "<math><mmultiscripts>
+            <mi>R</mi> <mi>i</mi><none/> <none/><mi>j</mi> <mi>k</mi><none/> <mi>l</mi><none/> 
+        </mmultiscripts></math>";
+    test_prefs("pl", "SimpleSpeak", vec![("Verbosity", "Verbose")], expr,
+            "wielka r z 4 prawe indeksy, indeks dolny i indeks górny j indeks dolny k indeks dolny l")?;
+    test_prefs("pl", "SimpleSpeak", vec![("Verbosity", "Medium")], expr,
+            "wielka r z 4 prawe indeksy, indeks dolny i indeks górny j indeks dolny k indeks dolny l")?;
+            return Ok(());
+
+}
+
+#[test]
+fn huge_num_mmultiscripts() -> Result<()> {
+    let expr = "<math><mmultiscripts>
+            <mi>R</mi> <mi>i</mi><none/> <none/><mi>j</mi> <mi>k</mi><none/> <mi>l</mi><none/> <mi>m</mi><none/>
+            <mprescripts/> <mi>I</mi><none/> <none/><mi>J</mi> <mi>K</mi><none/> <mi>L</mi><none/>
+        </mmultiscripts></math>";
+    test_prefs("pl", "SimpleSpeak", vec![("Verbosity", "Verbose")], expr,
+            "wielka r z 4 lewe indeksy, lewy indeks dolny wielka i, lewy indeks górny wielka j i kolejne lewe indeksy wielka k none wielka l none koniec lewych indeksów i z 5 prawe indeksy, indeks dolny i indeks górny j indeks dolny k indeks dolny l i kolejne indeksy m none koniec indeksów")?;
+            return Ok(());
+
+}
+
+#[test]
+fn prime() -> Result<()> {
+    let expr = "<math> <msup><mi>x</mi><mo >&#x2032;</mo></msup> </math>";
+    test("pl", "SimpleSpeak", expr, "x prim")?;
+    return Ok(());
+
+}
+
+#[test]
+fn given() -> Result<()> {
+    let expr = "<math><mi>P</mi><mo>(</mo><mi>A</mi><mo>|</mo><mi>B</mi><mo>)</mo></math>";
+    test("pl", "SimpleSpeak", expr, "wielka p; nawias otwierający, wielka a pod warunkiem wielka b; nawias zamykający")?;
+    test("pl", "ClearSpeak", expr,  "wielka p; nawias otwierający, wielka a pod warunkiem wielka b; nawias zamykający")?; // not good, but follows the spec
+    return Ok(());
+
+}
+
+#[test]
+fn simple_msubsup() -> Result<()> {
+    let expr = "<math>
+            <mstyle displaystyle='true' scriptlevel='0'>
+            <msubsup>
+                <mi>x</mi>
+                <mrow>
+                <mi>k</mi>
+                </mrow>
+                <mrow>
+                <mi>i</mi>
+                </mrow>
+            </msubsup>
+            </mstyle>
+        </math>";
+    test("pl", "ClearSpeak", expr, "x indeks dolny k, do potęgi i")?;
+    return Ok(());
+
+}
+
+#[test]
+fn non_simple_msubsup() -> Result<()> {
+  let expr = "<math><msubsup><mi>i</mi><mrow><mi>j</mi><mo>&#x2212;</mo><mn>2</mn></mrow><mi>k</mi></msubsup></math>";
+  test("pl", "SimpleSpeak", expr, "i indeks dolny j minus 2 koniec indeksu dolnego, do potęgi k")?;
+  test("pl", "ClearSpeak", expr, "i indeks dolny j minus 2 koniec indeksu dolnego, do potęgi k")?;
+  test_prefs("pl", "SimpleSpeak", vec![("Impairment", "LearningDisability")], expr,
+          "i indeks dolny j minus 2, do potęgi k")?;
+          return Ok(());
+
+}
+
+#[test]
+fn presentation_mathml_in_semantics() -> Result<()> {
+    let expr = "<math>
+        <semantics>
+            <annotation encoding='application/x-tex'>{\\displaystyle x_k^i}</annotation>
+            <annotation-xml encoding='MathML-Presentation'>
+                <msubsup>
+                    <mi>x</mi>
+                    <mrow>
+                    <mi>k</mi>
+                    </mrow>
+                    <mrow>
+                    <mi>i</mi>
+                    </mrow>
+                </msubsup>
+            </annotation-xml>
+        </semantics>
+    </math>";
+    test("pl", "ClearSpeak", expr, "x indeks dolny k, do potęgi i")?;
+    return Ok(());
+
+}
+
+#[test]
+fn roman_like_superscript_identifier_is_not_chemistry() -> Result<()> {
+    // Regression test for https://github.com/daisy/MathCAT/issues/528
+    let expr = "<math>
+        <mi>I</mi>
+        <mo>=</mo>
+        <mo>−</mo>
+        <mi>b</mi>
+        <mi>r</mi>
+        <mo>+</mo>
+        <msup>
+            <mi>z</mi>
+            <mi>I</mi>
+        </msup>
+    </math>";
+    test("pl", "ClearSpeak", expr, "wielka i równa się, minus b r plus z do potęgi wielka i")?;
+    Ok(())
+}
+
+#[test]
+fn roman_like_identifier_sequence_is_not_number() -> Result<()> {
+    // Regression test for https://github.com/daisy/MathCAT/issues/528
+    let expr = "<math>
+        <mi>C</mi>
+        <mo>+</mo>
+        <mi>I</mi>
+        <mo>+</mo>
+        <mi>X</mi>
+    </math>";
+    test("pl", "ClearSpeak", expr, "wielka c plus wielka i plus wielka x")?;
+    Ok(())
+}
+
+
+#[test]
+fn ignore_period() -> Result<()> {
+    // from https://en.wikipedia.org/wiki/Probability
+    let expr = "<math>
+    <semantics>
+    <annotation encoding='application/x-tex'>{\\displaystyle x_k^i}</annotation>
+    <annotation-xml encoding='MathML-Presentation'>
+      <mrow>
+        <mstyle displaystyle='true' scriptlevel='0'>
+          <mi>P</mi>
+          <mo stretchy='false'>(</mo>
+          <mi>A</mi>
+          <mrow>
+            <mstyle displaystyle='false' scriptlevel='0'>
+              <mtext>&nbsp;and&nbsp;</mtext>
+            </mstyle>
+          </mrow>
+          <mi>B</mi>
+          <mo stretchy='false'>)</mo>
+          <mo>=</mo>
+          <mi>P</mi>
+          <mo stretchy='false'>(</mo>
+          <mi>A</mi>
+          <mo>∩<!-- ∩ --></mo>
+          <mi>B</mi>
+          <mo stretchy='false'>)</mo>
+          <mo>=</mo>
+          <mi>P</mi>
+          <mo stretchy='false'>(</mo>
+          <mi>A</mi>
+          <mo stretchy='false'>)</mo>
+          <mi>P</mi>
+          <mo stretchy='false'>(</mo>
+          <mi>B</mi>
+          <mo stretchy='false'>)</mo>
+          <mo>.</mo>
+        </mstyle>
+      </mrow>
+      </annotation-xml>
+    </semantics>  
+  </math>";
+    test("pl", "SimpleSpeak", expr, "wielka p; nawias otwierający, wielka a and wielka b; nawias zamykający; równa się; wielka p; nawias otwierający, wielka a przecięcie wielka b; nawias zamykający; równa się; wielka p z wielka a, wielka p z wielka b")?;
+    return Ok(());
+
+}
+
+#[test]
+fn ignore_mtext_period() -> Result<()> {
+    let expr = "<math><mrow><mrow><mo>{</mo><mn>2</mn><mo>}</mo></mrow><mtext>.</mtext></mrow></math>";
+    test("pl", "SimpleSpeak", expr, "zbiór 2")?;
+    return Ok(());
+
+}
+
+#[test]
+fn ignore_comma() -> Result<()> {
+    // from https://en.wikipedia.org/wiki/Probability
+    let expr = "<math>
+    <mrow>
+      <mstyle displaystyle='true' scriptlevel='0'>
+        <mi>ϕ<!-- ϕ --></mi>
+        <mo stretchy='false'>(</mo>
+        <mi>x</mi>
+        <mo stretchy='false'>)</mo>
+        <mo>=</mo>
+        <mi>c</mi>
+        <msup>
+          <mi>e</mi>
+          <mrow>
+            <mo>−<!-- − --></mo>
+            <msup>
+              <mi>h</mi>
+              <mrow>
+                <mn>2</mn>
+              </mrow>
+            </msup>
+            <msup>
+              <mi>x</mi>
+              <mrow>
+                <mn>2</mn>
+              </mrow>
+            </msup>
+          </mrow>
+        </msup>
+        <mo>,</mo>
+      </mstyle>
+    </mrow>
+</math>";
+    test("pl", "SimpleSpeak", expr, "fi z x równa się; c razy, e do potęgi minus h do kwadratu, x do kwadratu")?;
+    return Ok(());
+
+}
+
+#[test]
+#[ignore] // issue #14
+fn ignore_period_and_space() -> Result<()> {
+    // from https://en.wikipedia.org/wiki/Probability
+    let expr = "<math>
+      <mrow>
+        <mstyle displaystyle='true' scriptlevel='0'>
+          <mi>P</mi>
+          <mo stretchy='false'>(</mo>
+          <mi>A</mi>
+          <mo>∣<!-- ∣ --></mo>
+          <mi>B</mi>
+          <mo stretchy='false'>)</mo>
+          <mo>=</mo>
+          <mrow>
+            <mfrac>
+              <mrow>
+                <mi>P</mi>
+                <mo stretchy='false'>(</mo>
+                <mi>A</mi>
+                <mo>∩<!-- ∩ --></mo>
+                <mi>B</mi>
+                <mo stretchy='false'>)</mo>
+              </mrow>
+              <mrow>
+                <mi>P</mi>
+                <mo stretchy='false'>(</mo>
+                <mi>B</mi>
+                <mo stretchy='false'>)</mo>
+              </mrow>
+            </mfrac>
+          </mrow>
+          <mo>.</mo>
+          <mspace width='thinmathspace'></mspace>
+        </mstyle>
+      </mrow>
+</math>";
+    test("pl", "ClearSpeak", expr, "cap p, open paren, cap eigh divides cap b, close paren; is equal to; the fraction with numerator; cap p, open paren, cap eigh intersection cap b; close paren; and denominator cap p of cap b")?;
+    return Ok(());
+
+}
+
+
+#[test]
+fn bug_199_2pi() -> Result<()> {
+  let expr = "<math>
+      <mrow>
+        <mo stretchy=\"false\" form=\"prefix\">[</mo>
+        <mspace width=\"0.333em\"></mspace>
+        <mn>0</mn>
+        <mspace width=\"0.333em\"></mspace>
+        <mo>,</mo>
+        <mspace width=\"0.333em\"></mspace>
+        <mn>2</mn>
+        <mi>π</mi>
+        <mspace width=\"0.333em\"></mspace>
+        <mo stretchy=\"false\" form=\"postfix\">)</mo>
+      </mrow>
+    </math>";
+  test("pl", "SimpleSpeak",expr, "przedział lewostronnie domknięty prawostronnie otwarty od 0 do 2 pi")?;
+  return Ok(());
+
+}
+
+#[test]
+fn caret_and_hat() -> Result<()> {
+  let expr = "<math><mi>x</mi><mo>^</mo><mn>2</mn><mo>+</mo><mover><mi>y</mi><mo>^</mo></mover></math>";
+  test("pl", "SimpleSpeak",expr, "x daszek 2 plus y daszek")?;
+  return Ok(());
+
+}
+
+#[test]
+fn dots() -> Result<()> {
+  let expr = "<math>
+         <mover><mi>x</mi><mo>.</mo></mover><mo>+</mo>
+         <mover><mi>x</mi><mo>..</mo></mover><mo>+</mo>
+         <mover><mi>x</mi><mo>...</mo></mover>
+    </math>";
+  test("pl", "SimpleSpeak",expr, "x kropka, plus x .., plus x ...")?;
+  return Ok(());
+}
+
+#[test]
+fn mn_with_space() -> Result<()> {
+  let expr = "<math><mn>1 234 567</mn></math>";
+  test_prefs("pl", "SimpleSpeak", vec![("DecimalSeparators", "."), ("BlockSeparators", " ,")], expr, "1234567")?;
+  return Ok(());
+
+}
+
+#[test]
+fn ignore_bold() -> Result<()> {
+  let expr = r#"<math>
+				<mi mathvariant="bold-italic">x</mi>
+				<mo>=</mo>
+				<mn>2</mn>
+				<mrow>
+				<mi>𝒔𝒊𝒏</mi>
+				<mo>&#x2061;</mo>
+				<mrow><mi mathvariant="bold-italic">t</mi></mrow>
+				</mrow>
+				<mo>-</mo>
+				<mn>1</mn>
+			</math>"#; 
+  test_prefs("pl", "SimpleSpeak", vec![("IgnoreBold", "false")],
+             expr, "pogrubione x równa się, 2 sinus z pogrubione t; minus 1")?;
+  test_prefs("pl", "SimpleSpeak", vec![("IgnoreBold", "true")],
+             expr, "pogrubione x równa się, 2 sinus z pogrubione t; minus 1")?;
+             return Ok(());
+
+}
+
+#[test]
+fn mn_with_block_and_decimal_separators() -> Result<()> {
+  let expr = "<math><mn>1,234.56</mn></math>";                                       // may want to change this for another language
+  test_prefs("pl", "SimpleSpeak", vec![("DecimalSeparators", "."), ("BlockSeparators", " ,")], expr, "1234.56")?;
+  return Ok(());
+
+}
+
+#[test]
+fn divergence() -> Result<()> {
+  let expr = "<math><mo>&#x2207;</mo><mo>&#xB7;</mo><mi mathvariant='normal'>F</mi></math>";                                       // may want to change this for another language
+  test_prefs("pl", "SimpleSpeak", vec![("Verbosity", "Terse")], expr, "dywergencja wielka f")?;
+  test_prefs("pl", "SimpleSpeak", vec![("Verbosity", "Verbose")], expr, "dywergencja z wielka f")?;
+  return Ok(());
+
+}
+
+#[test]
+fn curl() -> Result<()> {
+  let expr = "<math><mo>&#x2207;</mo><mo>&#xD7;</mo><mi mathvariant='normal'>F</mi></math>";          
+  // may want to change this for another language
+  test_prefs("pl", "SimpleSpeak", vec![("Verbosity", "Terse")], expr, "rotacja wielka f")?;
+  test_prefs("pl", "SimpleSpeak", vec![("Verbosity", "Verbose")], expr, "rotacja z wielka f")?;
+  return Ok(());
+
+}
+
+#[test]
+fn gradient() -> Result<()> {
+  let expr = "<math><mo>&#x2207;</mo><mi mathvariant='normal'>F</mi></math>";          
+  // may want to change this for another language
+  test_prefs("pl", "SimpleSpeak", vec![("Verbosity", "Terse")], expr, "gradient wielka f")?;
+  test_prefs("pl", "SimpleSpeak", vec![("Verbosity", "Verbose")], expr, "gradient z wielka f")?;
+  return Ok(());
+
+}
+
+#[test]
+fn literal_speak_perpendicular() -> Result<()> {
+  let expr = r#"<math data-latex='\vec{A} \perp \vec{B}' display='block'>
+  <mrow data-changed='added'>
+    <mover data-latex='\vec{A}'>
+      <mi data-latex='A'>A</mi>
+      <mo stretchy='false'>→</mo>
+    </mover>
+    <mo intent='perpendicular-to'>⊥</mo>
+    <mover data-latex='\vec{B}'>
+      <mi data-latex='B'>B</mi>
+      <mo stretchy='false'>→</mo>
+    </mover>
+  </mrow>
+ </math>"#; 
+  test("pl", "LiteralSpeak", expr, "wielka a strzałka w prawo, perpendicular to, wielka b strzałka w prawo")?;
+  return Ok(());
+
+}
+
+#[test]
+fn literal_speak_chars() -> Result<()> {
+  let expr = r#"<math>
+        <mfenced open="|" close="|">
+            <mrow>
+                <mi>x</mi><mo>&#xD7;</mo><mi>y</mi>
+                <mo>&#xB7;</mo>
+                <mi>z</mi><mo>/</mo><mn>2</mn>
+                <mo>+</mo>
+                <mi>a</mi><mo>&#x2225;</mo><mi>b</mi>
+                <mo>+</mo>
+                <mi>x</mi><mo>!</mo>
+            </mrow>
+        </mfenced>
+    </math>"#; 
+  test("pl", "LiteralSpeak", expr, "kreska pionowa; x krzyż, y kropka z ukośnik 2; plus a; podwójna pionowa kreska, b plus x wykrzyknik; kreska pionowa")?;
+  return Ok(());
+
+}
+
+#[test]
+fn literal_speak_with_name() -> Result<()> {
+  let expr = r#"<math intent='forced($x)'>
+      <mrow arg="x">
+        <mi>f</mi>
+        <mo data-changed='added'>&#x2061;</mo>
+        <mrow data-changed='added'>
+          <mo>(</mo>
+          <mrow data-changed='added'>
+            <mi>x</mi>
+            <mo>!</mo>
+          </mrow>
+          <mo>)</mo>
+        </mrow>
+      </mrow>
+    </math>"#;
+  test("pl", "LiteralSpeak", expr, "forced f, lewy nawias x wykrzyknik, prawy nawias")?;
+  return Ok(());
+
+}
+
+#[test]
+fn literal_speak_with_property() -> Result<()> {
+  let expr = r#"<math intent=':prefix'>
+      <mrow arg="x">
+        <mi>f</mi>
+        <mo data-changed='added'>&#x2061;</mo>
+        <mrow data-changed='added'>
+          <mo>(</mo>
+          <mrow data-changed='added'>
+            <mi>x</mi>
+            <mo>!</mo>
+          </mrow>
+          <mo>)</mo>
+        </mrow>
+      </mrow>
+    </math>"#; 
+  test("pl", "LiteralSpeak", expr, "f, lewy nawias x wykrzyknik, prawy nawias")?;
+  return Ok(());
+
+}
+
+#[test]
+fn literal_intent_property() -> Result<()> {
+  let expr = r#"<math data-latex='\vec{A} \perp \vec{B}' display='block'>
+  <mrow intent=":literal">
+    <mover data-latex='\vec{A}'>
+      <mi data-latex='A'>A</mi>
+      <mo stretchy='false'>→</mo>
+    </mover>
+    <mo intent='perpendicular-to'>⊥</mo>
+    <mover data-latex='\vec{B}'>
+      <mi data-latex='B'>B</mi>
+      <mo stretchy='false'>→</mo>
+    </mover>
+  </mrow>
+ </math>"#; 
+  test("pl", "SimpleSpeak", expr, "wielka a strzałka w prawo, perpendicular to, wielka b strzałka w prawo")?;
+  return Ok(());
+
+}
+
+#[test]
+fn literal_intent_property_with_name() -> Result<()> {
+  let expr = r#"<math intent='forced:literal($x)'>
+      <mrow arg="x">
+        <mi>f</mi>
+        <mo data-changed='added'>&#x2061;</mo>
+        <mrow data-changed='added'>
+          <mo>(</mo>
+          <mrow data-changed='added'>
+            <mi>x</mi>
+            <mo>!</mo>
+          </mrow>
+          <mo>)</mo>
+        </mrow>
+      </mrow>
+    </math>"#; 
+  test("pl", "SimpleSpeak", expr, "forced f, nawias otwierający, x wykrzyknik, nawias zamykający")?;
+  return Ok(());
+
+}

--- a/tests/Languages/pl/units.rs
+++ b/tests/Languages/pl/units.rs
@@ -1,0 +1,382 @@
+/// Tests for rules shared between various speech styles:
+/// *  modified var
+use crate::common::*;
+use anyhow::Result;
+
+// The basic layout of the tests is:
+// 1. Sweep through all the SI prefixes
+// 2. Sweep through each group of SI units
+//    a) with both singular and plural without prefixes
+//    b) with both singular and plural with one prefix
+// 3. Sweep through each group of units that don't take SI prefixes
+// These are broken into chunks so it is easier to see errors, when there are errors
+
+#[test]
+fn prefix_sweep() -> Result<()> {
+    let expr = r#"<math>
+        <mi intent=":unit">Qg</mi><mo>,</mo>
+        <mi intent=":unit">Rg</mi><mo>,</mo>
+        <mi intent=":unit">Yg</mi><mo>,</mo>
+        <mi intent=":unit">Zg</mi><mo>,</mo>
+        <mi intent=":unit">Eg</mi><mo>,</mo>
+        <mi intent=":unit">Pg</mi><mo>,</mo>
+        <mi intent=":unit">Tg</mi><mo>,</mo>
+        <mi intent=":unit">Gg</mi><mo>,</mo>
+        <mi intent=":unit">Mg</mi><mo>,</mo>
+        <mi intent=":unit">kg</mi><mo>,</mo>
+        <mi intent=":unit">hg</mi><mo>,</mo>
+        <mi intent=":unit">dag</mi><mo>,</mo>
+        <mi intent=":unit">dg</mi><mo>,</mo>
+        <mi intent=":unit">cg</mi><mo>,</mo>
+        <mi intent=":unit">mg</mi><mo>,</mo>
+        <mi intent=":unit">µg</mi><mo>,</mo>
+        <mi intent=":unit">ng</mi><mo>,</mo>
+        <mi intent=":unit">pg</mi><mo>,</mo>
+        <mi intent=":unit">fg</mi><mo>,</mo>
+        <mi intent=":unit">ag</mi><mo>,</mo>
+        <mi intent=":unit">zg</mi><mo>,</mo>
+        <mi intent=":unit">yg</mi><mo>,</mo>
+        <mi intent=":unit">rg</mi><mo>,</mo>
+        <mi intent=":unit">qg</mi>
+        </math>"#;
+    test("pl", "SimpleSpeak", expr, 
+        "kwetta-grams, przecinek; ronna-grams, przecinek; jotta-grams, przecinek; zetta-grams, przecinek; eksa-grams, przecinek; peta-grams, przecinek; tera-grams, przecinek; giga-grams, przecinek; mega-grams, przecinek; kilo-grams, przecinek; hekto-grams, przecinek; deka-grams, przecinek; decy-grams, przecinek; centy-grams, przecinek; mili-grams, przecinek; mikro-grams, przecinek; nano-grams, przecinek; piko-grams, przecinek; femto-grams, przecinek; atto-grams, przecinek; zepto-grams, przecinek; jokto-grams, przecinek; ronto-grams, przecinek; kwekto-grams")?;
+                return Ok(());
+
+}
+
+#[test]
+fn si_base() -> Result<()> {
+    let expr = r#"<math>
+        <mn>1</mn><mi intent=":unit">A</mi><mo>,</mo><mn>2</mn><mi intent=":unit">A</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">cd</mi><mo>,</mo><mn>2</mn><mi intent=":unit">cd</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">K</mi><mo>,</mo><mn>2</mn><mi intent=":unit">K</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">K</mi><mo>,</mo><mn>2</mn><mi intent=":unit">K</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">g</mi><mo>,</mo><mn>2</mn><mi intent=":unit">g</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">m</mi><mo>,</mo><mn>2</mn><mi intent=":unit">m</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">mol</mi><mo>,</mo><mn>2</mn><mi intent=":unit">mol</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">s</mi><mo>,</mo><mn>2</mn><mi intent=":unit">s</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">″</mi><mo>,</mo><mn>2</mn><mi intent=":unit">″</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">&quot;</mi><mo>,</mo><mn>2</mn><mi intent=":unit">&quot;</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">sec</mi><mo>,</mo><mn>2</mn><mi intent=":unit">sec</mi>
+    </math>"#;
+    test("pl", "SimpleSpeak", expr, 
+        "1 amper, przecinek; 2 ampers, przecinek; 1 kandela, przecinek; 2 kandelas, przecinek; 1 kelwin, przecinek; 2 kelwins, przecinek; 1 kelwin, przecinek; 2 kelwins, przecinek; 1 gram, przecinek; 2 grams, przecinek; 1 metr, przecinek; 2 metrs, przecinek, 1 mol, przecinek; 2 mols, przecinek; 1 sekunda, przecinek; 2 sekundas, przecinek; 1 sekunda, przecinek; 2 sekundas, przecinek; 1 sekunda, przecinek; 2 sekundas, przecinek; 1 sekunda, przecinek; 2 sekundas")?;
+                return Ok(());
+
+}
+
+#[test]
+fn si_base_with_prefixes() -> Result<()> {
+    let expr = r#"<math>
+        <mn>1</mn><mi intent=":unit">QA</mi><mo>,</mo><mn>2</mn><mi intent=":unit">RA</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">Ycd</mi><mo>,</mo><mn>2</mn><mi intent=":unit">Zcd</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">EK</mi><mo>,</mo><mn>2</mn><mi intent=":unit">PK</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">TK</mi><mo>,</mo><mn>2</mn><mi intent=":unit">GK</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">Mg</mi><mo>,</mo><mn>2</mn><mi intent=":unit">kg</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">hm</mi><mo>,</mo><mn>2</mn><mi intent=":unit">dam</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">dmol</mi><mo>,</mo><mn>2</mn><mi intent=":unit">cmol</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">ms</mi><mo>,</mo><mn>2</mn><mi intent=":unit">µs</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">nsec</mi><mo>,</mo><mn>2</mn><mi intent=":unit">psec</mi>
+    </math>"#;
+    test("pl", "SimpleSpeak", expr, 
+        "1 kwetta-amper, przecinek; 2 ronna-ampers, przecinek; 1 jotta-kandela, przecinek; 2 zetta-kandelas; przecinek; 1 eksa-kelwin, przecinek; 2 peta-kelwins, przecinek; 1 tera-kelwin, przecinek; 2 giga-kelwins, przecinek; 1 mega-gram, przecinek; 2 kilo-grams, przecinek; 1 hekto-metr, przecinek; 2 deka-metrs, przecinek; 1 decy-mol, przecinek; 2 centy-mols, przecinek; 1 mili-sekunda, przecinek; 2 mikro-sekundas; przecinek; 1 nano-sekunda, przecinek; 2 piko-sekundas")?;
+                return Ok(());
+
+}
+
+
+#[test]
+fn si_derived_1() -> Result<()> {
+    let expr = r#"<math>
+        <mn>1</mn><mi intent=":unit">Bq</mi><mo>,</mo><mn>2</mn><mi intent=":unit">Bq</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">C</mi><mo>,</mo><mn>2</mn><mi intent=":unit">C</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">°C</mi><mo>,</mo><mn>2</mn><mi intent=":unit">°C</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">℃</mi><mo>,</mo><mn>2</mn><mi intent=":unit">℃</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">F</mi><mo>,</mo><mn>2</mn><mi intent=":unit">F</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">Gy</mi><mo>,</mo><mn>2</mn><mi intent=":unit">Gy</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">H</mi><mo>,</mo><mn>2</mn><mi intent=":unit">H</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">Hz</mi><mo>,</mo><mn>2</mn><mi intent=":unit">Hz</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">J</mi><mo>,</mo><mn>2</mn><mi intent=":unit">J</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">kat</mi><mo>,</mo><mn>2</mn><mi intent=":unit">kat</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">lm</mi><mo>,</mo><mn>2</mn><mi intent=":unit">lm</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">lx</mi><mo>,</mo><mn>2</mn><mi intent=":unit">lx</mi>
+    </math>"#;
+    test("pl", "SimpleSpeak", expr, 
+        "1 bekerel, przecinek; 2 bekerels, przecinek; 1 kulomb, przecinek; 2 kulombs, przecinek; 1 stopień Celsjusza, przecinek; 2 stopnie Celsjusza, przecinek; 1 stopień Celsjusza, przecinek; 2 stopnie Celsjusza, przecinek; 1 farad, przecinek; 2 farads, przecinek; 1 grej, przecinek; 2 grejs, przecinek; 1 henr, przecinek; 2 henry, przecinek; 1 herce, przecinek; 2 herces, przecinek; 1 dżul, przecinek; 2 dżuls, przecinek; 1 katal, przecinek; 2 katals, przecinek; 1 lumen, przecinek; 2 lumens, przecinek; 1 luks, przecinek; 2 luksy")?;
+                return Ok(());
+
+}
+
+#[test]
+fn si_derived_1_with_prefixes() -> Result<()> {
+    let expr = r#"<math>
+        <mn>1</mn><mi intent=":unit">QBq</mi><mo>,</mo><mn>2</mn><mi intent=":unit">RBq</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">YC</mi><mo>,</mo><mn>2</mn><mi intent=":unit">ZC</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">EF</mi><mo>,</mo><mn>2</mn><mi intent=":unit">PF</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">TGy</mi><mo>,</mo><mn>2</mn><mi intent=":unit">GGy</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">MH</mi><mo>,</mo><mn>2</mn><mi intent=":unit">kH</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">daHz</mi><mo>,</mo><mn>2</mn><mi intent=":unit">dHz</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">cJ</mi><mo>,</mo><mn>2</mn><mi intent=":unit">mJ</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">µkat</mi><mo>,</mo><mn>2</mn><mi intent=":unit">nkat</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">plm</mi><mo>,</mo><mn>2</mn><mi intent=":unit">flm</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">alx</mi><mo>,</mo><mn>2</mn><mi intent=":unit">zlx</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">m°C</mi><mo>,</mo><mn>2</mn><mi intent=":unit">µ°C</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">p℃</mi><mo>,</mo><mn>2</mn><mi intent=":unit">n℃</mi>
+    </math>"#;
+    test("pl", "SimpleSpeak", expr, 
+        "1 kwetta-bekerel, przecinek; 2 ronna-bekerels; przecinek; 1 jotta-kulomb, przecinek; 2 zetta-kulombs; przecinek; 1 eksa-farad, przecinek; 2 peta-farads, przecinek; 1 tera-grej, przecinek; 2 giga-grejs, przecinek; 1 mega-henr, przecinek; 2 kilo-henry, przecinek; 1 deka-herce, przecinek; 2 decy-herces, przecinek; 1 centy-dżul, przecinek; 2 mili-dżuls, przecinek; 1 mikro-katal, przecinek; 2 nano-katals, przecinek; 1 piko-lumen, przecinek; 2 femto-lumens, przecinek; 1 atto-luks, przecinek; 2 zepto-luksy, przecinek; 1 mili-stopień Celsjusza; przecinek; 2 mikro-stopnie Celsjusza; przecinek; 1 piko-stopień Celsjusza; przecinek; 2 nano-stopnie Celsjusza")?;
+                return Ok(());
+
+}
+
+#[test]
+fn si_derived_2() -> Result<()> {
+    let expr = r#"<math>
+        <mn>1</mn><mi intent=":unit">N</mi><mo>,</mo><mn>2</mn><mi intent=":unit">N</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">Ω</mi><mo>,</mo><mn>2</mn><mi intent=":unit">Ω</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">Ω</mi><mo>,</mo><mn>2</mn><mi intent=":unit">Ω</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">Pa</mi><mo>,</mo><mn>2</mn><mi intent=":unit">Pa</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">S</mi><mo>,</mo><mn>2</mn><mi intent=":unit">S</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">Sv</mi><mo>,</mo><mn>2</mn><mi intent=":unit">Sv</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">T</mi><mo>,</mo><mn>2</mn><mi intent=":unit">T</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">V</mi><mo>,</mo><mn>2</mn><mi intent=":unit">V</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">W</mi><mo>,</mo><mn>2</mn><mi intent=":unit">W</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">Wb</mi><mo>,</mo><mn>2</mn><mi intent=":unit">Wb</mi>
+    </math>"#;
+    test("pl", "SimpleSpeak", expr, 
+        "1 niuton, przecinek; 2 niutons, przecinek, 1 om przecinek; 2 oms, przecinek, 1 om przecinek; 2 oms, przecinek; 1 paskal, przecinek; 2 paskals, przecinek; 1 siemens, przecinek; 2 siemens, przecinek; 1 siwert, przecinek; 2 siwerts, przecinek; 1 tesla, przecinek; 2 teslas, przecinek; 1 wolt, przecinek; 2 wolty, przecinek, 1 wat, przecinek; 2 waty, przecinek; 1 weber, przecinek; 2 webers")?;
+                return Ok(());
+
+}
+
+#[test]
+fn si_derived_2_with_prefixes() -> Result<()> {
+    let expr = r#"<math>
+        <mn>1</mn><mi intent=":unit">qN</mi><mo>,</mo><mn>2</mn><mi intent=":unit">rN</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">yΩ</mi><mo>,</mo><mn>2</mn><mi intent=":unit">zΩ</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">aΩ</mi><mo>,</mo><mn>2</mn><mi intent=":unit">fΩ</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">pPa</mi><mo>,</mo><mn>2</mn><mi intent=":unit">nPa</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">µS</mi><mo>,</mo><mn>2</mn><mi intent=":unit">mS</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">cSv</mi><mo>,</mo><mn>2</mn><mi intent=":unit">dSv</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">daT</mi><mo>,</mo><mn>2</mn><mi intent=":unit">hT</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">kV</mi><mo>,</mo><mn>2</mn><mi intent=":unit">MV</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">GW</mi><mo>,</mo><mn>2</mn><mi intent=":unit">TW</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">PWb</mi><mo>,</mo><mn>2</mn><mi intent=":unit">EWb</mi>
+    </math>"#;
+    test("pl", "SimpleSpeak", expr, 
+        "1 kwekto-niuton, przecinek; 2 ronto-niutons; przecinek; 1 jokto-om, przecinek; 2 zepto-oms, przecinek; 1 atto-om, przecinek; 2 femto-oms, przecinek; 1 piko-paskal, przecinek; 2 nano-paskals, przecinek; 1 mikro-siemens, przecinek; 2 mili-siemens, przecinek; 1 centy-siwert, przecinek; 2 decy-siwerts, przecinek; 1 deka-tesla, przecinek; 2 hekto-teslas, przecinek; 1 kilo-wolt, przecinek; 2 mega-wolty, przecinek; 1 giga-wat, przecinek; 2 tera-waty, przecinek; 1 peta-weber, przecinek; 2 eksa-webers")?;
+                return Ok(());
+
+}
+
+
+#[test]
+fn si_accepted() -> Result<()> {
+    let expr = r#"<math>
+        <mn>1</mn><mi intent=":unit">l</mi><mo>,</mo><mn>2</mn><mi intent=":unit">l</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">L</mi><mo>,</mo><mn>2</mn><mi intent=":unit">L</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">ℓ</mi><mo>,</mo><mn>2</mn><mi intent=":unit">ℓ</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">t</mi><mo>,</mo><mn>2</mn><mi intent=":unit">t</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">Da</mi><mo>,</mo><mn>2</mn><mi intent=":unit">Da</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">Np</mi><mo>,</mo><mn>2</mn><mi intent=":unit">Np</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">u</mi><mo>,</mo><mn>2</mn><mi intent=":unit">u</mi><mo>,</mo> 
+        <mn>1</mn><mi intent=":unit">eV</mi><mo>,</mo><mn>2</mn><mi intent=":unit">eV</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">rad</mi><mo>,</mo><mn>2</mn><mi intent=":unit">rad</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">sr</mi><mo>,</mo><mn>2</mn><mi intent=":unit">sr</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">a</mi><mo>,</mo><mn>2</mn><mi intent=":unit">a</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">as</mi><mo>,</mo><mn>2</mn><mi intent=":unit">as</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">b</mi><mo>,</mo><mn>2</mn><mi intent=":unit">b</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">B</mi><mo>,</mo><mn>2</mn><mi intent=":unit">B</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">Bd</mi><mo>,</mo><mn>2</mn><mi intent=":unit">Bd</mi>
+    </math>"#;
+    test("pl", "SimpleSpeak", expr, 
+        "1 litr, przecinek; 2 litrs, przecinek; 1 litr, przecinek; 2 litrs, przecinek; 1 litr, przecinek; 2 litrs, przecinek; 1 tona, przecinek; 2 tonas, przecinek; 1 dalton, przecinek; 2 daltons, przecinek; 1 neper, przecinek; 2 nepers, przecinek; 1 jednostka masy atomowej, przecinek; 2 jednostka masy atomowejs; przecinek; 1 elektronowolt, przecinek; 2 elektronowolts, przecinek; 1 radian, przecinek; 2 radians, przecinek; 1 steradian, przecinek; 2 steradians, przecinek, 1 rok, przecinek; 2 roks, przecinek; 1 sekunda łuku, przecinek; 2 sekunda łukus, przecinek, 1 bit, przecinek; 2 bits, przecinek; 1 bajt, przecinek; 2 bajts, przecinek, 1 bod, przecinek; 2 bods")?;
+                return Ok(());
+
+}
+
+#[test]
+fn si_accepted_with_prefixes() -> Result<()> {
+    let expr = r#"<math>
+        <mn>1</mn><mi intent=":unit">Ql</mi><mo>,</mo><mn>2</mn><mi intent=":unit">Rl</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">YL</mi><mo>,</mo><mn>2</mn><mi intent=":unit">ZL</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">Eℓ</mi><mo>,</mo><mn>2</mn><mi intent=":unit">Pℓ</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">Tt</mi><mo>,</mo><mn>2</mn><mi intent=":unit">Gt</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">MDa</mi><mo>,</mo><mn>2</mn><mi intent=":unit">kDa</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">dNp</mi><mo>,</mo><mn>2</mn><mi intent=":unit">cNp</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">hu</mi><mo>,</mo><mn>2</mn><mi intent=":unit">dau</mi><mo>,</mo> 
+        <mn>1</mn><mi intent=":unit">meV</mi><mo>,</mo><mn>2</mn><mi intent=":unit">µeV</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">nrad</mi><mo>,</mo><mn>2</mn><mi intent=":unit">prad</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">fsr</mi><mo>,</mo><mn>2</mn><mi intent=":unit">asr</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">Ga</mi><mo>,</mo><mn>2</mn><mi intent=":unit">Ma</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">zas</mi><mo>,</mo><mn>2</mn><mi intent=":unit">yas</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">kb</mi><mo>,</mo><mn>2</mn><mi intent=":unit">Mb</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">GB</mi><mo>,</mo><mn>2</mn><mi intent=":unit">TB</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">TBd</mi><mo>,</mo><mn>2</mn><mi intent=":unit">EBd</mi>
+    </math>"#;
+    test("pl", "SimpleSpeak", expr, 
+        "1 kwetta-litr, przecinek; 2 ronna-litrs, przecinek; 1 jotta-litr, przecinek; 2 zetta-litrs, przecinek; 1 eksa-litr, przecinek; 2 peta-litrs, przecinek; 1 tera-tona, przecinek; 2 giga-tonas, przecinek; 1 mega-dalton, przecinek; 2 kilo-daltons, przecinek; 1 decy-neper, przecinek; 2 centy-nepers, przecinek; 1, hekto-jednostka masy atomowej; przecinek; 2, deka-jednostka masy atomowejs; przecinek; 1 mili-elektronowolt; przecinek; 2 mikro-elektronowolts; przecinek; 1 nano-radian, przecinek; 2 piko-radians, przecinek; 1 femto-steradian, przecinek; 2 atto-steradians; przecinek; 1 giga-rok, przecinek; 2 mega-roks, przecinek; 1 zepto-sekunda łuku; przecinek; 2 jokto-sekunda łukus; przecinek; 1 kilo-bit, przecinek; 2 mega-bits, przecinek; 1 giga-bajt, przecinek; 2 tera-bajts, przecinek; 1 tera-bod, przecinek; 2 eksa-bods")?;
+                return Ok(());
+
+}
+
+#[test]
+fn without_prefix_time() -> Result<()> {
+    let expr = r#"<math>
+        <mn>1</mn><mi intent=":unit">″</mi><mo>,</mo><mn>2</mn><mi intent=":unit">″</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">&quot;</mi><mo>,</mo><mn>2</mn><mi intent=":unit">&quot;</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">′</mi><mo>,</mo><mn>2</mn><mi intent=":unit">′</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">'</mi><mo>,</mo><mn>2</mn><mi intent=":unit">'</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">min</mi><mo>,</mo><mn>2</mn><mi intent=":unit">min</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">h</mi><mo>,</mo><mn>2</mn><mi intent=":unit">h</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">hr</mi><mo>,</mo><mn>2</mn><mi intent=":unit">hr</mi><mo>,</mo> 
+        <mn>1</mn><mi intent=":unit">Hr</mi><mo>,</mo><mn>2</mn><mi intent=":unit">Hr</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">d</mi><mo>,</mo><mn>2</mn><mi intent=":unit">d</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">dy</mi><mo>,</mo><mn>2</mn><mi intent=":unit">dy</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">w</mi><mo>,</mo><mn>2</mn><mi intent=":unit">w</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">wk</mi><mo>,</mo><mn>2</mn><mi intent=":unit">wk</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">y</mi><mo>,</mo><mn>2</mn><mi intent=":unit">y</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">yr</mi><mo>,</mo><mn>2</mn><mi intent=":unit">yr</mi>
+    </math>"#;
+    test("pl", "SimpleSpeak", expr, 
+        "1 sekunda, przecinek; 2 sekundas, przecinek; 1 sekunda, przecinek; 2 sekundas, przecinek; 1 minuta, przecinek; 2 minutas, przecinek; 1 minuta, przecinek; 2 minutas, przecinek; 1 minuta, przecinek; 2 minutas, przecinek; 1 godzina, przecinek; 2 godzinas, przecinek; 1 godzina, przecinek; 2 godzinas, przecinek; 1 godzina, przecinek; 2 godzinas, przecinek; 1 dzień, przecinek; 2 dzieńs, przecinek; 1 dzień, przecinek; 2 dzieńs, przecinek; 1 tydzień, przecinek; 2 tydzieńs, przecinek; 1 tydzień, przecinek; 2 tydzieńs, przecinek, 1 rok, przecinek; 2 roks, przecinek, 1 rok, przecinek; 2 roks")?;
+                return Ok(());
+
+}
+
+#[test]
+fn without_prefix_angles() -> Result<()> {
+    let expr = r#"<math>
+        <mn>1</mn><mi intent=":unit">°</mi><mo>,</mo><mn>2</mn><mi intent=":unit">°</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">deg</mi><mo>,</mo><mn>2</mn><mi intent=":unit">deg</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">arcmin</mi><mo>,</mo><mn>2</mn><mi intent=":unit">arcmin</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">amin</mi><mo>,</mo><mn>2</mn><mi intent=":unit">amin</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">am</mi><mo>,</mo><mn>2</mn><mi intent=":unit">am</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">MOA</mi><mo>,</mo><mn>2</mn><mi intent=":unit">MOA</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">arcsec</mi><mo>,</mo><mn>2</mn><mi intent=":unit">arcsec</mi><mo>,</mo> 
+        <mn>1</mn><mi intent=":unit">asec</mi><mo>,</mo><mn>2</mn><mi intent=":unit">asec</mi>
+    </math>"#;
+    test("pl", "SimpleSpeak", expr, 
+        "1 stopień, przecinek; 2 stopnie, przecinek; 1 stopień, przecinek; 2 stopnie, przecinek; 1 minuta łuku, przecinek; 2 minuta łukus, przecinek; 1 minuta łuku, przecinek; 2 minuta łukus, przecinek; 1 minuta łuku, przecinek; 2 minuta łukus, przecinek; 1 minuta łuku, przecinek; 2 minuta łukus, przecinek; 1 sekunda łuku, przecinek; 2 sekunda łukus, przecinek; 1 sekunda łuku, przecinek; 2 sekunda łukus")?;
+                return Ok(());
+
+}
+
+#[test]
+fn without_prefix_distance() -> Result<()> {
+    let expr = r#"<math>
+        <mn>1</mn><mi intent=":unit">au</mi><mo>,</mo><mn>2</mn><mi intent=":unit">au</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">ltyr</mi><mo>,</mo><mn>2</mn><mi intent=":unit">ltyr</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">pc</mi><mo>,</mo><mn>2</mn><mi intent=":unit">pc</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">Å</mi><mo>,</mo><mn>2</mn><mi intent=":unit">Å</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">Å</mi><mo>,</mo><mn>2</mn><mi intent=":unit">Å</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">fm</mi><mo>,</mo><mn>2</mn><mi intent=":unit">fm</mi>
+    </math>"#;
+    test("pl", "SimpleSpeak", expr, 
+        "1 jednostka astronomiczna, przecinek; 2 jednostka astronomicznas; przecinek; 1 rok świetlny, przecinek; 2 rok świetlnys, przecinek; 1 parsek, przecinek; 2 parseks, przecinek; 1 angstrem, przecinek; 2 angstrems, przecinek; 1 angstrem, przecinek; 2 angstrems, przecinek; 1 fermi, przecinek; 2 fermis")?;
+                return Ok(());
+
+}
+
+#[test]
+fn without_prefix_other() -> Result<()> {
+    let expr = r#"<math>
+        <mn>1</mn><mi intent=":unit">ha</mi><mo>,</mo><mn>2</mn><mi intent=":unit">ha</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">dB</mi><mo>,</mo><mn>2</mn><mi intent=":unit">dB</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">atm</mi><mo>,</mo><mn>2</mn><mi intent=":unit">atm</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">amu</mi><mo>,</mo><mn>2</mn><mi intent=":unit">amu</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">bar</mi><mo>,</mo><mn>2</mn><mi intent=":unit">bar</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">cal</mi><mo>,</mo><mn>2</mn><mi intent=":unit">cal</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">Ci</mi><mo>,</mo><mn>2</mn><mi intent=":unit">Ci</mi><mo>,</mo> 
+        <mn>1</mn><mi intent=":unit">grad</mi><mo>,</mo><mn>2</mn><mi intent=":unit">grad</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">M</mi><mo>,</mo><mn>2</mn><mi intent=":unit">M</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">R</mi><mo>,</mo><mn>2</mn><mi intent=":unit">R</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">rpm</mi><mo>,</mo><mn>2</mn><mi intent=":unit">rpm</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">fl dr</mi><mo>,</mo><mn>2</mn><mi intent=":unit">fl dr</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">℧</mi><mo>,</mo><mn>2</mn><mi intent=":unit">℧</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">dyn</mi><mo>,</mo><mn>2</mn><mi intent=":unit">dyn</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">erg</mi><mo>,</mo><mn>2</mn><mi intent=":unit">erg</mi>
+    </math>"#;
+    test("pl", "SimpleSpeak", expr, 
+        "1 hektar, przecinek; 2 hektars, przecinek; 1 decybel, przecinek; 2 decybels, przecinek; 1 atmosfera, przecinek; 2 atmosferas, przecinek; 1 jednostka masy atomowej, przecinek; 2 jednostka masy atomowejs; przecinek, 1 bar, przecinek; 2 bars, przecinek; 1 kaloria, przecinek; 2 kalorias, przecinek; 1 kiur, przecinek; 2 kiurs, przecinek; 1 grad, przecinek; 2 grads, przecinek; 1 molowy, przecinek; 2 molowys, przecinek; 1 rentgen, przecinek; 2 rentgens, przecinek; 1 obrót na minutę, przecinek; 2 obroty na minutę, przecinek; 1 drachma płynu, przecinek; 2 drachma płynus, przecinek; 1 M h o, przecinek; 2 M h os, przecinek; 1 dyna, przecinek; 2 dynas, przecinek, 1 erg, przecinek; 2 ergs")?;
+                return Ok(());
+
+}
+
+#[test]
+fn without_prefix_powers_of_2() -> Result<()> {
+    let expr = r#"<math>
+        <mn>1</mn><mi intent=":unit">Kib</mi><mo>,</mo><mn>2</mn><mi intent=":unit">Kib</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">Mib</mi><mo>,</mo><mn>2</mn><mi intent=":unit">Mib</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">Gib</mi><mo>,</mo><mn>2</mn><mi intent=":unit">Gib</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">Tib</mi><mo>,</mo><mn>2</mn><mi intent=":unit">Tib</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">Pib</mi><mo>,</mo><mn>2</mn><mi intent=":unit">Pib</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">Eib</mi><mo>,</mo><mn>2</mn><mi intent=":unit">Eib</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">Zib</mi><mo>,</mo><mn>2</mn><mi intent=":unit">Zib</mi><mo>,</mo> 
+        <mn>1</mn><mi intent=":unit">Yib</mi><mo>,</mo><mn>2</mn><mi intent=":unit">Yib</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">KiB</mi><mo>,</mo><mn>2</mn><mi intent=":unit">KiB</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">MiB</mi><mo>,</mo><mn>2</mn><mi intent=":unit">MiB</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">GiB</mi><mo>,</mo><mn>2</mn><mi intent=":unit">GiB</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">TiB</mi><mo>,</mo><mn>2</mn><mi intent=":unit">TiB</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">PiB</mi><mo>,</mo><mn>2</mn><mi intent=":unit">PiB</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">EiB</mi><mo>,</mo><mn>2</mn><mi intent=":unit">EiB</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">ZiB</mi><mo>,</mo><mn>2</mn><mi intent=":unit">ZiB</mi><mo>,</mo> 
+        <mn>1</mn><mi intent=":unit">YiB</mi><mo>,</mo><mn>2</mn><mi intent=":unit">YiB</mi>
+    </math>"#;
+    test("pl", "SimpleSpeak", expr, 
+        "1 kibibit, przecinek; 2 kibibits, przecinek; 1 mebibit, przecinek; 2 mebibits, przecinek; 1 gibibit, przecinek; 2 gibibits, przecinek; 1 tebibit, przecinek; 2 tebibits, przecinek; 1 pebibit, przecinek; 2 pebibits, przecinek; 1 eksbibit, przecinek; 2 eksbibits, przecinek; 1 zebibit, przecinek; 2 zebibits, przecinek; 1 jobibit, przecinek; 2 jobibits, przecinek; 1 kibibajt, przecinek; 2 kibibajts, przecinek; 1 mebibajt, przecinek; 2 mebibajts, przecinek; 1 gibibajt, przecinek; 2 gibibajts, przecinek; 1 tebibajt, przecinek; 2 tebibajts, przecinek; 1 pebibajt, przecinek; 2 pebibajts, przecinek; 1 eksbibajt, przecinek; 2 eksbibajts, przecinek; 1 zebibajt, przecinek; 2 zebibajts, przecinek; 1 jobibajt, przecinek; 2 jobibajts")?;
+                return Ok(());
+
+}
+
+
+#[test]
+fn si_other_numbers() -> Result<()> {
+    let expr = r#"<math><mn>1.0</mn><mi intent=":unit">l</mi><mo>,</mo>
+                            <mn>2.0</mn><mo>&#xA0;</mo><mi intent=":unit">m</mi><mo>,</mo>
+                            <mi>x</mi><mo>&#xA0;</mo><mi intent=":unit">ms</mi><mo>,</mo>
+                            <mi>y</mi><mi intent=":unit">µs</mi><mo>,</mo>
+                            <mi intent=":unit">dag</mi><mo>,</mo>
+                            <mn>1235</mn><mi intent=":unit">daN</mi><mo>,</mo>
+                            <mn>2.5</mn><mi intent=":unit">&#xB5;sec</mi><mo>,</mo>
+                            <mn>32.34</mn><mi intent=":unit">mol</mi></math>"#;
+    test_prefs("pl", "SimpleSpeak", vec![("Verbosity", "Terse")], expr,
+            "10 l przecinek, 20 m przecinek; x mili-sekundas; przecinek; y mikro-sekundas; przecinek; deka-grams, przecinek; 1235 deka-niutons; przecinek; 25 mikro-sekundas; przecinek; 3234 mols")?;
+    test_prefs("pl", "ClearSpeak", vec![("Verbosity", "Medium")], expr,
+            "10 litr, przecinek; 20 metrs, przecinek; x mili-sekundas; przecinek; y mikro-sekundas; przecinek; deka-grams, przecinek; 1235 deka-niutons; przecinek; 25 mikro-sekundas; przecinek; 3234 mols")?;
+    test_prefs("pl", "SimpleSpeak", vec![("Verbosity", "Verbose")], expr,
+            "10 litr, przecinek; 20 metrs, przecinek; x mili-sekundas; przecinek; y mikro-sekundas; przecinek; deka-grams, przecinek; 1235 deka-niutons; przecinek; 25 mikro-sekundas; przecinek; 3234 mols")?;
+                    return Ok(());
+
+}
+
+
+#[test]
+fn test_mtext_inference() -> Result<()> {
+    let expr = r#"<math><mo>[</mo>
+                <mn>1</mn><mtext>t</mtext><mo>,</mo>
+                <mn>2</mn><mtext>PA</mtext><mo>,</mo>
+                <mn>3</mn><mtext>Pa</mtext><mo>,</mo>
+                <mn>4.5</mn><mtext>mT</mtext>
+            <mo>]</mo></math>"#;
+    test("pl", "SimpleSpeak", expr, 
+        "nawias kwadratowy otwierający; 1 tona, przecinek; 2 peta-ampers, przecinek; 3 paskals, przecinek; 45 mili-teslas; nawias kwadratowy zamykający")?;
+                return Ok(());
+
+}
+
+    #[test]
+    fn infer_unit() -> Result<()> {
+        let expr = r#"<math>
+            <mn>3</mn><mi mathvariant="normal">m</mi><mo>,</mo>
+            <mn>1</mn><mi>km</mi><mo>,</mo>
+            <mn>3</mn><mtext>m</mtext><mo>,</mo>
+            <mfrac><mn>3</mn><mn>10</mn></mfrac><mi mathvariant="normal">F</mi><mo>,</mo>
+            <msub><mi>m</mi><mi>min</mi></msub>
+            </math>"#;
+        test("pl", "SimpleSpeak", expr, 
+            "3 metrs, przecinek; 1 kilo-metr, przecinek; 3 metrs, przecinek; 3 dziesiąte farads, przecinek; m indeks dolny minimum koniec indeksu dolnego")?;
+            return Ok(());
+
+    }


### PR DESCRIPTION
Follow-up to #623. After the Polish language pack was merged you asked whether I could add more tests (Polish had 56, most languages have 500+). This brings Polish to **605 tests**.

## What's here

**1. Tests mirrored from the English suite (56 -> 599).**
Structure mirrors `tests/Languages/en/` (ClearSpeak, SimpleSpeak, shared, definitions, units, chemistry, alphabets, mtable). Expected speech strings were **captured from the actual engine output** with the Polish rules and then verified as correct Polish, rather than translated by hand.

A few cases keep engine-level behavior that is identical in English and Polish (an intent without explicit fixity; the `root` intent without an index, which errors in both languages) — these are annotated in-place, and one such tuple is skipped rather than asserting a core-level quirk.

**2. Fix: Polish plural declension in multi-line equations (599 -> 605).**
Polish declines a counted noun by number: 1 -> singular, 2-4 (except 12-14) -> nominative plural, otherwise genitive plural. The multi-line rules were copied from English and appended an `s` suffix, producing wrong forms like *"2 równanies"* or *"5 równania"*. Fixed in both speech paths:
- `SharedRules/general.yaml` (SimpleSpeak)
- `ClearSpeak_Rules.yaml` (ClearSpeak — all labels: Case/Line/Constraint/Equation/Row/Step)

Now: **1 równanie / 2 równania / 5 równań** (and 12 równań, 22 równania). Polish-specific tests cover singular, paucal, genitive plural and the 12-14 exception in both styles.

## Scope
All changes are limited to `tests/Languages/pl/` and `Rules/Languages/pl/`. **Engine core (`src/`) is untouched.** `cargo test --test languages Languages::pl` -> 605 passed, 0 failed, 1 ignored (the ignored one mirrors en's `#[ignore] // issue #14`).