### PR TITLE
fix plural forms of physical units in German

### DIFF
--- a/Rules/Languages/de/SharedRules/general.yaml
+++ b/Rules/Languages/de/SharedRules/general.yaml
@@ -300,7 +300,7 @@
           # HACK: '\uF8FE' is used internally for the concatenation char by 'ct' -- this gets the prefix concatenated to the base
           then: [x: "$Word"]
         - else_if: "DefinitionValue($Word, 'Speech', 'PluralForms') != ''"
-          then: [x: "DefinitionValue($Word, 'Speech', 'PluralForms')"]
+          then: [x: "DefinitionValue($Word, 'Speech', 'PluralForms')", ct: " "]
           else: [x: "$Word", ct: "s"]
       else:
       - x: "$Prefix"
@@ -310,7 +310,7 @@
           # HACK: '\uF8FE' is used internally for the concatenation char by 'ct' -- this gets the prefix concatenated to the base
           then: [x: "concat('\uF8FE', $Word)"]
         - else_if: "DefinitionValue($Word, 'Speech', 'PluralForms') != ''"
-          then: [x: "concat('\uF8FE', DefinitionValue($Word, 'Speech', 'PluralForms'))"]
+          then: [x: "concat('\uF8FE', DefinitionValue($Word, 'Speech', 'PluralForms'))", ct: " "]
           else: [x: "concat('\uF8FE', $Word)", ct: "s"]
 
     

--- a/Rules/Languages/de/definitions.yaml
+++ b/Rules/Languages/de/definitions.yaml
@@ -159,16 +159,23 @@
   }
 
 - PluralForms: {
-    "inch": "zoll", "square inch": "quadratzoll", "cubic inch": "kubikzoll",
-    "foot": "füße", "square foot": "quadratfuß", "cubic foot": "kubikfuß",
-    "board foot": "brettfuß",
-    "degree celsius": "grad celsius",
-    "degree fahrenheit": "grad fahrenheit",
-    "hertz": "hertz",
-    "siemens": "siemens",
-    "revolution per minute": "umdrehungen pro minute",
-    "mile per hour": "meilen pro stunde",
-    "mile per gallon": "meilen pro gallone"
+    "ampere": "ampere", "candela": "candela", "kelvin": "kelvin",
+    "gramm": "gramm", "meter": "meter", "mol": "mol", "sekunde": "sekunden",
+    "becquerel": "becquerel", "coulomb": "coulomb", "grad celsius": "grad celsius",
+    "farad": "farad", "gray": "gray", "henry": "henry", "hertz": "hertz",
+    "joule": "joule", "katal": "katal", "lumen": "lumen", "lux": "lux",
+    "newton": "newton", "ohm": "ohm", "pascal": "pascal", "siemens": "siemens",
+    "sievert": "sievert", "tesla": "tesla", "volt": "volt", "watt": "watt", "weber": "weber",
+    "liter": "liter", "tonne": "tonnen", "dalton": "dalton", "neper": "neper",
+    "atommasse-einheit": "atommasse-einheiten", "elektronenvolt": "elektronenvolt",
+    "radiant": "radianten", "steradiant": "steradianten", "jahr": "jahre",
+    "bogenminute": "bogenminuten", "bogensekunde": "bogensekunden", "bit": "bit",
+    "byte": "byte", "baud": "baud",
+    "zoll": "zoll", "fuß": "füße", "meile": "meilen", "rute": "ruten",
+    "glied": "glieder", "kette": "ketten", "fass": "fässer", "gallone": "gallonen",
+    "grad fahrenheit": "grad fahrenheit",
+    "umdrehungen pro minute": "umdrehungen pro minute",
+    "meile pro stunde": "meilen pro stunde", "meile pro gallone": "meilen pro gallone"
   }
 
 

--- a/tests/Languages/de/ClearSpeak/mfrac.rs
+++ b/tests/Languages/de/ClearSpeak/mfrac.rs
@@ -86,7 +86,7 @@ fn frac_with_units() -> Result<()> {
         </mfrac>
         </mrow>
     </math>";
-    test("de", "ClearSpeak", expr, "62 meiles pro stunde")?;
+    test("de", "ClearSpeak", expr, "62 meilen pro stunde")?;
     return Ok(());
 
 }

--- a/tests/Languages/de/units.rs
+++ b/tests/Languages/de/units.rs
@@ -40,7 +40,7 @@ fn prefix_sweep() -> Result<()> {
         <mi intent=":unit">qg</mi>
         </math>"#;
     test("de", "SimpleSpeak", expr,
-        "quetta-gramms, komma ronna-gramms, komma yotta-gramms, komma zetta-gramms, komma exa-gramms, komma peta-gramms, komma tera-gramms, komma giga-gramms, komma mega-gramms, komma kilo-gramms, komma hekto-gramms, komma deka-gramms, komma dezi-gramms, komma zenti-gramms, komma milli-gramms, komma mikro-gramms, komma nano-gramms, komma piko-gramms, komma femto-gramms, komma atto-gramms, komma zepto-gramms, komma yocto-gramms, komma ronto-gramms, komma quecto-gramms")?;
+        "quetta-gramm, komma ronna-gramm, komma yotta-gramm, komma zetta-gramm, komma exa-gramm, komma peta-gramm, komma tera-gramm, komma giga-gramm, komma mega-gramm, komma kilo-gramm, komma hekto-gramm, komma deka-gramm, komma dezi-gramm, komma zenti-gramm, komma milli-gramm, komma mikro-gramm, komma nano-gramm, komma piko-gramm, komma femto-gramm, komma atto-gramm, komma zepto-gramm, komma yocto-gramm, komma ronto-gramm, komma quecto-gramm")?;
         return Ok(());
 
 }
@@ -61,9 +61,21 @@ fn si_base() -> Result<()> {
         <mn>1</mn><mi intent=":unit">sec</mi><mo>,</mo><mn>2</mn><mi intent=":unit">sec</mi>
     </math>"#;
     test("de", "SimpleSpeak", expr,
-        "1 ampere, komma 2 amperes, komma 1 candela, komma 2 candelas, komma 1 kelvin, komma 2 kelvins, komma 1 kelvin, komma 2 kelvins, komma 1 gramm komma 2 gramms, komma 1 meter komma 2 meters, komma 1 mol komma 2 mols, komma 1 sekunde, komma 2 sekundes, komma 1 sekunde, komma 2 sekundes, komma 1 sekunde, komma 2 sekundes, komma 1 sekunde, komma 2 sekundes")?;
+        "1 ampere, komma 2 ampere, komma 1 candela, komma 2 candela, komma 1 kelvin, komma 2 kelvin, komma 1 kelvin, komma 2 kelvin, komma 1 gramm komma 2 gramm, komma 1 meter komma 2 meter, komma 1 mol komma 2 mol, komma 1 sekunde, komma 2 sekunden, komma 1 sekunde, komma 2 sekunden, komma 1 sekunde, komma 2 sekunden, komma 1 sekunde, komma 2 sekunden")?;
         return Ok(());
 
+}
+
+#[test]
+fn si_unit_plural_regression() -> Result<()> {
+    let expr = r#"<math>
+        <mn>2</mn><mi intent=":unit">kg</mi><mo>,</mo>
+        <mn>2</mn><mi intent=":unit">°C</mi><mo>,</mo>
+        <mn>2</mn><mi intent=":unit">s</mi>
+    </math>"#;
+    test("de", "ClearSpeak", expr,
+        "2 kilo-gramm, komma 2 grad celsius, komma 2 sekunden")?;
+    Ok(())
 }
 
 /*


### PR DESCRIPTION
in German, adding an "s" does not work a lot of times.