### PR TITLE
Translate German absolute-value ending

### DIFF
--- a/Rules/Languages/de/ClearSpeak_Rules.yaml
+++ b/Rules/Languages/de/ClearSpeak_Rules.yaml
@@ -476,7 +476,7 @@
       if: "$ClearSpeak_AbsoluteValue = 'AbsEnd'"
       then:
       - pause: short
-      - T: "end"
+      - T: "ende"
       - x: "$WordToSay"
   - pause: short
 

--- a/tests/Languages/de/ClearSpeak/symbols_and_adornments.rs
+++ b/tests/Languages/de/ClearSpeak/symbols_and_adornments.rs
@@ -40,6 +40,16 @@ fn quotation_mark() -> Result<()> {
 }
 
 #[test]
+fn absolute_value_end_regression() -> Result<()> {
+    let expr = "<math><mrow><mo>|</mo><mrow><mi>x</mi><mo>+</mo><mn>1</mn></mrow><mo>|</mo></mrow></math>";
+    test_prefs("de", "ClearSpeak", vec![
+        ("Verbosity", "Terse"),
+        ("ClearSpeak_AbsoluteValue", "AbsEnd"),
+    ], expr, "Betrag von x plus 1, ende Betrag")?;
+    Ok(())
+}
+
+#[test]
 fn ellipses_auto_start() -> Result<()> {
     let expr = "<math>
             <mi>…</mi><mo>,</mo>


### PR DESCRIPTION
The German word for "end" is "ende".