### PR TITLE
Add Brazilian Portuguese (pt-BR) translation and tests

### DIFF
--- a/Rules/Languages/pt/ClearSpeak_Rules.yaml
+++ b/Rules/Languages/pt/ClearSpeak_Rules.yaml
@@ -1,0 +1,766 @@
+---
+- name: pause
+  tag: "!*"
+  match: "not(self::m:math) and not($MatchingPause) and @data-intent-property[contains(., ':pause')]"
+  replace:
+   - with:
+      variables: [MatchingPause: "true()"]
+      replace:
+      - test:
+        - if: "contains(@data-intent-property, ':pause-long')"
+          then: [pause: long]
+        - else_if: "contains(@data-intent-property, ':pause-short')"
+          then: [pause: short]
+          else: [pause: medium]
+      - x: "."
+
+- name: intent-literal-silent
+  tag: [mi, mo, mn]
+  match: "contains(@data-intent-property, ':silent:')"
+  # say nothing
+  replace: []
+
+# handling of negative numbers that come from 'intent' is hard -- we do something that is close to right here 
+- name: intent-literal-negative-number
+  tag: mn
+  match: "starts-with(text(), '-')"
+  replace:
+  - t: "menos"      # phrase(10 'minus' 4 equals 6)
+  - x: "translate(text(), '-_', '')"
+
+- name: default
+  tag: square-root
+  match: "."
+  replace:
+  - test:
+      if: "$Verbosity!='Terse'"
+      then: [ot: "a"]      # phrase('the' square root of 25)
+  - test:
+      if: "$ClearSpeak_Roots = 'PosNegSqRoot' or $ClearSpeak_Roots = 'PosNegSqRootEnd'"
+      then:
+      - bookmark: "*[1]/@id"
+      - test:
+          if: "parent::*[self::m:minus and count(*)=1]"
+          then: [t: "negativo"]      # phrase(minus 4 is a 'negative' number)
+          else: [t: "positivo"]      # phrase(10 is a 'positive' number)
+  - t: "raiz quadrada"      # phrase(8 is the 'square root' of 64)
+  - test:
+      if: "$Verbosity!='Terse'"
+      then: [t: "de"]      # phrase(the square root 'of' 5)
+      else: [pause: short]
+  - x: "*[1]"
+  - test:
+    - if: "$ClearSpeak_Roots = 'RootEnd' or $ClearSpeak_Roots = 'PosNegSqRootEnd'"
+      then:
+      - pause: short
+      - t: "raiz final"      # phrase(the square root of x 'end root')
+      - pause: medium
+    - else_if: "IsNode(*[1], 'simple')"
+      then: [pause: short]
+      else: [pause: long]
+
+- name: default
+  tag: root
+  match: "."
+  replace:
+  - test:
+      if: "$Verbosity!='Terse'"
+      then: [ot: "a"]      # phrase(6 is 'the' square root of 36)
+  - test:
+      if: "$ClearSpeak_Roots = 'PosNegSqRoot' or $ClearSpeak_Roots = 'PosNegSqRootEnd'"
+      then:
+      - test:
+          if: "parent::*[(self::m:minus or self::m:plus) and count(*)=1]"
+          then: [bookmark: "parent/@id"]
+      - test:
+          if: "parent::m:minus"
+          then: [t: "negativo"]      # phrase(minus 6 is a 'negative' number)
+          else: [t: "positivo"]      # phrase(10 is a 'positive' number)
+  - test:
+      if: "*[2][self::m:mn and not(contains(., '.'))]"
+      then_test:
+      - if: "*[2][.='2']"
+        then: [t: "raiz quadrada"]      # phrase(5 is the 'square root' of 25)
+      - else_if: "*[2][.='3']"
+        then: [t: "raiz cúbica"]      # phrase(5 is the 'cube root' of 625)
+      - else: [x: "ToOrdinal(*[2])", t: "raiz"]      # phrase(the square 'root' of 25)
+      else:
+      - test:
+          if: "*[2][self::m:mi][string-length(.)=1]"
+          then:
+          - x: "*[2]"
+          - pronounce: [text: "-th", ipa: "θ", sapi5: "th", eloquence: "T"]
+          else: [x: "*[2]"]
+      - t: "raiz"      # phrase(the square 'root' of 36)
+  - test:
+      if: "$Verbosity!='Terse'"
+      then: [t: "de"]      # phrase(the square root 'of' 36)
+  - x: "*[1]"
+  - test:
+      if: "$ClearSpeak_Roots = 'RootEnd' or $ClearSpeak_Roots = 'PosNegSqRootEnd'"
+      then:
+      - pause: short
+      - t: "raiz final"      # phrase(start the fifth root of x 'end root')
+      - pause: medium
+      else_test:
+        if: "IsNode(*[1], 'simple')"
+        then: [pause: short]
+        else: [pause: long]
+
+# The 'negative' rule interacts with the msqrt/mroot rules as those might pick off this case ("the negative square root of x")
+- name: negative_and_positive
+  tag: [plus, minus]
+  match: "count(*)=1 and contains(@data-intent-property, ':prefix:')"
+  replace:
+  - test:
+      if:
+      - "*[1][self::m:square-root or self::m:root] and"
+      - "($ClearSpeak_Roots = 'PosNegSqRoot' or $ClearSpeak_Roots = 'PosNegSqRootEnd')"
+      then: [t: ""]
+      else:
+      - bookmark: "@id"
+      - test:
+          if: "self::m:minus"
+          then: [t: "negativo"]      # phrase(minus 5 is a 'negative' number)
+          else: [t: "positivo"]      # phrase(7 is a 'positive' number)
+  - x: "*[1]"
+
+# Fraction rules
+# Mixed numbers mostly "just work" because the invisible char reads as "and" and other parts read properly on their own
+
+# Units (e.g., meters per second)
+- name: per-fraction
+  tag: fraction
+  match:
+  - "$ClearSpeak_Fractions='Per' or"
+  - "(BaseNode(*[1])[contains(@data-intent-property, ':unit') or"
+  - "                ( self::m:mrow and count(*)=3 and"  # maybe a bit paranoid checking the structure...
+  - "                 *[1][self::m:mn] and *[2][.='\u2062'] and BaseNode(*[3])[contains(@data-intent-property, ':unit')] ) ] and"
+  - " BaseNode(*[2])[contains(@data-intent-property, ':unit')] )"
+  replace:
+  - x: "*[1]"
+  - t: "por"      # phrase('5 meters 'per' second)
+  - x: "*[2]"
+
+- name: common-fraction
+  tag: fraction
+  match:
+  - "($ClearSpeak_Fractions='Auto' or $ClearSpeak_Fractions='Ordinal' or $ClearSpeak_Fractions='EndFrac') and"
+  - "*[1][self::m:mn][not(contains(., $DecimalSeparators)) and ($ClearSpeak_Fractions='Ordinal' or text()<20)]   and"
+  - "*[2][self::m:mn][not(contains(., $DecimalSeparators)) and ($ClearSpeak_Fractions='Ordinal' or (2<= text() and text()<=10))]"
+  variables: [IsPlural: "*[1]!=1"]
+  replace:
+  - x: "*[1]"
+  - x: "ToOrdinal(*[2], true(), $IsPlural)"   # extra args specify fractional ordinal and whether it is plural
+
+- name: fraction-over-simple
+  tag: fraction
+  match:
+  - "($ClearSpeak_Fractions='Over' or $ClearSpeak_Fractions='FracOver' or $ClearSpeak_Fractions='OverEndFrac') or"
+  - "( not($ClearSpeak_Fractions='General' or $ClearSpeak_Fractions='GeneralEndFrac') and"
+  - "  (IsNode(*[1],'simple') and IsNode(*[2],'simple')) )" # simple fraction in ClearSpeak spec
+  replace:
+  - test:
+      if: "$ClearSpeak_Fractions='FracOver'"
+      then:
+      - test:
+          if: "$Verbosity!='Terse'"
+          then: [ot: "o"]
+      - t: "fração"      # phrase(the 'fraction' with 3 over 4)
+  - x: "*[1]"
+  - t: "sobre"      # phrase(the fraction 3 'over' 4)
+  - x: "*[2]"
+  - test:
+      # very ugly!!! -- replicate nested ordinal fraction as they are an exception
+      if: "$ClearSpeak_Fractions='OverEndFrac' or ($ClearSpeak_Fractions='EndFrac' and not( ($ClearSpeak_Fractions='Auto' or $ClearSpeak_Fractions='Ordinal' or $ClearSpeak_Fractions='EndFrac') and *[1][*[1][self::m:mn][not(contains(., '.')) and ($ClearSpeak_Fractions='Ordinal' or text()<20)]   and *[2][self::m:mn][not(contains(., '.')) and ($ClearSpeak_Fractions='Ordinal' or (2<= text() and text()<=10))] ] and *[2][*[1][self::m:mn][not(contains(., '.')) and ($ClearSpeak_Fractions='Ordinal' or text()<20)]   and *[2][self::m:mn][not(contains(., '.')) and ($ClearSpeak_Fractions='Ordinal' or (2<= text() and text()<=10))] ] ) )"
+      then:
+      - pause: short
+      - t: "fração final"      # phrase(7 over 8 'end fraction')
+      - pause: short
+
+- # fraction with text or numbers followed by text in both numerator and denominator
+  name: fraction-over-text
+  tag: fraction
+  match:
+  - "not($ClearSpeak_Fractions='General' or $ClearSpeak_Fractions='GeneralEndFrac') and"
+  - "( "
+  - "  ((*[1][self::m:mi or self::m:mtext][string-length(.)>1]) or " # fractions with text
+  - "   (*[1][self::m:mrow][count(*)=3][ "
+  - "        *[1][self::m:mn] and "
+  - "        *[2][self::m:mo][.='⁢'] and " # invisible times
+  - "        *[3][self::m:mi or self::m:mtext][string-length(.)>1] ]) ) and"
+  - "  ((*[2][self::m:mi or self::m:mtext][string-length(.)>1]) or " # fractions with text
+  - "   (*[2][self::m:mrow][count(*)=3][ "
+  - "        *[1][self::m:mn] and "
+  - "        *[2][self::m:mo][.='⁢'] and " # invisible times
+  - "        *[3][self::m:mi or self::m:mtext][string-length(.)>1] ]) )"
+  - ")"
+  replace:
+  - x: "*[1]"
+  - t: "sobre"      # phrase(the fraction 3 'over' 4)
+  - x: "*[2]"
+  - test:
+      if: "$ClearSpeak_Fractions='EndFrac' or $ClearSpeak_Fractions='OverEndFrac'"
+      then:
+      - pause: short
+      - t: "fração final"      # phrase(7 over 8 'end fraction')
+      - pause: short
+
+- name: default
+  tag: fraction
+  match: "."
+  replace:
+  - ot: "o"      # phrase(5 is 'the' square toot of 25)
+  - t: "fração com numerador"      # phrase(the 'fraction with numerator' 6)
+  - test:
+      if: "not(IsNode(*[1], 'simple'))"
+      then: [pause: medium]
+  - x: "*[1]"
+  - pause: medium
+  - t: "e denominador"      # phrase(the fraction with numerator 5 'and denominator' 8)
+  - x: "*[2]"
+  - pause: long
+  - test:
+      if: "$ClearSpeak_Fractions='EndFrac' or $ClearSpeak_Fractions='GeneralEndFrac'"
+      then:
+      - pause: short
+      - t: "fração final"      # phrase(the fraction with 3 over 4 'end fraction')
+      - pause: short
+
+# rules for functions raised to a power
+# these could have been written on 'mrow' but putting them on msup seems more specific
+# to see if it is a function, we look right to see if the following sibling is apply-function
+- name: ClearSpeak-function-inverse
+  tag: inverse-function
+  match: "."
+  replace:
+  - test:
+      if: "$ClearSpeak_Trig = 'TrigInverse'"
+      then: [x: "*[1]", bookmark: "*[2]/@id", t: "inverso"]      # phrase(8 over 5 is the 'inverse' of 5 over 8)
+      else_test:
+        if: "$ClearSpeak_Trig = 'ArcTrig'"
+        then: [bookmark: "*[2]/@id", t: "arco", x: "*[1]"]      # phrase(the 'arc' of a circle)
+        else: [bookmark: "*[2]/@id", t: "inverso", x: "*[1]"] # default/Auto      # phrase(8 over 5 is the 'inverse' of 5 over 8)
+
+- name: function-squared-or-cubed
+  tag: power
+  match:
+  - "*[2][self::m:mn][.='2' or .='3'] and"
+  - "following-sibling::*[1][self::m:mo][.='⁡']" #invisible function apply
+  replace:
+  - x: "*[1]"
+  - bookmark: "*[2]/@id"
+  - test:
+      if: "*[2][.='2']"
+      then: [t: "ao quadrado"]      # phrase(25 equals 5 'squared')
+      else: [t: "ao cubo"]      # phrase(625 equals 5 'cubed')
+
+- name: function-power
+  tag: power
+  match:
+  - "following-sibling::*[1][self::m:mo][.='⁡']" #invisible function apply
+  replace:
+  - test:
+      if: "$Verbosity!='Terse'"
+      then: [ot: "a"]      # phrase('the' third power of 2)
+  - bookmark: "*[2]/@id"
+  - test:
+      if: "*[2][self::m:mn][not(contains(., '.'))]"
+      then: [x: "ToOrdinal(*[2])"]
+      else: [x: "*[2]"]
+  - t: "potência de"      # phrase(the third 'power of' 6)
+  - pause: short
+  - x: "*[1]"
+
+- name: AfterPower-nested
+  tag: power
+  match: # directly a superscript or an mrow that contains a superscript
+  - "$ClearSpeak_Exponents = 'AfterPower' and"
+  - "*[2][self::m:power or self::m:power or self::m:mrow[m:power]]"
+  replace:
+  - x: "*[1]"
+  - t: "elevado ao expoente"      # phrase(5 'raised to the exponent' x plus 1)
+  - pause: short
+  - x: "*[2]"
+  - pause: short
+  - t: "expoente final"      # phrase(5 raised to the exponent x plus 1 'end exponent')
+
+- name: AfterPower-default
+  tag: power
+  match: "$ClearSpeak_Exponents = 'AfterPower'"
+  replace:
+  - x: "*[1]"
+  - t: "elevado à potência"      # phrase(x is 'raised to the power' 4)
+  - x: "*[2]"
+  - pause: short
+
+- name: squared
+  tag: power
+  match: "*[2][self::m:mn][.='2'] and $ClearSpeak_Exponents = 'Auto'"
+  replace:
+  - x: "*[1]"
+  - bookmark: "*[2]/@id"
+  - t: "quadrado"      # phrase(7 'squared' equals 49)
+
+- name: cubed
+  tag: power
+  match: "*[2][self::m:mn][.='3'] and $ClearSpeak_Exponents = 'Auto'"
+  replace:
+  - x: "*[1]"
+  - bookmark: "*[2]/@id"
+  - t: "ao cubo"      # phrase(5 'cubed' equals 125)
+
+- name: simple-integer
+  tag: power
+  match: "*[2][self::m:mn][not(contains(., '.'))]"
+  replace:
+  - x: "*[1]"
+  - t: "à"      # phrase(2 raised 'to the' power 7)
+  - test:
+      if: "*[2][.>0]"
+      then: [x: "ToOrdinal(*[2])"]
+      else: [x: "*[2]"]
+  - test:
+      if: "$ClearSpeak_Exponents != 'Ordinal'"
+      then: [t: "potência"]      # phrase(2 raised to the 'power' 7)
+
+- name: simple-negative-integer
+  tag: power
+  match:
+  - "*[2][self::m:minus and count(*)=1 and "
+  - "     *[1][self::m:mn][not(contains(., '.'))]"
+  - "    ]"
+  replace:
+  - x: "*[1]"
+  - t: "à"      # phrase(2 raised 'to the' power 7)
+  - x: "*[2]"
+  - test:
+      if: "$ClearSpeak_Exponents != 'Ordinal'"
+      then: [t: "potência"]      # phrase(2 raised to the 'power' 7)
+
+- name: simple-var
+  tag: power
+  match: "*[2][self::m:mi][string-length(.)=1]"
+  replace:
+  - x: "*[1]"
+  - t: "à"      # phrase(3 raised 'to the' power 7)
+  - x: "*[2]"
+  - pronounce: [text: "-th", ipa: "θ", sapi5: "th", eloquence: "T"]
+  - test:
+      if: "$ClearSpeak_Exponents != 'Ordinal'"
+      then: [t: "potência"]      # phrase(2 raised to the 'power' 7)
+
+# match nested exponent, where the nested exponent is has the power 2 or 3 (n below)
+#   [xxx]^n, - [xxx]^n, [xxx] var^n, -[xxx] var^n
+# where xxx is a number or common fraction (or a var in the first two forms)
+# short of creating a specialized built-in function, I don't see a way to eliminate a lot of repetition in the matches
+# also really bad is that the test of a common fraction is replicated here (four times!)
+# Note: the ClearSpeak doc doesn't say these only apply when the pref is "Auto",
+#   but the test cases all fall back to "raised to the exponent" when not "Auto"
+#   If these are allowed for non-Auto values, then you end up with "...power power...".
+- # [xxx]^n
+  name: nested-squared-or-cubed
+  tag: power
+  match:
+  - "$ClearSpeak_Exponents = 'Auto' and"
+  - "*[2][self::m:power]["
+  - "     *[2][self::m:mn][.='2' or .='3'] and " # exp is 2 or 3
+  # base is mn, mi, common fraction ([xxx] case)
+  - "     *[1][self::m:mn or self::m:mi or "
+  - "          self::m:fraction[*[1][self::m:mn][not(contains(., '.')) and text()<20]   and"
+  - "                        *[2][self::m:mn][not(contains(., '.')) and 2<= text() and text()<=10]]"
+  - "         ]"
+  - "    ]"
+  replace:
+  - x: "*[1]"
+  - t: "elevado à"      # phrase(x 'raised to the' second power)
+  - x: "*[2]"
+  - t: "potência"      # phrase(x raised to the second 'power')
+
+- # - [xxx]^n
+  name: nested-negative-squared-or-cubed
+  tag: power
+  match:
+  - "$ClearSpeak_Exponents = 'Auto' and"
+  - " *[2][self::m:minus and count(*)=1 and "
+  - "      *[1]/*[1][self::m:power]["
+  - "                *[2][self::m:mn][.='2' or .='3'] and " # exp is 2 or 3"
+  # base is mn, mi, common fraction ([xxx] case)
+  - "                *[1][self::m:mn or self::m:mi or "
+  - "                     self::m:fraction[*[1][self::m:mn][not(contains(., '.')) and text()<20]   and"
+  - "                                   *[2][self::m:mn][not(contains(., '.')) and 2<= text() and text()<=10]]"
+  - "               ]"
+  - "          ]"
+  - "     ]"
+  replace:
+  - x: "*[1]"
+  - t: "elevado à"      # phrase(x 'raised to the' second power)
+  - x: "*[2]"
+  - t: "potência"      # phrase(x raised to the second 'power')
+
+- # [xxx] var^n
+  name: nested-var-squared-or-cubed
+  tag: power
+  match:
+  - "$ClearSpeak_Exponents = 'Auto' and"
+  - "  *[2][self::m:mrow][count(*)=3][ "
+  - "       *[3][self::m:power]["
+  - "            *[2][self::m:mn][.='2' or .='3'] and " # exp is 2 or 3
+  - "            *[1][self::m:mi]"
+  - "           ] and "
+  - "       *[2][self::m:mo][.='⁢'] and " # invisible times
+  # base is mn, or common fraction ([xxx] case)
+  - "       *[1][self::m:mn or "
+  - "            self::m:fraction[*[1][self::m:mn][not(contains(., '.')) and text()<20]   and"
+  - "                          *[2][self::m:mn][not(contains(., '.')) and 2<= text() and text()<=10]]"
+  - "           ]"
+  - "      ]"
+  replace:
+  - x: "*[1]"
+  - t: "elevado à"      # phrase(x 'raised to the' second power)
+  - x: "*[2]"
+  - t: "potência"      # phrase(x raised to the second 'power')
+
+- # -[xxx] var^n
+  name: nested-negative-var-squared-or-cubed
+  tag: power
+  match:
+  - "$ClearSpeak_Exponents = 'Auto' and"
+  - "  *[2][self::m:mrow][count(*)=3][ "
+  - "       *[3][self::m:power]["
+  - "            *[2][self::m:mn][.='2' or .='3'] and " # exp is 2 or 3
+  - "            *[1][self::m:mi]"
+  - "           ] and "
+  - "       *[2][self::m:mo][.='⁢'] and " # invisible times
+  - "       *[1][self::m:minus and count(*)=1 and "
+  # base is mn, or common fraction ([xxx] case)
+  - "            *[1][self::m:mn or "
+  - "                 self::m:fraction[*[1][self::m:mn][not(contains(., '.')) and text()<20]   and"
+  - "                                  *[2][self::m:mn][not(contains(., '.')) and 2<= text() and text()<=10]]"
+  - "                ]"
+  - "           ]"
+  - "      ]"
+  replace:
+  - x: "*[1]"
+  - t: "elevado à"      # phrase(x 'raised to the' second power)
+  - x: "*[2]"
+  - t: "potência"      # phrase(x raised to the second 'power')
+
+- name: default-exponent-power
+  tag: power
+  match: # directly a superscript or an mrow that contains a superscript
+  - "*[2][self::m:power or self::m:power or self::m:mrow[m:power]]"
+  replace:
+  - x: "*[1]"
+  - t: "elevado ao expoente"      # phrase(x is 'raised to the exponent')
+  - pause: short
+  - x: "*[2]"
+  - pause: short
+  - t: "expoente final"      # phrase(and now 'end exponent' has been reached)
+
+- name: default
+  tag: power
+  match: "."
+  replace:
+  - x: "*[1]"
+  - t: "elevado à"      # phrase(x 'raised to the' second power)
+  - x: "*[2]"
+  - t: "potência"      # phrase(x raised to the second 'power')
+
+#
+# Some rules on mrows
+#
+- # the inference rules lump absolute value and cardinality together, so those rules are implemented here
+  name: ClearSpeak-absolute-value
+  tag: absolute-value
+  match: "."
+  variables: [WordToSay: "IfThenElse($ClearSpeak_AbsoluteValue = 'Cardinality', 'cardinality', 'absolute value')"]
+  replace:
+  - test:
+      if: "$Verbosity!='Terse'"
+      then: [ot: "o"]      # phrase('the' absolute value of 25)
+  - x: "$WordToSay"
+  - t: "de"      # phrase(the absolute value 'of' 25)
+  - x: "*[1]"
+  - test:
+      if: "$ClearSpeak_AbsoluteValue = 'AbsEnd'"
+      then:
+      - pause: short
+      - t: "final"      # phrase('end' absolute value)
+      - x: "$WordToSay"
+  - pause: short
+
+- name: set
+  tag: set
+  match: "."
+  replace:
+  - test:
+    - if: "count(*)=0"
+      then: [t: "o conjunto vazio"]      # phrase('the empty set')
+    - else_if: "count(*)=2"
+      then:
+      - test:
+          if: "$Verbosity!='Terse'"
+          then: [t: "o"]      # phrase('the' empty set)
+      - t: "conjunto vazio"      # phrase(the 'empty set')
+    - else_if: "count(*[1]/*)=3 and *[1]/*[2][self::m:mo][.=':' or .='|' or .='∣']"
+      then:
+      - test:
+          if: "$Verbosity!='Terse'"
+          then: [t: "o"]      # phrase('the' set of all integers)
+      - t: "conjunto de"      # phrase(this is a 'set of' numbers)
+      - test:
+          if: "$ClearSpeak_Sets != 'woAll'"
+          then: [t: "todos"]      # phrase(the set of 'all' integers)
+      - x: "*[1]/*[1]"
+      - t: "tal que"      # phrase(the set S 'such that' x is less than y)
+      - x: "*[1]/*[3]"
+      else:
+      - test:
+          if: "$ClearSpeak_Sets != 'SilentBracket'"
+          then:
+          - test:
+              if: "$Verbosity!='Terse'"
+              then: [t: "o"]      # phrase('the' set of integers)
+          - t: "conjunto"      # phrase(this is a 'set' of integers)
+      - x: "*[1]"
+
+- # intervals are controlled by a ClearSpeak Preference -- parens/brackets don't have to match, so we avoid IsBracketed
+  # alternatively, we could have four (or ten) rules, but there is a lot of duplication if we do that
+  # this one rule handles all ten cases listed as part $ClearSpeak_Paren = 'Interval'
+  # note that *[2] is an mrow with X, ",", Y, so getting X or Y is a double index
+  name: ClearSpeak-intervals # avoid overriding with default "intervals" name
+  variables:
+  - is_intervals_start_infinity: "*[1][self::m:minus and count(*)=1 and *[1][.='∞']]"
+  - is_intervals_end_infinity: "*[2][.='∞'or (self::m:plus and count(*)=1 and *[1][.='∞'])]"
+  tag: [open-interval, open-closed-interval, closed-interval, closed-open-interval]
+  match: "."
+  replace:
+  - t: "o intervalo de"      # phrase('the interval from' a to b)
+  - x: "*[1]"
+  - t: "a"      # phrase(the interval from a 'to' b)
+  - x: "*[2]"
+  - pause: short
+  - test:
+      if: "not($is_intervals_start_infinity)"
+      then:
+      - test:
+          if: "starts-with(name(.), 'open')"
+          then: [t: "não"]      # phrase(the interval from a to b 'not' including b)
+      - t: "incluindo"      # phrase(the interval from a to b not 'including' b)
+      - x: "*[1]"
+    # logic to deal with [not] arg #1
+  - test:
+      if: "not($is_intervals_start_infinity or $is_intervals_end_infinity)"
+      then_test:
+      - if: "name(.)='open-interval'"
+        then: [t: "ou"]      # phrase(the interval including a 'or' b )
+      - else_if: "name(.)='closed-interval'"
+        then: [t: "e"]      # phrase(the interval including a 'and' b)
+        else: [t: "mas"]      # phrase(the interval including a 'but' not b)
+    # some ugly logic dealing with connectives: or, but, but, and (cleaner to be part of next clause?)
+  - test:
+      if: "not($is_intervals_end_infinity)"
+      then:
+      - test:
+          # there is some asymmetry to the test because of the and/or/but logic above
+          if: "not( name(.)='open-interval' or name(.)='closed-interval' ) or $is_intervals_start_infinity"
+          then:
+          - test:
+              if: "name(.) = 'open-interval' or name(.) = 'closed-open-interval'"
+              then: [t: "não"]      # phrase(the interval 'not' including a)
+          - t: "incluindo"      # phrase(the interval not 'including' a)
+      - x: "*[2]"
+
+    # onto the [not] [including]... part
+- name: binomial-frac-vector
+  tag: matrix
+  match:
+  - "$ClearSpeak_Matrix = 'Combinatorics' and "
+  - "count(*[1]/*)=1 and count(*)=2"
+  replace:
+  - x: "*[1]/*[1]/*" # mtable/mtr/mtd
+  - t: "escolher"      # phrase(the binomial coefficient n 'choose' m)
+  - x: "*[2]/*[1]/*"
+
+- name: ClearSpeak-default
+  tag: [mtr, mlabeledtr]
+  match: "parent::m:matrix or parent::m:determinant"
+  variables: [NextLineIsContinuedRow: "following-sibling::*[1][contains(@data-intent-property, ':continued-row:')]"]
+  replace:
+  - pause: medium
+  - t: "linha"      # phrase(the first 'row' of a matrix)
+  - x: "count(preceding-sibling::*)+1"
+  - test:
+      if: ".[self::m:mlabeledtr]"
+      then:
+      - t: "com rótulo"      # phrase(the line 'with label' first equation)
+      - x: "*[1]/*"
+      - pause: short
+  - pause: medium
+  - test:
+      if: ".[self::m:mlabeledtr]"
+      then: [x: "*[position()>1]"]
+      else: [x: "*"]
+
+- # handle both log and ln
+  name: ClearSpeak-log
+  tag: mi
+  match: ".='log' or .='ln'"
+  replace:
+  - bookmark: "@id"
+  - test:
+      if: "$Verbosity!='Terse' and not(IsNode(following-sibling::*[2],'simple'))"
+      then: [ot: "a"]      # phrase('the' square root of 25)
+  - test:
+    - if: ".='log'"
+      then: [t: "registro"]
+    - else_if: "$ClearSpeak_Log = 'LnAsNaturalLog'"
+      then: [t: "log natural"]      # phrase(the 'natural log' of x)
+      else: [spell: "'ln'"]
+
+- name: ClearSpeak-multi-line
+  tag: [piecewise, system-of-equations, lines] # these are ignored in favor of the ClearSpeak prefs
+  match: "."
+  variables:
+    # Wikipedia has some tables where all the entire first column is empty (e.g., https://en.wikipedia.org/wiki/List_of_trigonometric_identities)
+  - LineCount: "count(*[not(contains(@data-intent-property, ':continued-row:'))])"
+  - NextLineIsContinuedRow: "false()"   # default value
+  - IsColumnSilent: true()
+  replace:
+  - test:
+    - if: "$ClearSpeak_MultiLineOverview = 'Auto'"
+      then:
+      - x: "$LineCount"
+      - test:
+        - if: "($ClearSpeak_MultiLineLabel = 'Auto' and self::m:piecewise) or $ClearSpeak_MultiLineLabel = 'Case'"
+          then: [t: "caso"]      # phrase(this is the first 'case' of three cases)
+        - else_if: "$ClearSpeak_MultiLineLabel = 'Auto' or $ClearSpeak_MultiLineLabel = 'Line' or $ClearSpeak_MultiLineLabel = 'None'" # already dealt with Auto/Case
+          then: [t: "linha"]      # phrase(this is the first 'line' of three lines)
+        - else_if: "$ClearSpeak_MultiLineLabel = 'Constraint'"
+          then: [t: "restrição"]      # phrase(this is the first 'constraint' of three constraints)
+        - else_if: "$ClearSpeak_MultiLineLabel = 'Equation'"
+          then: [t: "equação"]      # phrase(this is the first 'equation' of three equations)
+        - else_if: "$ClearSpeak_MultiLineLabel = 'Row'"
+          then: [t: "linha"]      # phrase(this is the first 'row' of three rows)
+        - else_if: "$ClearSpeak_MultiLineLabel = 'Step'"
+          then: [t: "passo"]      # phrase(this is the first 'step' of three steps)
+          # else 'None -- don't say anything'
+      - test:
+        - if: "$LineCount != 1"
+          then: [ct: "s"] # plural      # phrase(shown by the letter 's')
+      - pause: short
+  - x: "*"
+  - pause: long
+
+- name: ClearSpeak-default-multiline
+  tag: [mtr, mlabeledtr]
+  match: "parent::m:piecewise or parent::m:system-of-equations or parent::m:lines"
+  variables: [NextLineIsContinuedRow: "following-sibling::*[1][contains(@data-intent-property, ':continued-row:')]"]
+  replace:
+  - test:
+      if: "not($LineCount=1 or $ClearSpeak_MultiLineLabel='None' or contains(@data-intent-property, ':continued-row:'))"
+      then:
+      - pause: medium
+      - test:
+        - if: "($ClearSpeak_MultiLineLabel = 'Auto' and parent::m:piecewise) or $ClearSpeak_MultiLineLabel = 'Case'"
+          then: [t: "caso"]      # phrase(in this  'case' x is not equal to y)
+        - else_if: "$ClearSpeak_MultiLineLabel = 'Auto' or $ClearSpeak_MultiLineLabel = 'Line'" # already dealt with Auto/Case
+          then: [t: "linha"]      # phrase(the straight 'line' between x and y)
+        - else_if: "$ClearSpeak_MultiLineLabel = 'Constraint'"
+          then: [t: "restrição"]      # phrase(there is a 'constraint' on possible values)
+        - else_if: "$ClearSpeak_MultiLineLabel = 'Equation'"
+          then: [t: "equação"]      # phrase(the 'equation' pi r squared gives the area of a circle)
+        - else_if: "$ClearSpeak_MultiLineLabel = 'Row'"
+          then: [t: "linha"]      # phrase(the values on the top 'row' are relevant)
+        - else_if: "$ClearSpeak_MultiLineLabel = 'Step'"
+          then: [t: "passo a passo"]      # phrase(this is a 'step' by step process)
+          # else 'None -- don't say anything'
+      - x: "count(preceding-sibling::*[not(contains(@data-intent-property, ':continued-row:'))]) + 1"
+  - test:
+      if: "self::m:mlabeledtr"
+      then:
+      - t: "com etiqueta"      # phrase(the diagram is complete 'with label')
+      - x: "*[1]/*"
+  - test:
+    - if: "$ClearSpeak_MultiLineLabel='None'"
+      then: [pause: xlong]   # need a very long pause with no line labels
+    - else_if: "not(contains(@data-intent-property, ':continued-row:'))"
+      then: [pause: medium]
+  - test:
+      if: "self::m:mlabeledtr"
+      then: [x: "*[position()>1]"]
+      else: [x: "*"]
+
+- name: ClearSpeak_Functions_None
+  tag: mo
+  match:
+  - ".='⁡' and $ClearSpeak_Functions = 'None' and"
+  - "not(preceding-sibling::*[1][IsInDefinition(., 'TrigFunctionNames')])" # Functions=None does not apply to "trig" functions
+  replace:
+    test:
+      if: "$ClearSpeak_ImpliedTimes = 'None'"
+      then: [t: ""]
+      else: [t: "vezes"]      # phrase(5 'times' 3 equals 15)
+
+- name: no-times
+  tag: mo
+  match:
+  # Note: this rule is also part of the paren rule so that the parens speak
+  - ".='⁢' and $ClearSpeak_ImpliedTimes = 'None'"
+  replace:
+  - t: ""
+
+- name: ClearSpeak-times
+  tag: mo
+  match:
+  # say "times" when invisible times is followed by parens or a superscript that has a base with parens or "|"s
+  # if we aren't sure if it is times or not, don't say anything
+  - ".='⁢' and (not(@data-function-guess) or $ClearSpeak_Functions = 'None') and"
+  - "not(ancestor-or-self::*[contains(@data-intent-property, ':literal:')]) and ("
+  - "  $ClearSpeak_ImpliedTimes = 'MoreImpliedTimes'"
+  - " or "
+  - "  following-sibling::*[1]["
+  - "    IsBracketed(., '(', ')') or IsBracketed(., '[', ']') or IsBracketed(., '|', '|') or "
+  # most of these aren't mentioned in ClearSpeak spec, but are (I think) expected uses of "times"
+  - "    self::m:matrix or self::m:determinant or self::m:binomial or" # followed by parens
+  - "    self::m:square-root or self::m:msqrt or self::m:root or self::m:mroot or"
+  - "    (self::m:msub or self::m:msubsup or"
+  - "    ((self::m:msup or self::m:power) and not(IsNode(*[1], 'leaf') and *[2][self::m:mn and (.=2 or '.=3')]))) and " # followed by msup, etc.
+  - "     (*[1][self::m:mrow[IsBracketed(., '(', ')') or IsBracketed(., '[', ']') or IsBracketed(., '|', '|')] or "
+  - "           self::m:matrix or self::m:determinant] or" # base has parens
+  - "      not(IsNode(*[2], 'simple')) or "
+  - "      (self::m:msubsup and not(IsNode(*[3], 'simple')))"
+  - "     )"
+  - "  ]"
+  # other possibility is the preceding element has parens (but not the following)
+  # this is not mentioned in the ClearSpeak rules or examples but seems like it should say "times". E.g, |x| y
+  - " or "
+  - "  preceding-sibling::*[1]["
+  - "    IsBracketed(., '(', ')') or IsBracketed(., '[', ']') or IsBracketed(., '|', '|')]" # followed by parens
+  - " )"
+  replace:
+  - t: "vezes"      # phrase(5 'times' 3 equals 15)
+
+- name: no-say-parens
+  tag: mrow
+  match:
+  - "parent::*[not(self::m:msup) and not(self::m:msub) and not(self::m:msubsup) and not(self::m:power) and"
+  - "          not(self::m:math) ] and "       # rule out [x] standing alone
+  - "( IsBracketed(., '(', ')') or IsBracketed(., '[', ']') ) and "
+  - "not( $ClearSpeak_Functions = 'None' and "
+  - "     (preceding-sibling::*[1][.='⁡'] or following-sibling::*[1][.='⁡']) ) and "
+  - "not( $ClearSpeak_ImpliedTimes = 'None' and "
+  - "     (preceding-sibling::*[1][.='⁢'] or following-sibling::*[1][.='⁢']) ) and "
+  - "IsNode(*[2], 'simple') and"
+  - "not(preceding-sibling::*[1][.='\u2062' and @data-function-guess]) and"
+  - "not(ancestor-or-self::*[contains(@data-intent-property, ':literal:')])"
+  # missing clause: 'a positive fraction that is spoken as an ordinal
+  #   (either by the Ordinal preference or by the default rules)'
+  replace:
+  - x: "*[2]"
+
+- include: "SharedRules/geometry.yaml"
+- include: "SharedRules/linear-algebra.yaml"
+- include: "SharedRules/general.yaml"
+- include: "SharedRules/default.yaml"

--- a/Rules/Languages/pt/SharedRules/calculus.yaml
+++ b/Rules/Languages/pt/SharedRules/calculus.yaml
@@ -1,0 +1,56 @@
+---
+
+- name: laplacian
+  tag: laplacian
+  match: "count(*) <= 1"   # can be on ∇^2 or on enclosing mrow
+  replace:
+  - t: "laplaciano"      # phrase('laplacian' of x)  -- "LahPlahsian" sounds better with speech engines tested
+  - test:
+      if: "count(*) = 1"
+      then:
+      - test:
+          if: "$Verbosity!='Terse'"
+          then: [t: "de"]             # phrase(function 'of' one variable) -- note OneCore voices spell out "div"
+      - test:
+          if: "not(IsNode(*[1], 'leaf'))"
+          then: [pause: short]
+      - x: "*[1]"
+
+- name: divergence
+  tag: divergence
+  match: "count(*) = 1"
+  replace:
+  - test:
+      if: "$Verbosity='Terse'"
+      then: [t: "div"]             # phrase('div' is short for divergence) -- note OneCore voices spell out "div"
+      else: [t: "divergência de"]      # phrase('divergence of' this function from the mean)
+  - test:
+      if: "not(IsNode(*[1], 'leaf'))"
+      then: [pause: short]
+  - x: "*[1]"
+
+- name: curl
+  tag: curl
+  match: "count(*) = 1"
+  replace:
+  - t: "curvatura de"      # phrase(the 'curl of' a field)
+  - test:
+      if: "$Verbosity!='Terse'"
+      then: [t: "de"]             # phrase(function 'of' one variable) -- note OneCore voices spell out "div"
+  - test:
+      if: "not(IsNode(*[1], 'leaf'))"
+      then: [pause: short]
+  - x: "*[1]"
+
+- name: gradient
+  tag: gradient
+  match: "count(*) = 1"
+  replace:
+  - test:
+      if: "$Verbosity!='Terse'"
+      then: [t: "gradiente de"]      # phrase(the hill has a 'gradient of' five percent)
+      else: [t: "del"]      # phrase(the delete key is labeled 'del')
+  - test:
+      if: "not(IsNode(*[1], 'leaf'))"
+      then: [pause: short]
+  - x: "*[1]"

--- a/Rules/Languages/pt/SharedRules/default.yaml
+++ b/Rules/Languages/pt/SharedRules/default.yaml
@@ -1,0 +1,750 @@
+---
+#default rules shared among several speech rules
+- name: default
+  tag: math
+  match: "."
+  replace:
+  - with:
+      variables:
+      - ClearSpeak_Fractions: "IfThenElse($Verbosity='Verbose' and $ClearSpeak_Fractions='Auto', 'EndFrac', $ClearSpeak_Fractions)"
+      - ClearSpeak_AbsoluteValue: "IfThenElse($Verbosity='Verbose' and $ClearSpeak_AbsoluteValue='Auto', 'AbsEnd', $ClearSpeak_AbsoluteValue)"
+      - ClearSpeak_Roots: "IfThenElse($Verbosity='Verbose' and $ClearSpeak_Roots='Auto', 'RootEnd', $ClearSpeak_Roots)"
+      - ClearSpeak_Matrix: "IfThenElse($Verbosity='Verbose' and $ClearSpeak_Matrix='Auto', 'EndMatrix', $ClearSpeak_Matrix)"
+
+      - MatchingPause: false()
+      # should be set at mtable level, but unknown intents make that impossible to know
+      - IsColumnSilent: false()
+      replace:
+      - test:
+          if: "$MathRate = 100"
+          then: [x: "*"]
+          else:
+          - rate:
+              value: "$MathRate"
+              replace: [x: "*"]
+
+- name: empty-mrow
+  tag: mrow
+  match: "not(*)"
+  replace:
+  - t: "" # say nothing -- placeholder
+
+- name: default
+  tag: mrow
+  match: "."
+  replace:
+  - insert:
+      nodes: "*"
+      replace: [pause: auto]
+
+- name: default
+  tag: mn
+  match: "."
+  replace:
+  - bookmark: "@id"
+  - test:
+    - if: "@data-roman-numeral" 
+      then: [spell: "text()", pause: "short"]
+      else: [x: "translate(., $BlockSeparators, '')"]  # remove digit block separators
+
+- name: default
+  tag: [mo, mtext]
+  match: "."
+  replace:
+  - bookmark: "@id"
+  - x: "text()"
+
+- name: default
+  tag: mi
+  match: "."
+  replace:
+  - bookmark: "@id"
+  - test:
+    - if: "string-length(.) = 1 and text() != '_'"       # need unicode.tdl to kick in for single letter tokens
+      then: [x: "text()"]
+    - else_if: "@data-chem-element > 0 or @data-roman-numeral"                      # NavMode=Character needs this
+      then: [spell: "text()", pause: "short"]
+      else: [x: "translate(., '-_\u00A0', '  ')"]   # from intent literals or from extra spaces added (which get deleted)
+
+- name: default
+  tag: ms
+  match: "."
+  replace:
+  - t: "a string"      # phrase('the string' is long)
+  - pause: short
+  - x: "text()"
+
+- name: default
+  tag: mstyle
+  match: "."
+  replace: [x: "*"]
+
+
+- name: literal-simple
+  # don't include nested fractions. E.g, fraction a plus b over c + 1 end fraction" is ambiguous
+  # by simplistic SimpleSpeak's rules "b over c" is a fraction, but if we say nested fractions
+  # are never simple, then any 'over' applies only to enclosing "fraction...end fraction" pair.
+  tag: mfrac
+  match:
+  - "(IsNode(*[1],'leaf') and IsNode(*[2],'leaf')) and"
+  - "not(ancestor::*[name() != 'mrow'][1]/self::m:fraction)" # FIX: can't test for mrow -- what should be used???
+  replace:
+  - x: "*[1]"
+  - t: "sobre"               # phrase("the fraction x 'over' y")
+  - x: "*[2]"
+  - pause: short
+
+- name: literal-default
+  tag: mfrac
+  match: "."
+  replace:
+  - t: "início"              # phrase("'start'  fraction x over y end of fraction")
+  - pause: short
+  - x: "*[1]"
+  - test:
+      if: "not(IsNode(*[1],'leaf'))"
+      then: [pause: short]
+  - t: "sobre"               # phrase("the fraction x 'over' y")
+  - test:
+      if: "not(IsNode(*[2],'leaf'))"
+      then: [pause: short]
+  - x: "*[2]"
+  - pause: short
+  - test:
+      if: "$Impairment = 'Blindness'"
+      then: [t: "fim"]          # phrase("start of fraction x over y 'end over'")
+  - pause: medium
+
+
+# not sure what really should be said for these since we should not assume they are square roots
+- name: literal-default
+  tag: msqrt
+  match: "."
+  replace:
+  - test:
+      if: "$Verbosity!='Terse'"
+      then: [ot: "a"]    # phrase("'the' root of x")
+  - t: "raiz"
+  - test:
+      if: "$Verbosity!='Terse'"
+      then: [t: "de"]    # phrase("the root 'of' x")
+  - x: "*[1]"
+  - pause: short
+  - test:
+      if: "not(IsNode(*[1],'leaf')) or $Impairment = 'Blindness'"
+      then: [t: "fim da raiz", pause: medium] # phrase("root of x 'end root symbol'")
+
+# not sure what really should be said for these since we should not assume they are square roots
+- name: literal-default
+  tag: mroot
+  match: "."
+  replace:
+  - test:
+      if: "$Verbosity!='Terse'"
+      then: [ot: "a"]   # phrase("'the' root of x")
+  - t: "raiz com índice" # phrase("the 'root with index' 3 of 5")
+  - x: "*[1]"
+  - pause: short
+  - t: "de"              # phrase("the root 'of' x")
+  - x: "*[2]"
+  - pause: short
+  - test:
+      if: "not(IsNode(*[2],'leaf'))"
+      then: [t: "fim do símbolo de raiz"] # phrase("root of x 'end root symbol'")
+
+
+- name: simple-sub
+  tag: indexed-by
+  # invisible comma -- want "x 1 when subscript is an integer"
+  match: "count(*)=2 and $Verbosity='Terse' and *[2][self::m:mn and translate(., '.,', '')=.]"
+  replace:
+  - x: "*[1]"
+  - x: "*[2]"
+  - pause: short
+
+- name: no-end-sub
+  tag: indexed-by
+  match: "count(*)=2 and *[2][self::m:mrow and *[2][.='⁣']]"
+  replace:
+  - x: "*[1]"
+  - t: "sub"               # phrase(x 'sub' 2)
+  - x: "*[2]"
+  - pause: short
+
+- name: power-indexed-by
+  tag: power-indexed-by
+  match: "."
+  replace:
+  - x: "*[1]"
+  - t: "sub"               # phrase(x 'sub' 2)
+  - x: "*[2]"
+  - pause: short
+
+# otherwise let definitions/default infix handle it
+
+- name: literal
+  tag: msub
+  match: "."
+  replace:
+  - x: "*[1]"
+  - test:
+      if: "not($Verbosity='Terse' and *[2][self::m:mn and not(translate(., '.,', '')!=.)])"  # just say "x 1" for terse vs "x sub 1"
+      then: [t: "sub"]      # phrase(x 'sub' 2)
+  - x: "*[2]"
+
+
+- name: literal
+  tag: [msup, msubsup]
+  match: "."
+  replace:
+  - x: "*[1]"
+  - test:
+      if: "name(.)='msubsup'"
+      then:
+      - t: "sub"          # phrase(x 'sub' 2)
+      - x: "*[2]"
+  - test:
+      if: "*[last()][translate(., '′″‴⁗†‡°*', '')='']"
+      then:  [x: "*[last()]"]
+      else_test:
+          if: "ancestor-or-self::*[contains(@data-intent-property, ':literal:')]"  # FIX: is this test necessary?
+          then:
+          - t: "super"      # phrase(x 'super' 2)
+          - x: "*[last()]"
+          - test:
+              if: "not(IsNode(*[last()], 'simple')) or $Impairment = 'Blindness'"
+              then: [t: "fim do super"]      # phrase(x super 2 'end of super')
+          else:
+          - test:
+              if: "$Verbosity='Verbose'"
+              then: [t: "sobrescrito"]
+              else: [t: "super"]
+          - x: "*[last()]"
+          - test:
+              if: "$Verbosity='Verbose'"
+              then: [t: "final sobrescrito"]
+              else: [t: "final super"]
+
+- name: default
+  tag: munder
+  match: "."
+  replace:
+  - test:
+      if: "not(IsNode(*[1], 'leaf'))"
+      then: [t: "quantidade"]      # phrase(phrase(x 'quantity' with y above it)
+  - x: "*[1]"
+  - t: "com"      # phrase(x 'with' z below it)
+  - x: "*[2]"
+  - t: "abaixo"      # phrase(x with z 'below' it)
+
+# FIX: this only works for up to four dots (which is realistically all we need)
+- name: dot-over
+  tag: modified-variable
+  match: "*[1][self::m:mi] and (*[2][translate(., '.', '')=''])"
+  replace:
+  - x: "*[1]"
+  - x: "IfThenElse(string-length(*[2])=1, 'dot',
+        IfThenElse(string-length(*[2])=2, 'double dot',
+        IfThenElse(string-length(*[2])=3, 'triple dot', 'quadruple dot')
+        ))"
+  - pause: short
+
+# FIX: the 'translate' list is a little different from 'modified-variable', so we also include 'mover' (unify?)
+- name: diacriticals
+  tag: [mover, modified-variable]
+  match: "*[1][self::m:mi] and *[2][translate(., '\u0306\u030c.\u00A8\u02D9\u20DB\u20DC`^ˇ~→¯_', '')='']"
+  replace:
+  - x: "*[1]"
+  - x: "*[2]"
+  - pause: short
+
+- name: default
+  tag: mover
+  match: "."
+  replace:
+  - test:
+      if: "not(IsNode(*[1], 'leaf'))"
+      then: [t: "quantidade"]      # phrase(phrase(the 'quantity' x plus 1 with y above it)
+  - x: "*[1]"
+  - t: "com"         # phrase(x modified 'with' y above it)
+  - x: "*[2]"
+  - t: "acima"        # phrase(x modified 'with' y above it)
+
+- name: default
+  tag: munderover
+  match: "."
+  replace:
+  - test:
+      if: "not(IsNode(*[1], 'leaf'))"
+      then: [t: "quantidade"]      # phrase(the 'quantity' x plus 1 with y above it)
+  - x: "*[1]"
+  - t: "com"         # phrase(x modified 'with' y above it)
+  - x: "*[2]"
+  - t: "abaixo e"    # phrase(x modified with y 'below and' y above it)
+  - x: "*[3]"
+  - t: "acima"        # phrase(x modified with y 'above' it)
+
+- name: default
+  #   Here we support up to 2 prescripts and up to 4 postscripts -- that should cover all reasonable cases
+  #   If there are more, we just dump them out without regard to sup/super :-(
+  # FIX: this could use more special cases 
+  # There is (currently) no way in MathCAT to deal with n-ary arguments other than "all" ('*') or an individual entry ('*[1]').
+  tag: mmultiscripts
+  match: "."
+  variables:
+  # computing the number of postscripts is messy because of <mprescripts> being optionally present -- we use "mod" to get the count right
+  - Prescripts: "m:mprescripts/following-sibling::*"
+  - NumChildren: "count(*)" # need to stash this since the count is wrong inside '*[...]' below
+  - Postscripts: "*[position()>1 and position() < (last() + ($NumChildren mod 2) -count($Prescripts))]"
+  replace:
+  - x: "*[1]"
+  - test:
+      if: "$Prescripts" # more common case
+      then:
+      - with:
+          variables:
+          - PreSubscript: "IfThenElse($Verbosity='Verbose', 'pre subscript', 'pre sub')"
+          - PreSuperscript: "IfThenElse($Verbosity='Verbose', 'pre superscript', 'pre super')"
+          replace:
+          - test: # only bother announcing if there is more than one prescript
+              if: "count($Prescripts) > 2"
+              then:
+              - t: "por"      # phrase(substitute x 'with' y)
+              - x: "count($Prescripts) div 2"
+              - t: "prescrições"      # phrase(in this equation certain 'prescripts' apply)
+              - pause: short
+          - test:
+              if: "not($Prescripts[1][self::m:none])"
+              then:
+              - x: "$PreSubscript"
+              - x: "$Prescripts[1]"
+          - test:
+              if: "not($Prescripts[1][self::m:none] or $Prescripts[2][self::m:none])"
+              then: [t: "e"]      # phrase(10 is greater than 8 'and' less than 15)
+          - test:
+              if: "not($Prescripts[2][self::m:none])"
+              then:
+              - x: "$PreSuperscript"
+              - x: "$Prescripts[2]"
+          - pause: short
+          - test:
+              if: "count($Prescripts) > 2" # more common case
+              then:
+              - test:
+                  if: "not($Prescripts[3][self::m:none])"
+                  then:
+                  - x: "$PreSubscript"
+                  - x: "$Prescripts[3]"
+              - test:
+                  if: "not($Prescripts[3][self::m:none] or $Prescripts[4][self::m:none])"
+                  then: [t: "e"]      # phrase(10 is grater than 8 'and' less than 15)
+              - test:
+                  if: "not($Prescripts[4][self::m:none])"
+                  then:
+                  - x: "$PreSuperscript"
+                  - x: "$Prescripts[4]"
+              - test:
+                  if: "count($Prescripts) > 4" # give up and just dump them out so at least the content is there
+                  then:
+                  - t: "e prescrições alternadas"      # phrase(in this case there are values 'and alternating prescripts')
+                  - x: "$Prescripts[position() > 4]"
+                  - t: "prescrições finais"      # phrase(This is where 'end prescripts' occurs)
+  - test:
+      if: "$Postscripts"
+      then:
+      - with:
+          variables:
+          - PostSubscript: "IfThenElse($Verbosity='Verbose', 'subscript', 'sub')"
+          - PostSuperscript: "IfThenElse($Verbosity='Verbose', 'superscript', 'super')"
+          replace:
+          - test: # only bother announcing if there is more than one postscript
+              if: "count($Postscripts) > 2"
+              then:
+              - test:
+                  if: "$Prescripts"
+                  then: [t: "e"]      # phrase(10 is greater than 8 'and' less than 15)
+              - t: "por"      # phrase(substitute x 'with' y)
+              - x: "count($Postscripts) div 2"
+              - t: "pós-escritos"      # phrase(this material includes several 'postscripts')
+              - pause: short
+          - test:
+              if: "not($Postscripts[1][self::m:none])"
+              then:
+              - x: "$PostSubscript"
+              - x: "$Postscripts[1]"
+          - test:
+              if: "not($Postscripts[1][self::m:none] or $Postscripts[2][self::m:none])"
+              then: [t: "e"]      # phrase(10 is greater than 8 'and' less than 15)
+          - test:
+              if: "not($Postscripts[2][self::m:none])"
+              then:
+              - x: "$PostSuperscript"
+              - x: "$Postscripts[2]"
+          - test:
+              if: "count($Postscripts) > 2"
+              then:
+              - test:
+                  if: "not($Postscripts[3][self::m:none])"
+                  then:
+                  - x: "$PostSubscript"
+                  - x: "$Postscripts[3]"
+              - test:
+                  if: "not($Postscripts[3][self::m:none] or $Postscripts[4][self::m:none])"
+                  then: [t: "e"]      # phrase(10 is greater than 8 'and' less than 15)
+              - test:
+                  if: "not($Postscripts[4][self::m:none])"
+                  then:
+                  - x: "$PostSuperscript"
+                  - x: "$Postscripts[4]"
+              - test:
+                  if: "count($Postscripts) > 4"
+                  then:
+                  - test:
+                      if: "not($Postscripts[5][self::m:none])"
+                      then:
+                      - x: "$PostSubscript"
+                      - x: "$Postscripts[5]"
+                  - test:
+                      if: "not($Postscripts[5][self::m:none] or $Postscripts[6][self::m:none])"
+                      then: [t: "e"]      # phrase(10 is greater than 8 'and' less than 15)
+                  - test:
+                      if: "not($Postscripts[6][self::m:none])"
+                      then:
+                      - x: "$PostSuperscript"
+                      - x: "$Postscripts[6]"
+                  - test:
+                      if: "count($Postscripts) > 6"
+                      then:
+                      - test:
+                          if: "not($Postscripts[7][self::m:none])"
+                          then:
+                          - x: "$PostSubscript"
+                          - x: "$Postscripts[7]"
+                      - test:
+                          if: "not($Postscripts[7][self::m:none] or $Postscripts[8][self::m:none])"
+                          then: [t: "e"]      # phrase(10 is less than 15 'and' greater than 5)
+                      - test:
+                          if: "not($Postscripts[8][self::m:none])"
+                          then:
+                          - x: "$PostSuperscript"
+                          - x: "$Postscripts[8]"
+                      - test:
+                          if: "count($Postscripts) > 8" # give up and just dump them out so at least the content is there
+                          then:
+                          - t: "e roteiros alternados"      # phrase(this situation involves complexities 'and alternating scripts')
+                          - x: "$Postscripts[position() > 8]"
+                          - t: "scripts finais"      # phrase(At this point 'end scripts' occurs)
+
+- name: default
+  tag: [mtable, array]
+  variables:
+  - IsColumnSilent: "false()"
+  - NumColumns: "CountTableColumns(.)"
+  - NumRows: "CountTableRows(.)"
+  match: "."
+  replace:
+  - t: "tabela com"      # phrase(the 'table with' 3 rows)
+  - x: "$NumRows"
+  - test:
+      if: "$NumRows=1"
+      then: [t: "linha"]      # phrase(the table with 1 'row')
+      else: [t: "linhas"]      # phrase(the table with 3 'rows')
+  - t: "e"      # phrase(the table with 3 rows 'and' 4 columns)
+  - x: "$NumColumns"
+  - test:
+      if: "$NumColumns=1"
+      then: [t: "coluna"]      # phrase(the table with 3 rows and 1 'column')
+      else: [t: "colunas"]      # phrase(the table with 3 rows and 4 'columns')
+  - pause: long
+  - x: "*"
+
+- name: default
+  # callers/context should do that.
+  # this may get called from navigation -- in that case, there is no context to speak the row #, so don't do it
+  tag: [mtr, mlabeledtr]
+  match: "."
+  replace:
+  - pause: medium
+  - t: "linha"      # phrase(the first 'row' of a matrix)
+  - x: "count(preceding-sibling::*)+1"
+  - test:
+      if: "self::m:mlabeledtr"
+      then:
+      - t: "com rótulo"      # phrase(the line 'with label' first equation)
+      - x: "*[1]/*"
+      - pause: short
+  - pause: medium
+  - test:
+      if: "self::m:mlabeledtr"
+      then: [x: "*[position()>1]"]
+      else: [x: "*"]
+
+- name: default
+  tag: mtd
+  match: "."
+  replace:
+  - test:
+      #  ClearSpeak normally speaks "column 1" even though it says the row number, which is a waste...
+      #  The following is commented out but the count(...)!=0 probably belongs in other rule sets
+      #   if: not($IsColumnSilent) and ($ClearSpeak_Matrix = 'SpeakColNum' or count(preceding-sibling::*) != 0)
+      if: "not($IsColumnSilent)"
+      then:
+      - t: "coluna"      # phrase(the first 'column' of the matrix)
+      - x: "count(preceding-sibling::*)+IfThenElse(parent::m:mlabeledtr, 0, 1)"
+      - pause: medium
+  - x: "*"
+  - test:
+    # short pause after each element; medium pause if last element in a row; long pause for last element in matrix
+    - if: count(following-sibling::*) > 0
+      then: [pause: short]
+    - else_if: count(../following-sibling::*) > 0
+      then: [pause: medium]
+      else: [pause: long]
+
+
+- name: empty-box
+  # The ordering below is the order in which words come out when there is more than one value
+  # Note: @notation can contain more than one value
+  tag: menclose
+  match: "@notation='box' and *[self::m:mtext and .=' ']"
+  replace:
+  - t: "caixa vazia"      # phrase(the 'empty box' contains no values)
+
+- name: default
+  # The ordering below is the order in which words come out when there is more than one value
+  # Note: @notation can contain more than one value
+  tag: menclose
+  match: "."
+  replace:
+  - test:
+      if: ".[contains(concat(' ', normalize-space(@notation), ' '), ' box ')]"
+      then: [t: "caixa", pause: short]      # phrase(the 'box' around the expression)
+  - test:
+      if: ".[contains(@notation,'roundedbox')]"
+      then: [t: "caixa redonda", pause: short]      # phrase(the 'round box' around the expression)
+  - test:
+      if: ".[contains(@notation,'circle')]"
+      then: [t: "círculo", pause: short]      # phrase(the 'circle' around the expression)
+  - test:
+      if: ".[ contains(concat(' ', normalize-space(@notation), ' '), ' left ') or contains(concat(' ', normalize-space(@notation), ' '), ' right ') or contains(@notation,'top') or contains(@notation,'bottom') ]"
+      then:
+      - t: "linha"      # phrase(draw a straight 'line' on the page)
+      - test:
+          if: ".[contains(concat(' ', normalize-space(@notation), ' '), ' left ')]"
+          then: [t: "esquerda", pause: short]      # phrase(line on 'left' of the expression)
+      - test:
+          if: ".[contains(concat(' ', normalize-space(@notation), ' '), ' right ')]"
+          then: [t: "direita", pause: short]      # phrase(line on 'right' of the expression)
+      - test:
+          if: ".[contains(@notation,'top')]"
+          then: [t: "topo", pause: short]      # phrase(line on 'top' of the expression)
+      - test:
+          if: ".[contains(@notation,'bottom')]"
+          then: [t: "parte inferior", pause: short]      # phrase(line on the 'bottom' of the expression)
+  - test:
+      if: ".[ contains(@notation,'updiagonalstrike') or contains(@notation,'downdiagonalstrike') or contains(@notation,'verticalstrike') or contains(@notation,'horizontalstrike') ]"
+      then:
+      - test:
+          if: ".[contains(@notation,'updiagonalstrike') and contains(@notation,'downdiagonalstrike')]"
+          then: [spell: "'x'", pause: short] # seems better to say 'x cross out' than 'up diagonal, down diagonal cross out'
+          else:
+          - test:
+              if: ".[contains(@notation,'updiagonalstrike')]"
+              then: [t: "para cima na diagonal", pause: short]      # phrase(the line runs 'up diagonal')
+          - test:
+              if: ".[contains(@notation,'downdiagonalstrike')]"
+              then: [t: "diagonalmente para baixo", pause: short]      # phrase(the line runs 'down diagonal')
+      - test:
+          if: ".[contains(@notation,'verticalstrike')]"
+          then: [t: "vertical", pause: short]      # phrase(the line is  'vertical')
+      - test:
+          if: ".[contains(@notation,'horizontalstrike')]"
+          then: [t: "horizontal", pause: short]      # phrase(the line is 'horizontal')
+      - t: "risque"      # phrase(please 'cross out' the incorrect answer)
+      - pause: short
+  - test:
+      if: ".[contains(@notation,'uparrow')]"
+      then: [t: "seta para cima", pause: short]      # phrase(direction is shown by the 'up arrow')
+  - test:
+      if: ".[contains(concat(' ', normalize-space(@notation), ' '), ' downarrow ')]"
+      then: [t: "seta para baixo", pause: short]      # phrase(the trend is shown by the 'down arrow')
+  - test:
+      if: ".[contains(@notation,'leftarrow')]"
+      then: [t: "seta para a esquerda", pause: short]      # phrase(the 'left arrow' indicates going back)
+  - test:
+      if: ".[contains(concat(' ', normalize-space(@notation), ' '), ' rightarrow ')]"
+      then: [t: "seta para a direita", pause: short]      # phrase(the 'right arrow' indicates moving forward)
+  - test:
+      if: ".[contains(@notation,'northeastarrow')]"
+      then: [t: "seta nordeste", pause: short]      # phrase(direction is indicated by the 'northeast arrow')
+  - test:
+      if: ".[contains(concat(' ', normalize-space(@notation), ' '), ' southeastarrow ')]"
+      then: [t: "seta sudeste", pause: short]      # phrase(direction is shown by the 'southeast arrow')
+  - test:
+      if: ".[contains(concat(' ', normalize-space(@notation), ' '), ' southwestarrow ')]"
+      then: [t: "seta sudoeste", pause: short]      # phrase(direction is shown by the 'southwest arrow')
+  - test:
+      if: ".[contains(@notation,'northwestarrow')]"
+      then: [t: "seta noroeste", pause: short]      # phrase(direction is shown by the 'northwest arrow')
+  - test:
+      if: ".[contains(@notation,'updownarrow')]"
+      then: [t: "seta vertical dupla", pause: short]      # phrase(upward movement is indicated by the 'double ended vertical arrow')
+  - test:
+      if: ".[contains(@notation,'leftrightarrow')]"
+      then: [t: "seta horizontal dupla", pause: short]      # phrase(progress is indicated by the 'double ended horizontal arrow')
+  - test:
+      if: ".[contains(@notation,'northeastsouthwestarrow')]"
+      then: [t: "seta diagonal com ponta dupla", pause: short]      # phrase(trend is indicated by the 'double ended up diagonal arrow')
+  - test:
+      if: ".[contains(@notation,'northwestsoutheastarrow')]"
+      then: [t: "seta diagonal dupla para baixo", pause: short]      # phrase(trend is indicated by the 'double ended down diagonal arrow')
+  - test:
+      if: ".[contains(@notation,'actuarial')]"
+      then: [t: "símbolo atuarial", pause: short]      # phrase(the 'actuarial symbol' represents a specific quantity)
+  - test:
+      if: ".[contains(@notation,'madrub')]"
+      then: [t: "símbolo fatorial árabe", pause: short]      # phrase(the 'arabic factorial symbol' represents a factorial operation)
+  - test:
+      if: ".[contains(@notation,'phasorangle')]"
+      then: [t: "ângulo fasorial", pause: short]      # phrase(the 'phasor angle' is used to measure electrical current)
+  - test:
+      if: ".[contains(@notation,'longdiv') or not(@notation) or normalize-space(@notation) ='']" # default
+      then: [t: "símbolo de divisão longa", pause: short]      # phrase(the 'long division symbol' indicates  a long division calculation)
+  - test:
+      if: ".[contains(@notation,'radical')]"
+      then: [t: "raiz quadrada", pause: short]      # phrase(5 is the 'square root' of 25)
+  - t: "encerrando"      # phrase(parentheses are 'enclosing' part of the equation)
+  - test:
+      if: "*[self::m:mtext and .=' ']"
+      then: [t: "espaço"]     # otherwise there is complete silence      # phrase(there is a 'space' between the words)
+      else: [x: "*"]
+  - test:
+      if: "$Impairment = 'Blindness' and ( $SpeechStyle != 'SimpleSpeak' or not(IsNode(*[1], 'leaf')) )"
+      then: [t: "recinto final"]      # phrase(reached the 'end enclosure' point)
+  - pause: short
+
+- name: semantics
+  tag: "semantics"
+  match: "*[@encoding='MathML-Presentation']"
+  replace:
+  - x: "*[@encoding='MathML-Presentation']/*[1]"
+
+- name: semantics-default
+  tag: "semantics"
+  match: .
+  replace:
+  - x: "*[1]"
+
+- name: apply-function
+  tag: "apply-function"
+  match: .
+  replace:
+  - x: "*[1]"
+  - t: "de"      # phrase(the sine 'of' x )
+  - pause: auto
+  - x: "*[position() > 1]"
+ 
+# Here are the intent hints that need to be handled: 'prefix' | 'infix' | 'postfix' | 'function' | 'silent'
+- name: silent-intent
+  # uncaught intent -- the args have been inserted in the order of speech 
+  tag: "*"
+  match: "count(*)>0 and (contains(@data-intent-property, ':silent:') or translate(name(.), '-_', '')='')"
+  replace:
+  - x: "*"
+  - test:
+      if: "IsNode(., '2D')"
+      then: [pause: short]
+      else: [pause: auto]
+
+- name: nofix-intent
+  # uncaught intent -- the args have been inserted in the order of speech 
+  tag: "*"
+  match: "contains(@data-intent-property, ':nofix:') "
+  replace:
+  - x: "SpeakIntentName(name(.), $Verbosity, 'nofix')"
+
+- name: prefix-intent
+  # uncaught intent -- the args have been inserted in the order of speech 
+  tag: "*"
+  match: "count(*)>0 and contains(@data-intent-property, ':prefix:')"
+  replace:
+  - x: "SpeakIntentName(name(.), $Verbosity, 'prefix')"
+  - x: "*"
+  - test:
+      if: "not( IsBracketed(., '', '') or IsNode(*[last()], 'simple') )"
+      then: [x: "GetBracketingIntentName(name(.), $Verbosity, 'prefix', 'end')"]
+  - test:
+      if: "IsNode(., '2D')"
+      then: [pause: short]
+      else: [pause: auto]
+
+- name: postfix-intent
+  # uncaught intent -- the args have been inserted in the order of speech                
+  tag: "*"
+  match: "count(*)>0 and contains(@data-intent-property, ':postfix:')"
+  replace:
+  - test:
+      if: "$Impairment = 'Blindness' and not( IsBracketed(., '', '') or IsNode(*[1], 'simple') )"
+      then: [x: "GetBracketingIntentName(name(.), $Verbosity, 'postfix', 'start')"]
+  - x: "*"
+  - x: "SpeakIntentName(name(.), $Verbosity, 'postfix')"
+
+- name: infix-intent
+  # uncaught intent -- the args have been inserted in the order of speech 
+  tag: "*"
+  match: "count(*)>0 and contains(@data-intent-property, ':infix:')"
+  replace:
+  - test:
+      if: "$Impairment = 'Blindness' and not( IsBracketed(., '', '') or IsNode(*[1], 'simple') )"
+      then: [x: "GetBracketingIntentName(name(.), $Verbosity, 'infix', 'start')"]
+  - test:
+      if: "count(*) = 1"  # in cases such as continued-row, plus/minus might have just one child
+      then:
+      - x: "SpeakIntentName(name(.), $Verbosity, 'infix')"
+      - pause: auto
+      - x: "*[1]"
+      else:
+      - insert:
+          nodes: "*"
+          replace: [x: "SpeakIntentName(name(.), $Verbosity, 'infix')", pause: auto]
+  - test:
+      if: "$Impairment = 'Blindness' and not( IsBracketed(., '', '') or IsNode(*[last()], 'simple') )"
+      then: [x: "GetBracketingIntentName(name(.), $Verbosity, 'infix', 'end')"]
+  - test:
+      if: "IsNode(., '2D')"   # add (probably) a slightly longer pause if this came from a 2D node
+      then: [pause: short]
+      else: [pause: auto]
+
+- name: function-intent
+  # uncaught intent -- speak as foo of arg1 comma arg2 .... The MathML spec requires arguments to functions
+  tag: "*"
+  match: "count(*)>0"
+  replace:
+  - x: "SpeakIntentName(name(.), $Verbosity, 'function')"
+  - test:
+      if: "$Verbosity != 'Terse' and not(contains(@data-intent-property, ':literal:')) and
+           not(count(*)=2 and (IsInDefinition(*[1], 'TrigFunctionNames') or IsInDefinition(name(.), 'TerseFunctionNames')) and IsNode(*[2], 'simple'))"
+      then: [t: "de", pause: auto]      # phrase(sine 'of' 5)
+  - insert:
+      nodes: "*"
+      replace:
+      - test:
+          if: "not(contains(@data-intent-property, ':literal:'))"
+          then: [x: "','"]
+      - pause: auto
+  - test:
+      # speak "end ..." if not bracketed or last child is not simple and not last node
+      if: "$Impairment = 'Blindness' and not(*[last()][IsBracketed(., '', '') or IsNode(., 'simple')] )"
+      then: [x: "GetBracketingIntentName(name(.), $Verbosity, 'function', 'end')"]
+  - test:
+      if: "IsNode(., '2D')"
+      then: [pause: short]
+      else: [pause: auto]
+
+
+- name: default-text
+  # unknown leaf -- just speak the text -- could be a literal intent
+  tag: "*"
+  match: "."
+  replace:
+  - x: "translate(name(), '-_', ' ')"

--- a/Rules/Languages/pt/SharedRules/general.yaml
+++ b/Rules/Languages/pt/SharedRules/general.yaml
@@ -1,0 +1,1088 @@
+---
+
+# number-sets are a little messy in that the base was converted to a number-set, so we have to match that (simple) case last
+- name: pos-neg-number-sets
+  tag: number-sets
+  match: "count(*)=2 and *[2][.='+' or .='-']"
+  replace:
+  - test:
+      if: "$Verbosity!='Terse'"
+      then:
+      - t: "a"      # phrase('the' square root of 25 equals 5)
+  - bookmark: "*[2]/@id"
+  - test:
+    - if: "*[2][.='+']"
+      then: [t: "positivos"]      # phrase(set of all 'positive' integers less than 10)
+      else: [t: "negativos"]      # phrase(set of all 'negative' integers less than minus 10)
+  - bookmark: "*[1]/@id"
+  - test:
+    - if: "*[1][.='ℂ']"
+      then: [t: "números complexos"]      # phrase('complex numbers' consist of two parts)
+    - else_if: "*[1][.='ℕ']"
+      then: [t: "números naturais"]      # phrase('natural numbers' are numbers from 1 to infinity)
+    - else_if: "*[1][.='ℚ']"
+      then: [t: "números racionais"]      # phrase('rational numbers' are the fraction of 2 integers)
+    - else_if: "*[1][.='ℝ']"
+      then: [t: "números reais"]      # phrase('real numbers' can be both positive and negative)
+    - else_if: "*[1][.='ℤ']"
+      then: [t: "inteiros"]      # phrase(positive 'integers' are natural numbers above 0)
+      else: [x: "*[1][text()]"] # shouldn't happen
+
+- name: dimension-number-sets
+
+  # should be single digit integer at this point (e.g, R^3)
+  tag: number-sets
+  match: "count(*)=2"
+  replace:
+  - bookmark: "*[1]/@id"
+  - test:
+    - if: "*[1][.='ℂ']"
+      then: [t: "c"]      # phrase(the letter 'C' used to represent complex number)
+    - else_if: "*[1][.='ℕ']"
+      then: [t: "n"]      # phrase(the letter 'N' may represent natural numbers)
+    - else_if: "*[1][.='ℚ']"
+      then: [t: "q"]      # phrase(the letter 'Q' may represent rational numbers)
+    - else_if: "*[1][.='ℝ']"
+      then: [t: "r"]      # phrase(the letter 'R' may represent real numbers)
+    - else_if: "*[1][.='ℤ']"
+      then: [t: "z"]      # phrase(the letter 'Z' may represent integers)
+      else: [x: "*[1][text()]"] # shouldn't happen
+  - bookmark: "*[2]/@id"
+  - x: "*[2]"
+
+- name: simple-number-sets
+  tag: number-sets
+  match: "count(*)=0"
+  replace:
+  - bookmark: "@id"
+  - test:
+    - if: ".='ℂ'"
+      then: [t: "os números complexos"]      # phrase('the complex numbers' include 2 parts)
+    - else_if: ".='ℕ'"
+      then: [t: "os números naturais"]      # phrase('the natural numbers' begin at 1)
+    - else_if: ".='ℚ'"
+      then: [t: "os números racionais"]      # phrase('the rational numbers' are the fraction of 2 integers)
+    - else_if: ".='ℝ'"
+      then: [t: "os números reais"]      # phrase('the real numbers' can be both positive and negative)
+    - else_if: ".='ℤ'"
+      then: [t: "os inteiros"]      # phrase('the integers' are natural numbers above 0)
+      else: [x: "text()"] # shouldn't happen
+
+- name: real-part
+  tag: real-part
+  match: "."
+  replace:
+  - bookmark: "@id"
+  - t: "a parte real"      # phrase('the real part' of a complex number does not include the imaginary part)
+
+- name: imaginary-part
+  tag: imaginary-part
+  match: "."
+  replace:
+  - bookmark: "@id"
+  - t: "a parte imaginária"      # phrase('the imaginary part' is part of a complex number)
+
+# rules on scripted vertical bars ('evaluated at')
+- name: evaluated-at-2
+  tag: evaluate
+  match: "count(*)=2"
+  replace:
+  - x: "*[1]"
+  - pause: auto
+  - t: "avaliados em"      # phrase(results were 'evaluated at' a given point)
+  - pause: auto
+  - x: "*[2]"
+
+- name: evaluated-at-3
+  tag: evaluate
+  match: "count(*)=3"
+  replace:
+  - x: "*[1]"
+  - pause: auto
+  - t: "avaliados"      # phrase(results were 'evaluated at' this point)
+  - pause: auto
+  - x: "*[3]"
+  - t: "menos a mesma expressão avaliada em"      # phrase(this result is 'minus the same expression evaluated at' an earlier point)
+  - x: "*[2]"
+
+- name: permutation
+  # Not a default because the order of the args is reversed
+  tag: pochhammer
+  match: "count(*)=2 and contains(@data-intent-property, ':infix:')"
+  replace:
+  - x: "*[2]"
+  - t: "permutações de"      # phrase(the solution  involves several 'permutations of' values)
+  - x: "*[1]"
+
+- name: intervals
+  tag: [open-interval, open-closed-interval, closed-interval, closed-open-interval]
+  match: "count(*)=2"
+  replace:
+  - test:
+      if: "$Verbosity!='Terse'"
+      then:
+      - t: "a"      # phrase('the' square root of 25 equals 5)
+  - x: "translate(name(.),'-', ' ')"
+  - test:
+      if: "$Verbosity!='Terse'"
+      then:
+      - t: "de"      # phrase(subtracting 5 'from' 10 gives 5)
+      - x: "*[1]"
+      - t: "a"      # phrase(adding 6 'to' 6 equals  12)
+      - x: "*[2]"
+      else:
+      - x: "*[1]"
+      - t: "vírgula"      # phrase(use a 'comma' to divide large numbers or as a decimal point)
+      - x: "*[2]"
+
+- name: default-point
+  tag: point
+  match: "count(*)=2"
+  replace:
+  - test:
+      if: "$Verbosity!='Terse'"
+      then:
+      - t: "a"      # phrase('the' square root of 25 equals 5)
+  - t: "ponto"      # phrase(a decimal 'point' indicates the fraction component of a number)
+  - x: "*[1]"
+  - t: "vírgula"      # phrase(use a 'comma' to divide large numbers or as a decimal point)
+  - x: "*[2]"
+
+- name: bigop-both
+  tag: large-op
+  match: "count(*) = 3"
+  replace:
+  - test:
+      if: "$Verbosity!='Terse'"
+      then: [ot: "a"]      # phrase('the' square root of 25 equals 5)
+  - x: "*[1]"
+  - t: "de"      # phrase(subtracting 5 'from' 10 gives 5)
+  - x: "*[2]"
+  - pause: short
+  - t: "a"      # phrase(adding 6 'to' 6 equals  12)
+  - x: "*[3]"
+  - test:
+      if: "following-sibling::*"
+      then: [t: "de"]      # phrase(the square root 'of' 25 equals 5)
+
+- name: bigop-under
+  tag: large-op
+  match: "count(*)=2"
+  replace:
+  - test:
+      if: "$Verbosity!='Terse'"
+      then: [ot: "a"]      # phrase('the' square root of 25 equals 5)
+  - x: "*[1]"
+  - t: "acima de"      # phrase(2 'over' 3 equals two thirds)
+  - x: "*[2]"
+  - test:
+      if: "following-sibling::*"
+      then: [t: "de"]      # phrase(the square root 'of' 25 equals 5)
+
+- name: largeop
+  tag: mrow
+  match: "count(*)=2 and IsInDefinition(*[1], 'LargeOperators')"
+  replace:
+  - test:
+      if: "$Verbosity!='Terse'"
+      then: [ot: "a"]      # phrase('the' square root of 25 equals 5)
+  - x: "*[1]"
+  - t: "de"      # phrase(the square root 'of' 25 equals 5)
+  - x: "*[2]"
+
+- name: repeating-decimal
+  tag: repeating-decimal
+  match: "."
+  replace:
+  - x: "*[1]"
+  - t: "com dígitos repetidos"      # phrase('with repeating digits')
+  - spell: "*[2]"
+
+- name: msubsup-skip-super
+  # handles single, double, etc., prime
+  tag: [skip-super, say-super]
+  match: "count(*)=3"
+  replace:
+  - x: "*[1]"
+  - test:
+      if: "$Verbosity='Verbose'"
+      then: [t: "subscrito"]      # phrase(a 'subscript' may be used to indicate an index)
+      else: [t: "sub"]      # phrase(the result is 'sub' optimal)
+  - x: "*[2]"
+  - test:
+      if: "not(IsNode(*[2],'leaf') and $Impairment = 'Blindness')"
+      then:
+      - test:
+          if: "$Verbosity='Verbose'"
+          then: [t: "subscrito final"]      # phrase(this is the 'end subscript' position)
+          else: [t: "end sub"]      # phrase(this is the 'end sub' position)
+      - pause: short
+      else_test:
+          if: "*[2][self::m:mi]"   # need a pause in "x sub k prime" so the prime is not associated with the 'k'
+          then: [pause: short]
+  - test:
+      if: "name(.)='say-super'"
+      then_test:
+        if: "$Verbosity='Verbose'"
+        then: [t: "sobrescrito"]      # phrase(a 'superscript' number indicates raised to a power)
+        else: [t: "super"]      # phrase(this is a 'super' set of numbers)
+  - x: "*[3]"
+  - pause: short
+
+# in terse mode, we just say "m" or "s", etc., not meters or seconds
+- name: unit-terse
+  tag: unit
+  match: "$Verbosity = 'Terse' and string-length(.)=1"
+  replace:
+  - bookmark: "@id"
+  - spell: "text()"
+
+# the order of matching is
+# 1. does it match the base of an SI unit
+# 2. does it match an English unit (if in an English language)
+# 3. does it match an SI prefix followed by an SI that accepts SI prefixes
+# Due to this order, some things like "ft" and "cd" mean "feet" vs "femto-tonnes" and "pints" vs "pico-tonnes"
+- name: unit
+  tag: unit
+  match: "."
+  variables:
+    # If the coefficient is singular, we don't add the plural ending. Finding the coefficient is tricky
+    # Normal case (A) "3m" (parents is mrow), but could also be (B) "3 m^2" (etc.) (parent is power/mrow)
+    # But it might be in a fraction as (C) "3 m/s" (parent is fraction/mrow) or (D) "3 m^2/s^2" (parent is power/fraction/mrow)
+    #   or even (E) {3 m^2}/s (parent is power/mrow)
+    # If in a fraction, only look in the numerator to find the coefficient
+    # Note: we have a special case for pseudo-scripts like "°" (degrees) which are not powers -- they are essentially "1^°"
+    # The following "IfThenElse" logic returns the mrow that potentially contains the coefficient, if it exists
+    # The tests are in the order A, B & E, C, D
+  - MRowForCoefficient: "IfThenElse(parent::m:mrow, parent::m:mrow,
+                         IfThenElse(parent::m:power, ancestor::*[2][self::m:mrow],
+                         IfThenElse(parent::m:fraction and not(preceding-sibling::*), ancestor::*[2][self::m:mrow],
+                         IfThenElse(parent::m:power[parent::m:fraction and not(preceding-sibling::*)], ancestor::*[3][self::m:mrow], false()) ) ) )"
+  - IsSingular: "(not($MRowForCoefficient) and parent::*[name(.)!='skip-super' or *[1][.=1]]) or
+                 ($MRowForCoefficient and $MRowForCoefficient[(count(*) = 3 and *[1][self::m:mn and .=1] and *[2]='\u2062')])"
+  - Prefix: "''"
+  - Word: "''"  
+  replace:
+  - bookmark: "@id"
+  - test:
+    # is the whole string match a SI Unit without a prefix?
+    - if: "DefinitionValue(., 'Speech', 'SIUnits') != ''"
+      then:
+      - set_variables: [Word: "DefinitionValue(., 'Speech', 'SIUnits')"]
+    - else_if: "DefinitionValue(., 'Speech', 'UnitsWithoutPrefixes') != ''"
+      then:
+      - set_variables: [Word: "DefinitionValue(., 'Speech', 'UnitsWithoutPrefixes')"]
+    - else_if: "DefinitionValue(., 'Speech', 'EnglishUnits') != ''"
+      then:
+      - set_variables: [Word: "DefinitionValue(., 'Speech', 'EnglishUnits')"]
+
+    # do the first two chars match "da" and the remainder match an SIUnit
+    - else_if: "string-length(.) >= 3 and 
+                substring(., 1, 2) = 'da' and
+                DefinitionValue(substring(., 3), 'Speech', 'SIUnits') != ''"
+      then:
+      - set_variables:
+        - Prefix: "DefinitionValue('da', 'Speech', 'SIPrefixes')"
+        - Word: "DefinitionValue(substring(., 3), 'Speech', 'SIUnits')"
+
+    # does the first char match a prefix and the remainder match an SIUnit
+    - else_if: "string-length(.) >= 2 and 
+                DefinitionValue(substring(., 1, 1), 'Speech', 'SIPrefixes') != ''  and
+                DefinitionValue(substring(., 2), 'Speech', 'SIUnits') != ''"
+      then:
+      - set_variables:
+        - Prefix: "DefinitionValue(substring(., 1, 1), 'Speech', 'SIPrefixes')"
+        - Word: "DefinitionValue(substring(., 2), 'Speech', 'SIUnits')"
+
+    # not a known unit -- just speak the text, possibly as a plural
+    - else:
+      - set_variables:
+        - Word: "text()"
+
+  # somewhat complicated logic to avoid spaces around "-" as in "centi-grams" vs "centi - grams" -- probably doesn't matter
+  - test:
+      if: "$Prefix = ''"
+      then:
+      - test:
+        - if: "$IsSingular"
+          # HACK: '\uF8FE' is used internally for the concatenation char by 'ct' -- this gets the prefix concatenated to the base
+          then: [x: "$Word"]
+        - else_if: "DefinitionValue($Word, 'Speech', 'PluralForms') != ''"
+          then: [x: "DefinitionValue($Word, 'Speech', 'PluralForms')"]
+          else: [x: "$Word", ct: "s"]
+      else:
+      - x: "$Prefix"
+      - ct: "-"
+      - test:
+        - if: "$IsSingular"
+          # HACK: '\uF8FE' is used internally for the concatenation char by 'ct' -- this gets the prefix concatenated to the base
+          then: [x: "concat('\uF8FE', $Word)"]
+        - else_if: "DefinitionValue($Word, 'Speech', 'PluralForms') != ''"
+          then: [x: "concat('\uF8FE', DefinitionValue($Word, 'Speech', 'PluralForms'))"]
+          else: [x: "concat('\uF8FE', $Word)", ct: "s"]
+
+# need to reverse the order of speech: $ 3 -> 3 dollars
+- name: currency
+  tag: mrow
+  match: "count(*)=3 and DefinitionValue(*[1], 'Speech', 'CurrencySymbols') != ''"
+  variables:
+    # If the amount is singular, we don't add the plural ending.
+  - IsSingular: "*[3][self::m:mn and .=1] and *[2]='\u2062'"
+  - CurrencyWord: "DefinitionValue(*[1], 'Speech', 'CurrencySymbols')"
+  replace:
+  - bookmark: "*[3]/@id"
+  - x: "*[3]"
+  - test:
+    - if: "$IsSingular"
+      then: [x: "$CurrencyWord"]
+    - else_if: "DefinitionValue($CurrencyWord, 'Speech', 'PluralForms') != ''"
+      then: [x: "DefinitionValue($CurrencyWord, 'Speech', 'PluralForms')"]
+      else: [x: "DefinitionValue(*[1], 'Speech', 'CurrencySymbols')", ct: "s"]
+
+- name: sin
+  tag: mi
+  match: ".='sin'"
+  replace:
+  - bookmark: "@id"
+  - t: "seno"      # phrase(the 'sine' of the angle)
+- name: cos
+  tag: mi
+  match: ".='cos'"
+  replace:
+  - bookmark: "@id"
+  - test:
+      if: "$Verbosity='Terse'"
+      then: [t: "cos"]      # phrase('cos' is the abbreviation for cosine)
+      else: [t: "cosseno"]      # phrase(find the 'cosine' in a right-angle triangle)
+- name: tan
+  tag: mi
+  match: ".='tan' or .='tg'"
+  replace:
+  - bookmark: "@id"
+  - test:
+      if: "$Verbosity='Terse'"
+      then: [t: "tan"]      # phrase(the 'tan' is the ratio of the opposite to the adjacent side of a right-angled triangle)
+      else: [t: "tangente"]      # phrase(a 'tangent' is a straight line that touches a curve)
+- name: sec
+  tag: mi
+  match: ".='sec'"
+  replace:
+  - bookmark: "@id"
+  - test:
+      if: "$Verbosity='Terse'"
+      then: [t: "procurar"]      # phrase(to 'seek' a solution)
+      else: [t: "secante"]      # phrase(a 'secant' intersects a curve at two or more points)
+- name: csc
+  tag: mi
+  match: ".='csc'"
+  replace:
+  - bookmark: "@id"
+  - test:
+      if: "$Verbosity='Terse'"
+      then: [t: "cossecar"]      # phrase(we will 'cosecant' a solution)
+      else: [t: "cossecante"]      # phrase(the 'cosecant' is the reciprocal of the secant)
+- name: cot
+  tag: mi
+  match: ".='cot'"
+  replace:
+  - bookmark: "@id"
+  - test:
+      if: "$Verbosity='Terse'"
+      then: [t: "cotangente"]      # phrase(find the 'cotangent' in a right-angle triangle)
+      else: [t: "cotangente"]      # phrase(the 'cotangent' is the reciprocal of the tangent)
+
+- name: sinh
+  tag: mi
+  match: ".='sinh'"
+  replace:
+  - bookmark: "@id"
+  - test:
+      if: "$Verbosity='Terse'"
+      then: [t: "sinch"]      # phrase(the word 'sinch' is an abbreviation for hyperbolic sine)
+      else: [t: "seno hiperbólico"]      # phrase(the 'hyperbolic sine' is used in mathematics)
+- name: cosh
+  tag: mi
+  match: ".='cosh'"
+  replace:
+  - bookmark: "@id"
+  - test:
+      if: "$Verbosity='Terse'"
+      then: [t: "cosh"]      # phrase('cosh' is an abbreviation of hyperbolic cosine)
+      else: [t: "cosseno hiperbólico"]      # phrase(the 'hyperbolic cosine' is a mathematical function)
+- name: tanh
+  tag: mi
+  match: ".='tanh'"
+  replace:
+  - bookmark: "@id"
+  - test:
+      if: "$Verbosity='Terse'"
+      then: [t: "tanch"]      # phrase('tanch' is shorthand for hyperbolic tangent)
+      else: [t: "tangente hiperbólica"]      # phrase('hyperbolic tangent' is a mathematical function)
+- name: sech
+  tag: mi
+  match: ".='sech'"
+  replace:
+  - bookmark: "@id"
+  - test:
+      if: "$Verbosity='Terse'"
+      then: [t: "sheck"]      # phrase('sheck' is shorthand for hyperbolic secant)
+      else: [t: "secante hiperbólica"]      # phrase('hyperbolic secant' is a mathematical function)
+- name: csch
+  tag: mi
+  match: ".='csch'"
+  replace:
+  - bookmark: "@id"
+  - test:
+      if: "$Verbosity='Terse'"
+      then: [t: "cosheck"]      # phrase('cosheck' is shorthand for hyperbolic cosecant)
+      else: [t: "cossecante hiperbólica"]      # phrase('hyperbolic cosecant' is a mathematical function)
+- name: coth
+  tag: mi
+  match: ".='coth'"
+  replace:
+  - bookmark: "@id"
+  - test:
+      if: "$Verbosity='Terse'"
+      then: [t: "cotanch"]      # phrase('cotanch' is shorthand for hyperbolic cotangent)
+      else: [t: "cotangente hiperbólica"]      # phrase(the 'hyperbolic cotangent' is a mathematical function)
+- name: exponential
+  tag: mi
+  match: ".='exp'"
+  replace:
+  - bookmark: "@id"
+  - test:
+      if: "$Verbosity='Terse'"
+      then: [t: "exp"]      # phrase('exp' means exponential function)
+      else: [t: "exponencial"]      # phrase('exponential' function)
+- name: covariance
+  tag: mi
+  match: ".='Cov'"
+  replace:
+  - bookmark: "@id"
+  - test:
+      if: "$Verbosity='Terse'"
+      then: [t: "cov"]      # phrase('Cov' is shorthand for the covariance function)
+      else: [t: "covariância"]      # phrase('covariance' function)
+
+-
+  name: log    # handle log, principal Log, and ln (if in an mrow, 'intents' are used)
+  tag: mi
+  match: ".='log' or .='Log' or .='ln'"
+  replace:
+  - bookmark: "@id"
+  - test:
+    - if: "$Verbosity!='Terse'"
+      then: [ot: "a"]      # phrase('the' logarithm function is used in mathematics)
+  - test:
+    - if: ".= 'log'"
+      then: [t: "log"]      # phrase(the 'log' function is used in mathematics)
+    - else_if: ".= 'Log'"
+      then: [t: "log de valor principal"]
+    - else_if: "$Verbosity='Terse'"
+      then: [spell: "'ln'"]
+      else: [t: "log natural"]      # phrase(the 'natural log' function is used in mathematics)
+
+
+- name: multi-line
+  #   that eliminates the need for the if: else_if: ...
+  # IDEA:  set a variable with the word to say for the row (e.g., RowLabel = Row/Case/Line/...)
+  tag: [piecewise, system-of-equations, lines]
+  match: "."
+  variables:
+    # Wikipedia has some tables where all the entire first column is empty (e.g., https://en.wikipedia.org/wiki/List_of_trigonometric_identities)
+  - LineCount: "count(*[not(contains(@data-intent-property, ':continued-row:'))])"
+  - NextLineIsContinuedRow: "false()"   # default value
+  - IsColumnSilent: true()
+  replace:
+  - x: "$LineCount"
+  - test:
+    - if: "self::m:piecewise"
+      then: [t: "caso"]      # phrase(this is the first 'case' of three cases)
+    - else_if: "self::m:system-of-equations"
+      then: [t: "equação"]      # phrase(this is the first 'equation' of three equations)
+      else: [t: "linha"]      # phrase(this is the first 'line' of three lines)
+  - test:
+    - if: "$LineCount != 1"
+      then: [ct: "s"] # plural
+  - pause: short
+  - x: "*"
+  - pause: long
+
+
+- name: default-multiline
+  tag: [mtr, mlabeledtr]
+  match: "parent::m:piecewise or parent::m:system-of-equations or parent::m:lines"
+  variables: [NextLineIsContinuedRow: "following-sibling::*[1][contains(@data-intent-property, ':continued-row:')]"]
+  replace:
+  - test:
+      if: "not($LineCount=1 or contains(@data-intent-property, ':continued-row:'))"
+      then:
+      - pause: medium
+      - test:
+        - if: "parent::m:piecewise"
+          then: [t: "caso"]     # phrase('case' 1 of 10 cases)
+        - else_if: "parent::m:system-of-equations"
+          then: [t: "equação"] # phrase('equation' 1 of 10 equations)
+          else: [t: "linha"]     # phrase('line 1 of 10 lines)
+      - x: "count(preceding-sibling::*[not(contains(@data-intent-property, ':continued-row:'))]) + 1"
+  - test:
+      if: "self::m:mlabeledtr"
+      then:
+      - t: "com etiqueta"      # phrase(the diagram is complete 'with label')
+      - x: "*[1]/*"
+  - test:
+      if: "not(contains(@data-intent-property, ':continued-row:'))"
+      then: [pause: medium]
+  - test:
+      if: "self::m:mlabeledtr"
+      then: [x: "*[position()>1]"]
+      else: [x: "*"]
+
+- name: default-multiline
+  tag: mtd
+  match: "parent::*[parent::m:piecewise or parent::m:system-of-equations or parent::m:lines]"
+  variables: [LongPause: "$SpeechStyle = 'ClearSpeak' and $ClearSpeak_MultiLinePausesBetweenColumns = 'Long'"]
+  replace:
+  - test:
+      if: "IsInDefinition(*[1], 'ComparisonOperators')"
+      then: [pause: short]
+  - test:
+      if: "*[1][@data-added!='missing-content']"
+      then: [x: "*"]
+  - test:
+    # no pause after each element; medium pause if last element in a row; long pause for last element in matrix unless ClearSpeak override
+    - if: "count(following-sibling::*) = 0 and not($NextLineIsContinuedRow)"
+      then_test:
+          if: "count(../following-sibling::*) > 0"
+          then_test:
+              if: "$LongPause"
+              then: [pause: long]
+              else: [pause: medium]
+      else_test:
+          if: "IsInDefinition(*[1], 'ComparisonOperators')"
+          then: [pause: short]
+          else: [pause: auto]
+
+# Matrix/Determinant rules
+# matrix and determinant are the same other than "matrix"/"determinant" based on the bracketing chars
+# the pausing logic is pushed down to the <mtd>
+# the rules either speak the <mtr>s (to get "row n") or the <mtd>s. "column n" spoken if $IsColumnSilent is false
+- name: 1x1-matrix
+  tag: [matrix, determinant]
+  variables: [IsColumnSilent: true()]
+  match: "count(*)=1 and *[self::m:mtr][count(*) = 1]"
+  replace:
+  - ot: "a"      # phrase('the' 1 by 1 matrix M)
+  - t: "1 por 1"      # phrase(the '1 by 1' matrix)
+  - test:
+      if: "self::m:determinant" # just need to check the first bracket since we know it must be (, [, or |
+      then: [t: "determinante"]      # phrase(the 2 by 2 'determinant'))
+      else: [t: "matriz"]      # phrase(the 2 by 2 'matrix')
+      
+  - t: "com entrada"      # phrase(the 2 by 2 matrix 'with entry' x)
+  - x: "*[1]/*"
+
+# simpler reading methods for special case matrices
+- name: zero-matrix
+  tag: matrix
+  # select all the non-zero entries -- if there are none of them, then it is a zero matrix
+  match: "not( */*/*[not(self::m:mn and .= 0)] )"
+  replace:
+  - t: "a"      # phrase('the' 1 by 2 matrix M)
+  - x: count(*)
+  - t: "por"       # phrase(the 1 'by' 2 matrix)
+  - x: count(*[self::m:mtr][1]/*)
+  - t: "matriz zero"   # phrase(the 2 by 2 'zero matrix')
+  - pause: long
+
+- name: identity-matrix
+  tag: matrix
+  # every diagonal entry must be a literal 1, and every off-diagonal entry must be a literal 0
+  match:
+  - "count(*) = count(*[1]/*) and " # matrix is square
+  - "not( */*[count(preceding-sibling::*) = count(../preceding-sibling::*)]/*[not(self::m:mn and .= 1)] ) and " # on-diagonal
+  - "not( */*[count(preceding-sibling::*) != count(../preceding-sibling::*)]/*[not(self::m:mn and .= 0)] )" # off-diagonal
+  replace:
+  - t: "a"      # phrase('the' 1 by 2 matrix M)
+  - x: count(*)
+  - t: "por"       # phrase(the 1 'by' 2 matrix)
+  - x: count(*[self::m:mtr][1]/*)
+  - t: "matriz de identidade"   # phrase(the 2 by 2 'identity matrix')
+  - pause: long
+
+- name: diagonal-matrix
+  tag: matrix
+  # select all the non-zero entries...if they are not on the diagonal
+  #   if there are any of them, then this isn't an identity matrix
+  match:
+  - "count(*) = count(*[1]/*) and "
+  - "not( */*/*[not(self::m:mn and .= 0)]"
+  - "          [count(../preceding-sibling::*)!=count(../../preceding-sibling::*)]"
+  - "    )"
+  replace:
+  - t: "a"      # phrase('the' 1 by 2 matrix)
+  - x: count(*)
+  - t: "por"       # phrase(the 1 'by' 2 matrix)
+  - x: count(*[self::m:mtr][1]/*)
+  - t: "matriz diagonal"   # phrase(the 2 by 2 'diagonal matrix')
+  - pause: long
+  - insert:
+      # this lists the diagonal 'mtd's to be read, and they say "column nnn" before reading the contents
+      # there seems to be an xpath bug -- without the parens, the match fails for the
+      #   test Languages::en::mtable::diagonal_matrix due to match failure (the third matching element seems to be missing)
+      nodes: "(*/*/*[not(self::m:mn and .= 0)]/..)"
+      replace: [pause: auto]
+  - pause: long
+
+# simpler reading methods for smaller matrices if the entries are simple
+- name: 2-or-3x1-matrix
+  tag: matrix
+  variables: [IsColumnSilent: true()]
+  match:
+  - "$ClearSpeak_Matrix != 'SpeakColNum' and " # "simple" isn't used for this preference
+  - "*[self::m:mtr][count(*) = 1] and " # one column
+  - count(*)<=3 and # at least two rows
+  - IsNode(*/*/*,'simple') # IsNode() returns true if all the nodes are simple
+  replace:
+  - t: "a"      # phrase('the' 2 by 2 matrix M)
+  - x: count(*)
+  - t: "por 1 coluna"      # phrase(the 2 'by 1 column' matrix)
+  - test:
+      if: "$ClearSpeak_Matrix = 'Vector' or $ClearSpeak_Matrix = 'EndVector'"
+      then: [t: "vetor"]      # phrase(the 2 by 2 'vector')
+      else: [t: "matriz"]      # phrase(the 2 by 2 'matrix')
+  - pause: long
+  - x: "*/*"
+  - test:
+      if: "$ClearSpeak_Matrix = 'EndMatrix' or $ClearSpeak_Matrix = 'EndVector'"
+      then:
+      - t: "fim"      # phrase('end' of matrix)
+      - test:
+          if: $ClearSpeak_Matrix = 'EndVector'
+          then: [t: "vetor"]      # phrase(the 2 column 'vector')
+          else: [t: "matriz"]      # phrase(the 2 by 2 'matrix')
+
+- name: default-column-matrix
+  tag: matrix
+  variables: [IsColumnSilent: true()]
+  match: "*[self::m:mtr][count(*) = 1]"
+  replace:
+  - t: "a"      # phrase('the' 2 by 2 matrix M)
+  - x: "count(*)"
+  - t: "por 1 coluna"      # phrase(the 2 'by 1 column' matrix)
+  - test:
+      if: "$ClearSpeak_Matrix = 'Vector' or $ClearSpeak_Matrix = 'EndVector'"
+      then: [t: "vetor"]      # phrase(the 2 column 'vector')
+      else: [t: "matriz"]      # phrase(the 2 by 2 'matrix')
+  - pause: long
+  - x: "*" # select the rows (mtr)
+  - test:
+      if: "$ClearSpeak_Matrix = 'EndMatrix' or $ClearSpeak_Matrix = 'EndVector'"
+      then: [t: "fim da matriz"]      # phrase(the 'end of matrix' has been reached)
+
+- name: 1x2-or-3-matrix
+  tag: matrix
+  variables: [IsColumnSilent: "$SpeechStyle = 'SimpleSpeak' or ($SpeechStyle = 'ClearSpeak' and $ClearSpeak_Matrix != 'SpeakColNum')"]
+  match:
+  - "$ClearSpeak_Matrix != 'SpeakColNum' and " # "simple" isn't used for this preference
+  - count(*)=1  and # one row
+  - count(*[1]/*)<=3 and # at least two cols
+  - IsNode(*/*/*,'simple') # IsNode() returns true if all the nodes are simple
+  replace:
+  - t: "a 1 por"      # phrase('the 1 by' 2 matrix)
+  - x: count(*/*)
+  - t: "linha"      # phrase(the 1 by 4 'row' matrix)
+  - test:
+      if: "$ClearSpeak_Matrix = 'Vector' or $ClearSpeak_Matrix = 'EndVector'"
+      then: [t: "vetor"]      # phrase('the 1 by' 2 row 'vector')
+      else: [t: "matriz"]      # phrase('the 1 by' 2 'matrix')
+  - pause: long
+  - x: "*/*"
+  - test:
+      if: "$ClearSpeak_Matrix = 'EndMatrix' or $ClearSpeak_Matrix = 'EndVector'"
+      then:
+      - t: "fim"      # phrase(the 'end' of matrix has been reached)
+      - test:
+          if: $ClearSpeak_Matrix = 'EndMatrix'
+          then: [t: "matriz"]      # phrase(the 2 by 2 'matrix')
+          else: [t: "vetor"]      # phrase(the 2 by 1 'vector')
+
+- name: default-row-matrix
+  tag: matrix
+  variables: [IsColumnSilent: "$SpeechStyle = 'ClearSpeak' and $ClearSpeak_Matrix = 'SilentColNum'"]
+  match: "count(*)=1" # one row
+  replace:
+  - t: "a 1 por"      # phrase('the 1 by' 2 matrix)
+  - x: "count(*/*)"
+  - t: "linha"      # phrase(the 1 by 2 'row' matrix)
+  - test:
+      if: "$ClearSpeak_Matrix = 'Vector' or $ClearSpeak_Matrix = 'EndVector'"
+      then: [t: "vetor"]      # phrase(the 2 by 1 'vector')
+      else: [t: "matriz"]      # phrase(the 2 by 2 'matrix')
+  - pause: long
+  - pause: medium
+  - x: "*/*" # select the cols (mtd)
+  - test:
+      if: "$ClearSpeak_Matrix = 'EndMatrix' or $ClearSpeak_Matrix = 'EndVector'"
+      then:
+      - t: "fim"      # phrase(the 'end' of matrix has been reached)
+      - test:
+          if: $ClearSpeak_Matrix = 'EndMatrix'
+          then: [t: "matriz"]      # phrase(the 2 by 2 'matrix')
+          else: [t: "vetor"]      # phrase(the 2 by 1 'vector')
+
+- name: simple-small-matrix
+  tag: [matrix, determinant]
+  match:
+  - "$ClearSpeak_Matrix != 'SpeakColNum' and " # "simple" isn't used for this preference
+  - (count(*)<=3 and count(*[1]/*)<=3) and # no bigger than a 3x3 matrix
+  - IsNode(*/*/*,'simple') # IsNode() returns true if all the nodes are simple
+  variables: [IsColumnSilent: "$SpeechStyle = 'SimpleSpeak' or ($SpeechStyle = 'ClearSpeak' and $ClearSpeak_Matrix != 'SpeakColNum')"]
+  replace:
+  - t: "a"      # phrase('the' 1 by 2 matrix M)
+  - x: count(*)
+  - t: "por"      # phrase(the 1 'by' 2 matrix)
+  - x: count(*[self::m:mtr][1]/*)
+  - test:
+      if: "self::m:determinant"
+      then: [t: "determinante"]      # phrase(the 2 by 2 'determinant')
+      else:
+      - test:
+          if: "@columnlines and (contains(normalize-space(@columnlines), 'solid') or contains(normalize-space(@columnlines), 'dashed'))"
+          then: [t: "matriz aumentada"]      # phrase(the 2 by 2 'augmented matrix')
+          else: [t: "matriz"]      # phrase(the 2 by 2 'matrix')
+  - pause: long
+  - x: "*"
+  - test:
+      if: "$ClearSpeak_Matrix = 'EndMatrix' or $ClearSpeak_Matrix = 'EndVector'"
+      then:
+      - t: "fim"      # phrase(the 'end' of matrix has been reached)
+      - test:
+          if: "self::m:determinant"
+          then: [t: "determinante"]      # phrase(the 2 by 2 'determinant')
+          else: [t: "matriz"]      # phrase(the 2 by 2 'matrix')
+
+- name: default-matrix
+  tag: [matrix, determinant]
+  variables: [IsColumnSilent: "$SpeechStyle = 'ClearSpeak' and $ClearSpeak_Matrix = 'SilentColNum'"]
+  match: "."
+  replace:
+  - t: "a"      # phrase('the' 1 by 2 matrix M)
+  - x: "count(*)"
+  - t: "por"      # phrase(the 1 'by' 2 matrix)
+  - x: "count(*[self::m:mtr][1]/*)"
+  - test:
+      if: "self::m:determinant"
+      then: [t: "determinante"]      # phrase(the 2 by 2 'determinant')
+      else:
+      - test:
+          if: "@columnlines and (contains(normalize-space(@columnlines), 'solid') or contains(normalize-space(@columnlines), 'dashed'))"
+          then: [t: "matriz aumentada"]      # phrase(the 2 by 2 'augmented matrix')
+          else: [t: "matriz"]      # phrase(the 2 by 2 'matrix')
+  - pause: long
+  - x: "*"
+  - test:
+      if: "$ClearSpeak_Matrix = 'EndMatrix' or $ClearSpeak_Matrix = 'EndVector'"
+      then:
+      - t: "fim"      # phrase(the 'end' of matrix has been reached)
+      - test:
+          if: "self::m:determinant"
+          then: [t: "determinante"]      # phrase(the 2 by 2 'determinant')
+          else: [t: "matriz"]      # phrase(the 2 by 2 'matrix's)
+
+- name: chemistry-msub
+  tag: [chemical-formula]
+  match: "*[1][.='msub']"
+  replace:
+  - x: "*[2]"
+  - test:
+      if: "$Verbosity='Verbose'"
+      then: [t: "subscrito"]      # phrase(H 'subscript' 2)
+      else_test:
+        if: "$Verbosity='Medium'"
+        then: [t: "sub"]      # phrase(H 'sub' 2)
+  - x: "*[3]"
+
+- name: dimension-by
+  tag: mrow
+  match: dimension-product
+  replace:
+  - insert:
+      nodes: "*"
+      replace: [t: "por", pause: auto]      # phrase(3 'by' 5 matrix)
+
+- name: chemistry-msup
+  tag: [chemical-formula]
+  match: "count(*)=3 and *[1][.='msup']"
+  replace:
+  - x: "*[2]"
+  - test:
+      if: "$Verbosity='Verbose'"
+      then: [t: "sobrescrito"]      # phrase(H 'superscript' 2)
+      else_test:
+        if: "$Verbosity='Medium'"
+        then: [t: "super"]      # phrase(H 'super' 2)
+  - x: "*[3]"
+  - test:
+      if: "following-sibling::*[1][.='+' or .='-']" # a little lazy -- assumes chemistry superscripts end with + or -
+      then: [pause: medium]
+
+-
+  # There currently is no way to do sub/super for n-ary number of args
+  # Instead, we just deal with up to two prescripts and up to four postscripts (repeating blocks of similar code [UGLY!])
+  # This hopefully covers all reasonable cases...
+  name: chemistry-scripts
+  tag: [chemical-formula, chemical-nuclide]
+  variables:
+  # computing the number of postscripts is messy because of <mprescripts> being optionally present -- we use "mod" to get the count right
+  - Prescripts: "m:mprescripts/following-sibling::*"
+  - NumChildren: "count(*)" # need to stash this since the count is wrong inside '*[...]' below
+  - Postscripts: "*[position()>1 and position() < (last() + ($NumChildren mod 2) -count($Prescripts))]"
+  match: . # should only be msubsup or mmultiscripts at this point
+  replace:
+  - test:
+      if: "$Prescripts" # we have at least one pre sub/super 
+      then:
+      # nuclide: speak the superscript first
+      - test:
+          if: "not($Prescripts[2][self::m:none])"
+          then:
+          - test:
+              if: "$Verbosity='Verbose'"
+              then: [t: "sobrescrito"]      # phrase(H 'superscript' 2)
+              else_test:
+                if: "$Verbosity='Medium'"
+                then: [t: "super"]      # phrase(H 'super' 2)
+          - x: "$Prescripts[2]"
+          - pause: "short"
+      - test:
+          if: "not($Prescripts[1][self::m:none])"
+          then:
+          - test:
+              if: "$Verbosity='Verbose'"
+              then: [t: "subscrito"]      # phrase(a 'subscript' may be used to indicate an index)
+              else_test:
+                if: "$Verbosity='Medium'"
+                then: [t: "sub"]      # phrase(here is a 'sub' total)
+          - x: "$Prescripts[1]"
+          - pause: "short"
+      - test:
+          if: "count($Prescripts) > 2" # can this happen for chemistry??? we allow for one *extra* pre sub/super pair
+          then:
+          - test:
+              if: "not($Prescripts[4][self::m:none])"
+              then:
+              - test:
+                  if: "$Verbosity='Verbose'"
+                  then: [t: "sobrescrito"]      # phrase(H 'superscript' 2)
+                  else_test:
+                    if: "$Verbosity='Medium'"
+                    then: [t: "super"]      # phrase(H 'super' 2)
+              - x: "$Prescripts[4]"
+              - pause: "short"
+          - test:
+              if: "not($Prescripts[3][self::m:none])"
+              then:
+              - test:
+                  if: "$Verbosity='Verbose'"
+                  then: [t: "subscrito"]      # phrase(H 'subscript' 2)
+                  else_test:
+                    if: "$Verbosity='Medium'"
+                    then: [t: "sub"]      # phrase(H 'sub' 2)
+              - x: "$Prescripts[3]"
+              - pause: "short"
+  - x: "*[1]" # base
+  - test:
+      if: "$Postscripts"
+      then:
+      - test:
+          if: "not($Postscripts[1][self::m:none])"
+          then:
+          - test:
+              if: "$Verbosity='Verbose'"
+              then: [t: "subscrito"]      # phrase(phrase(H 'subscript' 2)
+              else_test:
+                if: "$Verbosity='Medium'"
+                then: [t: "sub"]      # phrase(phrase(H 'sub' 2)
+          - x: "$Postscripts[1]"
+          - pause: "short"
+      - test:
+          if: "not($Postscripts[2][self::m:none])"
+          then:
+          - test:
+              if: "$Verbosity='Verbose'"
+              then: [t: "sobrescrito"]      # phrase(H 'superscript' 2)
+              else_test:
+                if: "$Verbosity='Medium'"
+                then: [t: "super"]          # phrase(H 'super' 2)
+          - x: "$Postscripts[2]"
+          - pause: "short"
+      - test:
+          if: "count($Postscripts) > 2"
+          then:
+          - test:
+              if: "not($Postscripts[3][self::m:none])"
+              then:
+              - test:
+                  if: "$Verbosity='Verbose'"
+                  then: [t: "subscrito"]      # phrase(H 'subscript' 2)
+                  else_test:
+                    if: "$Verbosity='Medium'"
+                    then: [t: "sub"]          # phrase(H 'sub' 2)
+              - x: "$Postscripts[3]"
+              - pause: "short"
+          - test:
+              if: "not($Postscripts[4][self::m:none])"
+              then:
+              - test:
+                  if: "$Verbosity='Verbose'"
+                  then: [t: "sobrescrito"]      # phrase(H 'superscript' 2)
+                  else_test:
+                    if: "$Verbosity='Medium'"
+                    then: [t: "super"]          # phrase(H 'super' 2)
+              - x: "$Postscripts[4]"
+              - pause: "short"
+          - test:
+              if: "count($Postscripts) > 4"
+              then:
+              - test:
+                  if: "not($Postscripts[5][self::m:none])"
+                  then:
+                  - test:
+                      if: "$Verbosity='Verbose'"
+                      then: [t: "subscrito"]    # phrase(H 'subscript' 2)
+                      else_test:
+                        if: "$Verbosity='Medium'"
+                        then: [t: "sub"]        # phrase(H 'sub' 2)
+                  - x: "$Postscripts[5]"
+                  - pause: "short"
+              - test:
+                  if: "not($Postscripts[6][self::m:none])"
+                  then:
+                  - test:
+                      if: "$Verbosity='Verbose'"
+                      then: [t: "sobrescrito"]  # phrase(H 'superscript' 2)
+                      else_test:
+                        if: "$Verbosity='Medium'"
+                        then: [t: "super"]      # phrase(H 'super' 2)
+                  - x: "$Postscripts[6]"
+                  - pause: "short"
+              - test:
+                  if: "count($Postscripts) > 6"
+                  then:
+                  - test:
+                      if: "not($Postscripts[7][self::m:none])"
+                      then:
+                      - test:
+                          if: "$Verbosity='Verbose'"
+                          then: [t: "subscrito"]      # phrase(H 'subscript' 2)
+                          else_test:
+                            if: "$Verbosity='Medium'"
+                            then: [t: "sub"]      # phrase(H 'sub' 2)
+                      - x: "$Postscripts[7]"
+                      - pause: "short"
+                  - test:
+                      if: "not($Postscripts[8][self::m:none])"
+                      then:
+                      - test:
+                          if: "$Verbosity='Verbose'"
+                          then: [t: "sobrescrito"]      # phrase(H 'superscript' 2)
+                          else_test:
+                            if: "$Verbosity='Medium'"
+                            then: [t: "super"]      # phrase(H 'super' 2)
+                      - x: "$Postscripts[8]"
+                      - pause: "short"
+      - test:
+          if: "$Postscripts[last()][not(self::m:none)] and following-sibling::*[1][.='+' or .='-']"
+          then: [pause: medium]
+
+- name: chemistry
+  tag: chemical-equation
+  match: "."
+  replace:
+  - x: "*"
+
+- name: chemical-element
+  tag: chemical-element
+  match: "."
+  replace:
+  - bookmark: "@id"
+  - spell: text()
+  - pause: short
+
+- name: chemical-state
+  tag: chemical-state
+  match: "count(*)=1"
+  replace:
+  - bookmark: "*[1]/@id"
+  - test:
+    - if: ".='s'"
+      then: [t: "sólido"]      # phrase(Boron is a 'solid' in its natural state)
+    - else_if: ".='l'"
+      then: [t: "líquido"]      # phrase(water is a 'liquid')
+    - else_if: ".='g'"
+      then: [t: "gás"]      # phrase(hydrogen is a 'gas' )
+      else: [t: "aquosa"]      # phrase(an 'aqueous' solution is contained in water)
+  - pause: short
+
+- name: chemical-formula-operator-bond
+  tag: chemical-formula-operator
+  match: "@data-chemical-bond"
+  replace:
+  # FIX: this might be better/more efficient if in unicode.yaml
+  - bookmark: "@id"
+  - test:
+    - if: ".='-' or .=':'"
+      then: [t: "ligação simples"]      # phrase(a 'single bond' is formed when two atoms share one pair of electrons)
+    - else_if: ".='=' or .='∷'"
+      then: [t: "ligação dupla"]      # phrase(a 'double bond' may occur when two atoms share two pairs of electrons)
+    - else_if: ".='≡'"
+      then: [t: "ligação tripla"]      # phrase(a 'triple bond' occurs when two atoms share three pairs of electrons)
+    - else_if: ".='≣'"
+      then: [t: "ligação quádrupla"]      # phrase(a 'quadruple bond' occurs when two atoms share four pairs of electrons)
+      else: [x: "text()"]
+
+- name: chemical-formula-operator
+  tag: chemical-formula-operator
+  match: "."
+  replace:
+    x: "text()"
+
+- name: chemical-arrow-operator
+  tag: chemical-arrow-operator
+  match: "."
+  replace:
+  # FIX: this might be better/more efficient if in unicode.yaml
+  - bookmark: "@id"
+  - test:
+    - if: ".='→' or .='⟶'"
+      then_test:
+        if: "$Verbosity='Terse'"
+        then: [t: "formam"]      # phrase(hydrogen and oxygen 'forms' water )
+        else: [t: "reagem para formar"]      # phrase(hydrogen and oxygen 'reacts to form' water)
+    - else_if: ".='⇌' or .='🣑'" # U+01F8D1
+      then: [t: "está em equilíbrio com"]      # phrase(a reactant 'is in equilibrium with' a product)
+    - else_if: ".='🣓'" # U+1F8D3
+      then: [t: "está em equilíbrio inclinado para a esquerda com"]      # phrase(the reactant 'is in equilibrium biased to the left with' the product)
+    - else_if: ".='🣒'" # U+1F8D2
+      then: [t: "está em equilíbrio inclinado para a direita com"]      # phrase(the reactant 'is in equilibrium biased to the right with' the product)
+      else: [x: "*"]
+
+- name: chemical-equation-operator
+  tag: chemical-equation-operator
+  match: "."
+  replace:
+  - bookmark: "@id"
+  - x: "text()"
+
+- name: none
+  tag: none
+  match: "../../*[self::m:chemical-formula or self::m:chemical-nuclide]"
+  replace:
+  - t: "" # don't say anything
+
+- name: ignore-intent-wrapper
+  tag: intent-wrapper
+  match: "."
+  replace:
+  - x: "*"

--- a/Rules/Languages/pt/SharedRules/geometry.yaml
+++ b/Rules/Languages/pt/SharedRules/geometry.yaml
@@ -1,0 +1,79 @@
+---
+
+- name: line-segment
+  tag: line-segment
+  match: "count(*)=2"
+  replace:
+  - test:
+      if: "$Verbosity='Verbose'"
+      then:
+      - t: "o segmento de linha de"      # phrase('the line segment from' A to B)
+      - x: "*[1]"
+      - t: "para"                         # phrase(the line segment from A 'to' B)
+      - x: "*[2]"
+      else:
+      - t: "segmento de linha"               # phrase(the 'line segment' A  B)
+      - x: "*[1]"
+      - x: "*[2]"
+
+- name: geometry-ray
+  tag: ray
+  match: "count(*)=2"
+  replace:
+  - test:
+      if: "$Verbosity='Verbose'"
+      then:
+      - t: "o raio de"             # phrase('the ray from' A to B)
+      - x: "*[1]"
+      - t: "para"                       # phrase(the ray from A 'to' B)
+      - x: "*[2]"
+      else:
+      - t: "raio"                      # phrase(the 'ray'A  B)
+      - x: "*[1]"
+      - x: "*[2]"
+
+- name: geometry-arc
+  tag: arc
+  match: "count(*)=2"
+  replace:
+  - test:
+      if: "$Verbosity='Verbose'"
+      then: [ot: "o"]            # phrase('the' arc A B C)
+  - t: "arco"                        # phrase(the 'arc' A B C)
+  - x: "*[1]"
+  - x: "*[2]"
+
+- name: measure-of-angle
+  tag: measure-of-angle
+  match: "count(*)=3"
+  replace:
+  - test:
+      if: "$Verbosity='Verbose'"
+      then:
+      - t: "a medida do ângulo"      # phrase('the measure of the angle' ABC)
+      else:
+      - t: "medida do ângulo"      # phrase('measure of angle' ABC)
+  - x: "*[1]"
+  - x: "*[2]"
+  - x: "*[3]"
+
+
+- name: coordinate
+  tag: coordinate
+  match: "."
+  replace:
+  - test:
+      if: "$Verbosity='Verbose'"
+      then: [ot: "o"]      # phrase('the' point at 1, 2)
+  - t: "ponto"      # phrase(the 'point' at 1, 2)
+  - test:
+      if: "$Verbosity='Verbose'"
+      then: [t: "o"]      # phrase('the' point at 1, 2)
+  - pause: short
+  - insert:
+      nodes: "*"
+      replace: [t: "vírgula", pause: auto]      # phrase(f of x 'comma' y)
+  - pause: short
+  - test:
+      if: "($SpeechStyle='ClearSpeak' and $Verbosity='Verbose') or not(IsNode(*[last()],'leaf'))"
+      then: [t: "ponto final"]      # phrase(start point, 'end point')

--- a/Rules/Languages/pt/SharedRules/linear-algebra.yaml
+++ b/Rules/Languages/pt/SharedRules/linear-algebra.yaml
@@ -1,0 +1,36 @@
+---
+
+- name: scalar-determinant
+  tag: determinant
+  match: "count(*)=1 and not(*[1][self::m:mtr])"
+  replace:
+  - test:
+      if: "$Verbosity='Verbose'"
+      then:
+      - t: "a"      # phrase('the' square root of 25 equals 5)
+  - t: "determinante"      # phrase(the 'determinant' of a matrix)
+  - test:
+      if: "$Verbosity!='Terse'"
+      then:
+      - t: "de"      # phrase(systems 'of' linear equations)
+  - x: "*[1]"
+  - test:
+      if: "not(IsNode(*[1], 'simple')) and $Impairment = 'Blindness'"
+      then: [t: "determinante final"]      # phrase('end determinant' of a matrix)
+
+
+- name: subscripted-norm
+  tag: subscripted-norm
+  match: "count(*)=2"
+  replace:
+  - test:
+      if: "$Verbosity='Verbose'"
+      then:
+      - t: "a"      # phrase('the' square root of 25 equals 5)
+  - x: "*[2]"
+  - t: "norma"      # phrase(the 'norm' can be a measure of distance)
+  - test:
+      if: "$Verbosity!='Terse'"
+      then:
+      - t: "de"      # phrase(systems 'of' linear equations)
+  - x: "*[1]"

--- a/Rules/Languages/pt/SimpleSpeak_Rules.yaml
+++ b/Rules/Languages/pt/SimpleSpeak_Rules.yaml
@@ -1,0 +1,350 @@
+---
+- name: pause
+  tag: "!*"
+  match: "not(self::m:math) and not($MatchingPause) and @data-intent-property[contains(., ':pause')]"
+  replace:
+   - with:
+      variables: [MatchingPause: "true()"]
+      replace:
+      - test:
+        - if: "contains(@data-intent-property, ':pause-long')"
+          then: [pause: long]
+        - else_if: "contains(@data-intent-property, ':pause-short')"
+          then: [pause: short]
+          else: [pause: medium]
+      - x: "."
+
+- name: intent-literal-silent
+  tag: [mi, mo, mn]
+  match: "contains(@data-intent-property, ':silent:')"
+  # say nothing
+  replace: []
+
+# handling of negative numbers that come from 'intent' is hard -- we do something that is close to right here 
+- name: intent-literal-negative-number
+  tag: mn
+  match: "starts-with(text(), '-')"
+  replace:
+  - t: "menos"        # phrase(x 'minus' y)
+  - x: "translate(text(), '-_', '')"
+
+- name: default
+  tag: square-root
+  match: "."
+  replace:
+  - test:
+      if: "$Verbosity!='Terse'"
+      then: [ot: "a"]    # phrase('the' square root of x)
+  - t: "raiz quadrada"      # phrase(the 'square root' of x)
+  - test:
+      if: "$Verbosity!='Terse'"
+      then: [t: "de"]   # phrase(the square root 'of' x)
+      else: [pause: short]
+  - x: "*[1]"
+  - pause: short
+  - test:
+      if: "not(IsNode(*[1], 'leaf')) and $Impairment = 'Blindness'"
+      then: [t: "fim da raiz", pause: medium]  # phrase(start the square root of x 'end of root')
+
+- name: default
+  tag: root
+  match: "."
+  replace:
+  - test:
+      if: "$Verbosity!='Terse'"
+      then: [ot: "o"]
+  - test:
+      if: "*[2][self::m:mn and not(contains(., '.'))]"
+      then_test:
+      - if: "*[2][.='2']"
+        then: [t: "raiz quadrada"]        # phrase(the 'square root' of x)
+      - else_if: "*[2][.='3']"
+        then: [t: "raiz cúbica"]        # phrase(the 'cube root' of x)
+      - else: [x: "ToOrdinal(*[2])", t: "raiz"]      # phrase(the square 'root' of 25)
+      else:
+      - test:
+          if: "*[2][self::m:mi][string-length(.)=1]"
+          then:
+          - x: "*[2]"
+          - pronounce: [text: "-th", ipa: "θ", sapi5: "th", eloquence: "T"]
+          else: [x: "*[2]"]
+      - t: "raiz"        # phrase(the square 'root' of)
+  - test:
+      if: "$Verbosity!='Terse'"
+      then: [t: "de"]        # phrase(the square root 'of' x)
+  - x: "*[1]"
+  - pause: short
+  - test:
+      if: "not(IsNode(*[1], 'leaf')) and $Impairment = 'Blindness'"
+      then: [t: "fim da raiz", pause: medium]  # phrase(start the square root of x 'end of root')
+
+# Fraction rules
+# Mixed numbers mostly "just work" because the invisible char reads as "and" and other parts read properly on their own
+- name: common-fraction
+  tag: fraction
+  match:
+  - "*[1][self::m:mn][not(contains(., '.')) and text()<20]   and"
+  - "*[2][self::m:mn][not(contains(., '.')) and 2<= text() and text()<=10]"
+  variables: [IsPlural: "*[1]!=1"]
+  replace:
+  - x: "*[1]"
+  - x: "ToOrdinal(*[2], true(), $IsPlural)"   # extra args specify fractional ordinal and whether it is plural
+
+- name: common-fraction-mixed-number
+  tag: fraction
+  match:
+  - "preceding-sibling::*[1][self::m:mo][.='⁤'] and" # preceding element is invisible plus
+  - "*[1][self::m:mn][not(contains(., '.'))]   and"
+  - "*[2][self::m:mn][not(contains(., '.'))]"
+  variables: [IsPlural: "*[1]!=1"]
+  replace:
+  - x: "*[1]"
+  - x: "ToOrdinal(*[2], true(), $IsPlural)"   # extra args specify fractional ordinal and whether it is plural
+
+
+# Units (e.g., meters per second, m^2/s^2, (3m^2)/s)
+- name: per-fraction
+  tag: fraction
+  match:
+  - "BaseNode(*[1])[contains(@data-intent-property, ':unit') or"
+  - "               ( self::m:mrow and count(*)=3 and"  # maybe a bit paranoid checking the structure...
+  - "                 *[1][self::m:mn] and *[2][.='\u2062'] and BaseNode(*[3])[contains(@data-intent-property, ':unit')] ) ] and"
+  - "BaseNode(*[2])[contains(@data-intent-property, ':unit')] "
+  replace:
+  - x: "*[1]"
+  - t: "5 metros "      # phrase('5 meters 'per' second)
+  - x: "*[2]"
+
+- name: simple
+  # don't include nested fractions. E.g, fraction a plus b over c + 1 end fraction" is ambiguous
+  # by simplistic SimpleSpeak's rules "b over c" is a fraction, but if we say nested fractions
+  # are never simple, then any 'over' applies only to enclosing "fraction...end fraction" pair.
+  tag: fraction
+  match:
+  - "(IsNode(*[1],'leaf') and IsNode(*[2],'leaf')) and"
+  - "not(ancestor::*[name() != 'mrow'][1]/self::m:fraction)" # FIX: can't test for mrow -- what should be used???
+  replace:
+  - x: "*[1]"
+  - t: "sobre"      # phrase(the fraction 3 'over' 4)
+  - x: "*[2]"
+  - pause: short
+
+- name: default
+  tag: fraction
+  match: "."
+  replace:
+  - test:
+      if: "$Impairment = 'Blindness'"
+      then: [t: "fração"]      # phrase(the 'fraction' 3 over 4)
+  - pause: short
+  - x: "*[1]"
+  - test:
+      if: "not(IsNode(*[1],'leaf'))"
+      then: [pause: short]
+  - t: "sobre"      # phrase(the fraction 3 'over' 4)
+  - test:
+      if: "not(IsNode(*[2],'leaf'))"
+      then: [pause: short]
+  - x: "*[2]"
+  - pause: short
+  - test:
+      if: "$Impairment = 'Blindness'"
+      then: [t: "fim da fração"]      # phrase(start 7 over 8 'end of fraction')
+  - pause: medium
+
+# rules for functions raised to a power
+# these could have been written on 'mrow' but putting them on msup seems more specific
+# to see if it is a function, we look right to see if the following sibling is apply-function
+- name: inverse-function
+  tag: inverse-function
+  match: "."
+  replace:
+  - t: "inverso"      # phrase(the 'inverse' of f)
+  - x: "*[1]"
+
+- name: function-squared-or-cubed
+  tag: power
+  match:
+  - "*[2][self::m:mn][.='2' or .='3'] and"
+  - "following-sibling::*[1][self::m:mo][.='⁡']" #invisible function apply
+  replace:
+  - x: "*[1]"
+  - bookmark: "*[2]/@id"
+  - test:
+      if: "*[2][.=2]"
+      then: [t: "quadrado"]      # phrase(5 'squared' equals 25)
+      else: [t: "ao cubo"]      # phrase(5 'cubed' equals 125)
+- name: function-power
+  tag: power
+  match:
+  - "following-sibling::*[1][self::m:mo][.='⁡']" #invisible function apply
+  replace:
+  - test:
+      if: "$Verbosity!='Terse'"
+      then: [ot: "a"]      # # phrase('the' fourth power of 10)
+  - bookmark: "*[2]/@id"
+  - test:
+      if: "*[2][self::m:mn][not(contains(., '.'))]"
+      then: [x: "ToOrdinal(*[2])"]
+      else: [x: "*[2]"]
+  - t: "potência de"      # phrase(the fourth 'power of' 2)
+  - pause: short
+  - x: "*[1]"
+
+# non-function rules for power
+- name: squared-or-cubed
+  tag: power
+  match: "*[2][self::m:mn][.='2' or .='3']"
+  replace:
+  - x: "*[1]"
+  - bookmark: "*[2]/@id"
+  - test:
+      if: "*[2][.=2]"
+      then: [t: "quadrado"]      # phrase(5 'squared' equals 25)
+      else: [t: "ao cubo"]      # phrase(5 'cubed' equals 125)
+
+- name: simple-integer
+  tag: power
+  match: "*[2][self::m:mn][not(contains(., '.'))]"
+  replace:
+  - x: "*[1]"
+  - t: "à"      # phrase(15 raised 'to the' second power equals 225)
+  - test:
+      if: "*[2][.>0]"
+      then: [x: "ToOrdinal(*[2])"]
+      else: [x: "*[2]"]
+- name: simple-negative-integer
+  tag: power
+  match:
+  - "*[2][self::m:minus and count(*)=1 and"
+  - "     *[1][self::m:mn][not(contains(., '.'))]]"
+  replace:
+  - x: "*[1]"
+  - t: "à"      # phrase(15 raised 'to the' second power equals 225)
+  - x: "*[2]"
+- name: simple-var
+  tag: power
+  match: "*[2][self::m:mi][string-length(.)=1]"
+  replace:
+  - x: "*[1]"
+  - t: "à"      # phrase(15 raised 'to the' second power equals 225)
+  - x: "*[2]"
+  - pronounce: [text: "-th", ipa: "θ", sapi5: "th", eloquence: "T"]
+
+- name: simple
+  tag: power
+  match: "IsNode(*[2], 'leaf')"
+  replace:
+  - x: "*[1]"
+  - t: "à"      # phrase(15 raised 'to the' second power equals 225)
+  - x: "*[2]"
+
+- name: nested
+  # it won't end in "power" if the exponent is simple enough
+  # FIX: not that important, but this misses the case where the nested exp is a negative integer (change test if this is fixed)
+  # ending nested exponents with "...power power" sounds bad
+  tag: power
+  match:
+  - "*[2]["
+  - "     (self::m:power and not(IsNode(*[2], 'leaf'))) or" # non-simple nested superscript
+  - "     self::m:mrow[*[last()][self::m:power[not(IsNode(*[2], 'leaf'))]]]" # same as above but at the end of an mrow # FIX: need to figure out linear replacement
+  - "    ]"
+  replace:
+  - x: "*[1]"
+  - t: "elevado à"      # phrase(15 'raised to the' second power equals 225)
+  - x: "*[2]"
+  - pause: short
+  - test:
+      if: "$Impairment = 'Blindness'"
+      then:
+      - t: "fim do expoente"      # phrase(start 2 raised to the exponent 4 'end of exponent')
+      - pause: short
+      else:
+      - pause: medium
+
+- name: default
+  tag: power
+  match: "."
+  replace:
+  - x: "*[1]"
+  - t: "elevado à"      # phrase(15 'raised to the' second power equals 225)
+  - x: "*[2]"
+  - t: "potência"      # phrase(15 raised to the second 'power' equals 225)
+  - pause: short
+
+#
+# Some rules on mrows
+#
+- name: set
+  tag: set
+  match: "."
+  replace:
+  - test:
+    - if: "count(*)=0"
+      then:
+      - test:
+          if: "$Verbosity!='Terse'"
+          then: [t: "o"]      # phrase('the' empty set)
+      - t: "conjunto vazio"      # phrase(when a set contains no value it is called an 'empty set' and this is valid)
+    - else_if: "count(*[1]/*)=3 and *[1]/*[2][self::m:mo][.=':' or .='|' or .='∣']"
+      then:
+      - test:
+          if: "$Verbosity!='Terse'"
+          then: [t: "o"]      # phrase('the' set of all integers)
+      - t: "conjunto de todos"      # phrase(the 'set of all' positive integers less than 10)
+      - x: "*[1]/*[1]"
+      - t: "tal que"      # phrase(x 'such that' x is less than y)
+      - x: "*[1]/*[3]"
+      else:
+      - test:
+          if: "$Verbosity!='Terse'"
+          then: [t: "o"]      # phrase('the' set of integers)
+      - t: "conjunto"      # phrase(here is a 'set' of numbers)
+      - x: "*[1]"
+
+- name: times
+  tag: mo
+  match:
+  # say "times" when invisible times is followed by parens or a superscript that has a base with parens or "|"s
+  # added: say times is the superscript is not simple
+  # if we aren't sure if it is times or not, don't say anything
+  - ".='⁢' and"
+  - "not(@data-function-guess) and ("
+  - "not(ancestor-or-self::*[contains(@data-intent-property, ':literal:')]) and "
+  - "  following-sibling::*[1]["
+  - "    IsBracketed(., '(', ')') or IsBracketed(., '[', ']') or IsBracketed(., '|', '|') or "
+  - "    self::m:matrix or self::m:determinant or self::m:binomial or" # followed by parens
+  - "    self::m:square-root or self::m:msqrt or self::m:root or self::m:mroot or"
+  - "    (self::m:msub or self::m:msubsup or"
+  - "    ((self::m:msup or self::m:power) and not(IsNode(*[1], 'leaf') and *[2][self::m:mn and (.=2 or '.=3')]))) and " # followed by msup, etc.
+  - "     (*[1][self::m:mrow[IsBracketed(., '(', ')') or IsBracketed(., '[', ']') or IsBracketed(., '|', '|')] or "
+  - "           self::m:matrix or self::m:determinant] or" # base has parens
+  - "      not(IsNode(*[2], 'simple')) or "
+  - "      (self::m:msubsup and not(IsNode(*[3], 'simple')))"
+  - "     )"
+  - "  ]"  # other possibility is the preceding element has parens (but not the following)
+  - " or "
+  - "  preceding-sibling::*[1]["
+  - "    IsBracketed(., '(', ')') or IsBracketed(., '[', ']') or IsBracketed(., '|', '|')]" # followed by parens
+  - " )"
+  replace:
+  - t: "vezes"      # phrase(7 'times' 5 equals 35)
+
+- name: no-say-parens
+  tag: mrow
+  match:
+  - "parent::*[not(self::m:msup) and not(self::m:msub) and not(self::m:msubsup) and not(self::m:power) and"
+  - "          not(self::m:math) ] and "       # rule out [x] standing alone
+  - "( IsBracketed(., '(', ')') or IsBracketed(., '[', ']') ) and "
+  - "( IsNode(*[2], 'simple')  ) and"
+  - "not(preceding-sibling::*[1][.='\u2062' and @data-function-guess]) and"
+  - "not(ancestor-or-self::*[contains(@data-intent-property, ':literal:')])"
+  # missing clause: 'a positive fraction that is spoken as an ordinal
+  #   (either by the Ordinal preference or by the default rules_'
+  replace:
+  - x: "*[2]"
+
+- include: "SharedRules/geometry.yaml"
+- include: "SharedRules/linear-algebra.yaml"
+- include: "SharedRules/general.yaml"
+- include: "SharedRules/default.yaml"

--- a/Rules/Languages/pt/definitions.yaml
+++ b/Rules/Languages/pt/definitions.yaml
@@ -1,0 +1,596 @@
+---
+- include: "../../definitions.yaml"
+
+# If an "intent" is used, the 'terse:medium:verbose' speech for the intent name is given here for a prefix||infix||postfix||function||nofix||silent fixity
+# If only one ":" is used, the first part is used for 'terse' and the second part is used for 'medium' and 'verbose'
+# If no ":"s are used, the same speech is used for all forms
+# If bracketing words make sense, they are separated with ";"s
+# Intent mappings must specify whether they are "prefix", "infix", "postfix", or "function" with an "=" sign
+# If there are multiple fixities (e.g., see transpose), they are separated with "||"
+#   for readability, spaces can be used around any of the delimiter characters
+# Note: if there are multiple fixities, the first one is used if the fixity is not given in the intent
+- IntentMappings: {
+    "binomial": "infix=binomial; escolher; fim do binomial",
+
+    ### Functions and Inverses
+    # "closed-interval": "other=closed-interval; from,to; end closed-interval",
+    # "closed-interval":"function=closed interval between; and", #NOTE: Check test, does not follow this pattern
+    #"closed-open-interval":"function=interval between; included and",
+    #"open-closed-interval":"function=interval between; and included",
+    #"open-interval":"function=open interval between; and",
+    "inverse":"function=inversa || postfix=inversa", 
+
+    "domain": "function= ; domínio",
+    "codomain": "function= ; contradomínio",
+
+    "image":"function=imagem", 
+    #"fraction":"function=fraction; over; end fraction", # NOTE: Fails
+    "mixed-fraction":"infix=e", # NOTE: in website says function, but follow infix speech pattern.
+    "quotient":"function=parte inteira; dividido por", # NOTE: Logic somewhere here failing, becomes "divided by of x comma, y" instead of "integer part of x divided by y"
+    "evaluated-at":"infix=avaliado em",
+    "remainder":"function=o resto; dividido por",
+
+    "max":"function=máximo",
+    "min":"function=mínimo",
+
+    "power":"infix=à potência",
+    "root":"function=raiz",
+
+    "greatest-common-divisor": "function=mdc: o mdc: o máximo divisor comum",
+    "least-common-multiple":"function=mmc: o mmc: o mínimo múltiplo comum", # In webpage typo "lest common"
+
+    "absolute-value": "function= ; valor absoluto: o valor absoluto: o valor absoluto; fim do valor absoluto",
+    "complex-conjugate":"function=conjugado complexo",
+    "complex-arg":"function=argumento",
+    "real-part": "function=a parte real",
+    "imaginary-part": "function=parte imaginária: a parte imaginária: a parte imaginária",
+
+    "polar-coordinate":"function=coordenada polar; vírgula",
+    "spherical-coordinate":"function=coordenada esférica; vírgula; vírgula",
+    "cartesian-coordinate":"function=coordenada cartesiana; vírgula",
+    "coordinate":"function=coordenada; vírgula",
+    "floor":"function=piso",
+    "ceiling":"function=teto",
+    "round":"function=valor arredondado",
+    "fractional-part":"function=parte fracionária",
+
+
+    ### Calculus
+    # "definite-integral":"function=integral over || function=integral from; to", # Property ???
+    # "derivative":"function=the derivative; with respect to", # Property ???
+    # "partial-derivative":"function=partial", ## Note, included with infix, but separately under calculus tab has ??? for functionality
+
+    "limit": "prefix=limite quando: o limite quando",
+    "tends-to":"infix=tende a",
+    "tends-to-from-above":"infix=tende a por cima",
+    "tends-to-from-below":"infix=tende a por baixo",
+
+
+    ### Sets
+    "set": "function= ; conjunto: o conjunto",
+    "set-difference":"function=diferença de conjuntos; e || infix=menos", # NOTE: not tested
+    "complement":"function=complemento",
+    #"empty-set":"nofix=empty set",
+    "cardinality":"function=cardinalidade", # NOTE: does not have a defined speech template in website
+    "list":"function=lista",
+    "tuple": "function= ; ênupla: a ênupla",
+
+
+    ### Sequence and Series
+    "sum":"function= ; soma sobre : soma ; ", # : sum over : sum from; to",
+    "product":"function=produto || function=produto sobre || function=produto de; a",
+
+
+    ### Elementary classical functions
+    "sine":"function=seno: seno",
+    "cosine":"function=cosseno: cosseno",
+    "tangent":"function=tangente: tangente",
+    "secant":"function=secante: secante",
+    "cosecant":"function=cossecante: cossecante",
+    "cotangent":"function=cotangente: cotangente",
+
+    "arcsine":"function=arco seno",
+    "arccosine":"function=arco cosseno",
+    "arctangent":"function=arco tangente",
+    "arcsecant":"function=arco secante",
+    "arccosecant":"function=arco cossecante",
+    "arccotangent":"function=arco cotangente",
+
+    "hyperbolic-sine":"function=seno hiperbólico",
+    "hyperbolic-cosine":"function=cosseno hiperbólico",
+    "hyperbolic-tangent":"function=tangente hiperbólica",
+    "hyperbolic-secant":"function=secante hiperbólica",
+    "hyperbolic-cosecant":"function=cossecante hiperbólica",
+    "hyperbolic-cotangent":"function=cotangente hiperbólica",
+
+    "arc-hyperbolic-sine":"function=arco seno hiperbólico",
+    "arc-hyperbolic-cosine":"function=arco cosseno hiperbólico",
+    "arc-hyperbolic-tangent":"function=arco tangente hiperbólico",
+    "arc-hyperbolic-secant":"function=arco secante hiperbólico",
+    "arc-hyperbolic-cosecant":"function=arco cossecante hiperbólico",
+    "arc-hyperbolic-cotangent":"function=arco cotangente hiperbólico",
+
+    "exponential":"function=exponencial",
+    "natural-logarithm": "function=l n: log natural: log natural",
+    "logarithm":"function=logaritmo", ##Check arity 2 
+
+
+    ### Statistics and Probability
+    "mean":"function=média", 
+    "standard-deviation":"function=desvio padrão",
+    "variance":"function=variância",
+    "median":"function=mediana",
+    "mode":"function=moda",
+
+    "conditional-probability":"function=probabilidade; dado", # NOTE: Check test
+
+
+    ### Linear Algebra
+    "vector": "function= ; vetor || prefix=vetor", # prefix not tested, also prefix not on webpage
+    "matrix":"function=matriz", # NOTE: Failing test, recheck
+    "determinant":"function=determinante",
+    "adjugate":"function=adjunta",
+    "magnitude":"function=magnitude",
+    "norm": "function=; norma: norma: a norma; fim da norma",
+    "span":"function=gerado por",
+
+    "unit-vector":"prefix=vetor unitário",
+
+    "identity-matrix":"nofix=matriz identidade", # NOTE: no function specified
+    "transpose":"function=transposta || postfix=transposta", # postfix needs testing
+    "dimensional-product":"infix=por", # INFIX
+
+
+    ### Constants and Sets
+    "set-of-integers":"nofix=ℤ: conjunto de todos os inteiros",
+    "set-of-reals":"nofix=ℝ: conjunto de todos os números reais",
+    "set-of-rationals":"nofix=ℚ: conjunto de todos os números racionais",
+    "set-of-natural-numbers":"nofix=ℕ: conjunto de todos os números naturais",
+    "set-of-complex-numbers":"nofix=ℂ: conjunto de todos os números complexos",
+    "set-of-primes":"nofix=ℙ: conjunto de todos os números primos",
+
+    
+    ### Geometry
+    "line-segment":"prefix=segmento de reta",
+    "directed-line-segment":"prefix=segmento de reta orientado", 
+    "line":"prefix=reta",
+    "ray":"prefix=semirreta",
+    "arc":"prefix=arco",
+
+    "length":"function=comprimento",
+    "area":"function=área",
+
+    "point":"prefix=ponto",  ## NOTE: Has ??? for property in site. Should it be prefix? Or something else.
+
+    ### Separators
+    "time-separator":"infix=",
+
+    ### General Concepts 
+    "fenced-group":"function=grupo delimitado",
+     # NOTE: in site mentions "the pair x and y", due to being defined as function, needs the "of" keyword
+    "ordered-pair": "function= ; o par; e", # Needs to be tested, test converts "and" to "comma,"
+    "indexed-by": "infix= ; subscrito; fim do subscrito: fim do subscrito: fim do subscrito",
+    # "indexed-by": "infix= ; indexed by; ",
+    
+    "highlight":"postfix=destacado",
+    "least-common-denominator":"function=mínimo denominador comum",
+    "rate":"infix=por",
+    "translation":"function= translação por; vírgula", # NOTE: not tested, changes "translation" -> "comma" in test
+    "constraint":"infix= ; com restrição; ", 
+    
+    "binomial-coefficient":"infix=escolher",
+    "pochhammer":"function=permutação",
+    "permutation-cycle":"function=ciclo de permutação",
+    "embellished-name":"infix=com anotação",
+
+    ### Grouping
+    "annotation":"infix= ; que é ;",              # NOTE: Follows the same order as indexed-by, in site listed as function. Should it be infix?
+    "braced-group":"function=agrupado; fim do agrupamento",  # NOTE: not tested, site is missing "of" keyword function introduces
+    #"repeating-decimal":"function=repeating decimal", # NOTE: BREAKS TEST. Check again. Site is missing "of" keyword function introduces.
+
+
+    ### Other
+    ## Default fixity function
+    "curl": "function=rotacional",
+    "divergence": "function=div:divergência",
+    "gradient": "function=gradiente:gradiente",
+    "laplacian": "function=laplaciano",
+
+    ## Default fixity prefix
+    "angle": "prefix=ângulo",
+    "angle-measure": "prefix=medida do ângulo",
+    "change": "prefix=variação em",
+    "for-all": "prefix=para todo",
+    "measured-angle": "prefix=ângulo medido",
+    "not": "prefix=não",
+    "number-of": "prefix=número de",
+    "partial-derivative": "prefix=parcial",
+    "right-angle": "prefix=ângulo reto",
+    "square-root-of": "prefix=raiz quadrada de",
+    "there-does-not-exist": "prefix=não existe",
+    "there-exists": "prefix=existe",
+
+
+    ## Default fixity infix
+    "and": "infix=e",
+    "applied-to": "infix=aplicado a",
+    "approximately": "infix=aproximadamente",
+    "congruent": "infix=congruente a",
+    "cartesian-product": "infix=produto cartesiano",
+    "composed-with": "infix=composta com",
+    "cross-product": "infix=produto vetorial: produto vetorial: produto vetorial",
+    "defined-as": "infix=definido como",
+    "divided-by": "infix=dividido por",
+    "divides": "infix=divide",
+    "does-not-belong-to": "infix=não pertence a",
+    "does-not-divide": "infix=não divide",
+    "dot-product": "infix=produto escalar",
+    "downwards-diagonal-ellipsis": "infix=reticências diagonais para baixo",
+    "direct-product": "infix=produto direto",
+    "element-of": "infix=elemento de",
+    "ellipsis": "infix=reticências",
+    "equals": "infix=é igual a",
+    "equivalent-to": "infix=equivalente a",
+    "evaluates-to": "infix=avalia em",
+    "given": "infix=dado",
+    "greater-than": "infix=maior que",
+    "greater-than-or-equal-to": "infix=maior ou igual a",
+    "identically-equals": "infix=é idêntico a",
+    "if-and-only-if": "infix=se e somente se",
+    "implies": "infix=implica",
+    "inner-product": "infix=produto interno",
+    "intersection": "infix=interseção",
+    "less-than": "infix=menor que",
+    "less-than-or-equal-to": "infix=menor ou igual a",
+    "list-separator": "infix=vírgula",
+    "maps-to": "infix=mapeia para",
+    "member-of": "infix=membro de",
+    "minus-or-plus": "infix=menos ou mais",
+    "not-subset": "infix=não é subconjunto de",
+    "not-superset": "infix=não é superconjunto de",
+    "not-equal-to": "infix=não é igual a",
+    "not-member-of": "infix=não é membro de",
+    "not-parallel-to": "infix=não é paralelo a",
+    "obtained-from": "infix=obtido de",
+    "or": "infix=ou",
+    "outer-product": "infix=produto externo",
+    "parallel-to": "infix=paralelo a",
+    "perpendicular": "infix=perpendicular a",
+    "plus": "infix=mais || prefix=positivo", # Prefix not tested
+    "minus": "infix=menos || prefix=negativo", # Prefix not tested
+    "plus-or-minus": "infix=mais ou menos",
+    "precedes": "infix=precede",
+    "proportional": "infix=proporcional a",
+    "range-separator": "infix=até",
+    "ratio": "infix=razão",
+    "similar": "infix=semelhante a",
+    "subset": "infix=subconjunto de",
+    "subset-or-equal": "infix=subconjunto ou igual a",
+    "succeeds": "infix=sucede",
+    "such-that": "infix=tal que",
+    "superset": "infix=superconjunto de",
+    "superset-or-equal": "infix=superconjunto ou igual a",
+    "tilde": "infix=til",
+    "times": "infix=vezes",
+    "union": "infix=união",
+    "upwards-diagonal-ellipsis": "infix=reticências diagonais para cima",
+    "vertical-ellipsis": "infix=reticências verticais",
+    "xor": "infix=ou exclusivo",
+
+    ## Default fixity postfix
+    "factorial": "postfix=fatorial",
+    "percent": "postfix=por cento",
+
+    ## Default fixity nofix
+    "diameter":"nofix=d: diâmetro",
+    "distance":"nofix=d; D: distância",
+    "probability":"nofix=P: probabilidade",
+    "radius":"nofix=r: raio",
+    "volume":"nofix=V: volume || function=volume",
+    "exponential-e":"nofix=e",
+    "imaginary-i":"nofix=i",
+    "differential-d":"nofix=d",
+    "golden-ratio":"nofix=razão áurea",
+    
+
+    ## Other : Not tested, don't appear in https://w3c.github.io/mathml-docs/intent-core-concepts/
+    "modified-variable": "silent= ",
+    "say-super": "infix=super: sobrescrito: sobrescrito",   # used with 'mo' for superscripts (e.g, "<")
+    "skip-super": "silent=",   # used with 'mo' for superscripts (e.g, "*")
+    # "large-op": "infix=over || other=from,to",
+    "lim-sup": "prefix=lim sup quando: o limite superior quando: o limite superior quando",
+    "lim-inf": "prefix=lim inf quando: o limite inferior quando: o limite inferior quando",
+    "logarithm-with-base": "prefix=log na base: o log na base: o log na base",
+    # "pochhammer": "infix=permutations of",  # arguments are in reverse order, so can't work here
+    "trace": "function= ; traço : traço: o traço; fim do traço",
+    "dimension": "function=; dimensão : dimensão: a dimensão; fim da dimensão",
+    "homomorphism": "function= ; homomorfismo : homomorfismo: o homomorfismo; fim do homomorfismo",
+    "kernel": "function= ; núcleo : núcleo: o núcleo; fim do núcleo",
+    
+    "chemistry-concentration": "function= ; concentração: concentração de: a concentração de; fim da concentração",
+  }
+
+  # Names of functions that in terse mode don't say "of" (or it's equivalent in other languages)
+- TerseFunctionNames: {
+    "divergence", "del:gradient", "curl"
+  }
+
+- NavigationParts: {
+    # These are the parts of a formula that can be navigated to
+    "large-op": "base; limite inferior; limite superior",
+    "mfrac": "numerador; denominador",
+    "fraction": "numerador; denominador",
+    "msqrt": "raiz",
+    "square-root": "raiz",
+    "mroot": "raiz; índice da raiz",
+    "root": "raiz; índice da raiz",
+    "msub": "base; subscrito",
+    "sub": "base; subscrito",
+    "logarithm-with-base": "base",
+    "indexed-by": "base; subscrito",
+    "msup": "base; sobrescrito",
+    "say-super": "base; sobrescrito",
+    "skip-super": "base; sobrescrito",
+    "power": "base; expoente",
+    "msubsup": "base; subscrito; sobrescrito",
+    "munder": "base; limite inferior",
+    "mover": "base; limite superior",
+    "munderover": "base; limite inferior; limite superior",
+
+    # words for moving into and out of one of the parts (e.g., "move right 'out of' numerator, 'in' denominator")
+    # it's a hack to put them here, but at least they are grouped with the other navigation parts
+    "in": "em",
+    "out": "fora de",
+  }
+
+- KnownWords: {
+    # MathCAT will put together some runs of three or more mi's (a common mistake), but skips those in alphabetical order.
+    # This is a list of exceptions so that they do get put together. Don't list words with repeated letters.
+
+    # I asked bard and chatgpt for formula words that are alphabetical, and they failed.
+    # Here are the words I managed to find, but it almost certainly not complete. Change the list for other languages.
+    "Abel", "aery", "ails", "airy", "amps", "ceil", "cents", "chop", "flux", "flow", "knot", "most"
+  }
+
+- SIPrefixes: {
+    "Q": "quetta", "R": "ronna", "Y": "yotta", "Z": "zetta", "E": "exa", "P": "peta", "T": "tera", "G": "giga", "M": "mega", "k": "quilo", "h": "hecto", "da": "deca",
+    "d": "deci", "c": "centi", "m": "mili", "µ": "micro", "n": "nano", "p": "pico", "f": "femto", "a": "atto", "z": "zepto", "y": "yocto", "r": "ronto", "q": "quecto"
+  }
+
+# this is a list of all units that accept SIPrefixes
+# from www.bipm.org/documents/20126/41483022/SI-Brochure-9-EN.pdf
+#   Prefixes may be used with any of the 29 SI units with special names
+#   The SI prefixes can be used with several of accepted units, but not, for example, with the non-SI units of time.
+- SIUnits: {
+    # base units
+    "A": "ampere",
+    "cd": "candela",
+    "K": "kelvin", "K": "kelvin", # U+212A
+    "g": "grama",
+    "m": "metro",     # British spelling works for US also
+    "mol": "mol",
+    "s": "segundo", "sec": "segundo",  # "sec" not actually legal
+
+    # derived units
+    "Bq": "becquerel",
+    "C": "coulomb",
+    "°C": "grau Celsius", "℃": "grau Celsius", # should only take negative powers
+    "F": "farad",
+    "Gy": "gray",
+    "H": "henry",
+    "Hz": "hertz",
+    "J": "joule",
+    "kat": "katal",
+    "lm": "lúmen",
+    "lx": "lux",
+    "N": "newton",
+    "Ω": "ohm", "Ω": "ohm",       # Greek Cap letter, U+2126 OHM SIGN
+    "Pa": "pascal",
+    "S": "siemens",
+    "Sv": "sievert",
+    "T": "tesla",
+    "V": "volt",
+    "W": "watt",
+    "Wb": "weber",
+
+    # accepted (plus a few variants) that take SI prefixes
+    "l": "litro", "L": "litro", "ℓ": "litro",  # Should only take negative powers; British spelling works for US also
+    "t": "tonelada",           # should only take positive powers
+    "Da": "dalton",
+    "Np": "néper",               # should only take negative powers
+    "u": "unidade de massa atômica",     # 'u' is correct: https://en.wikipedia.org/wiki/Dalton_(unit)
+    "eV": "elétron-volt",
+    "rad": "radiano",             # should only take negative powers
+    "sr": "estereorradiano",           # should only take negative powers
+  
+    # others that take a prefix
+    "a": "ano",               # should only take positive powers
+    "as": "segundo de arco",          # see en.wikipedia.org/wiki/Minute_and_second_of_arc
+
+    # technically wrong, but used in practice with SI Units
+    "b": "bit",               # should only take positive powers
+    "B": "byte",              # should only take positive powers
+    "Bd": "baud",             # should only take positive powers
+  }
+
+
+- UnitsWithoutPrefixes: {
+    # time
+    "″": "segundo", "\"": "segundo",
+    "′": "minuto", "'": "minuto","min": "minuto",
+    "h": "hora", "hr": "hora", "Hr": "hora",
+    "d": "dia", "dy": "dia",
+    "w": "semana", "wk": "semana",
+    "y": "ano", "yr": "ano",    
+
+    # angles
+    "°": "grau", "deg": "grau", # should only take negative powers
+    "arcmin": "minuto de arco",
+    "amin": "minuto de arco",
+    "am": "minuto de arco",
+    "MOA": "minuto de arco",
+    "arcsec": "segundo de arco",
+    "asec": "segundo de arco",
+
+    # distance
+    "au": "unidade astronômica", "AU": "unidade astronômica",
+    "ltyr": "ano-luz", "ly": "ano-luz",
+    "pc": "parsec",
+    "Å": "angstrom", "Å": "angstrom",           # U+00C5 and U+212B
+    "fm": "fermi",
+
+    # others
+    "ha": "hectare",
+    # "B": "bel",    # "B" more commonly means bytes
+    "dB": "decibel", # already logarithmic, so not used with SI prefixes
+
+    "amu": "unidade de massa atômica",
+    "atm": "atmosfera",
+    "bar": "bar",
+    "cal": "caloria",
+    "Ci": "curie",
+    "grad": "grado",
+    "M": "molar",
+    "R": "roentgen",
+    "rpm": "revolução por minuto",
+    "℧": "mho",
+    "dyn": "dina",
+    "erg": "erg",
+
+    # special case overrides because prefixes with the base "metro" all get accents
+    "Qm": "quettâmetro", "Rm": "ronnâmetro", "Ym": "yottâmetro", "Zm": "zettâmetro", "Em": "exâmetro", "Pm": "petâmetro",
+      "Tm": "terâmetro", "Gm": "gigâmetro", "Mm": "megâmetro", "km": "quilômetro", "hm": "hectômetro", "dam": "decâmetro",
+    "dm": "decímetro", "cm": "centímetro", "mm": "milímetro", "µm": "micrômetro", "nm": "nanômetro", "pm": "picômetro",
+    #  conflicts: "fm": "femtômetro", "am": "attômetro",
+    "zm": "zeptômetro", "ym": "yoctômetro", "rm": "rontômetro", "qm": "quectômetro",
+
+    # powers of 2 used with bits and bytes
+    "Kib": "kibibit", "Mib": "mebibit", "Gib": "gibibit", "Tib": "tebibit", "Pib": "pebibit", "Eib": "exbibit", "Zib": "zebibit", "Yib": "yobibit",
+    "KiB": "kibibyte", "MiB": "mebibyte", "GiB": "gibibyte", "TiB": "tebibyte", "PiB": "pebibyte", "EiB": "exbibyte", "ZiB": "zebibyte", "YiB": "yobibyte",
+  }
+
+  # this will only be used if the language is English, so it can be empty for other countries
+- EnglishUnits: {
+  }
+
+- CurrencySymbols: {
+    "$": "dólar", "¢": "centavo", "€": "euro", "£": "libra", "₡": "colón", "₤": "lira", "₨": "rúpia",
+    "₩": "won", "₪": "shekel", "₱": "peso", "₹": "rúpia", "₺": "lira", "₿": "bitcoin",
+    # could add more currencies...
+  }
+
+- PluralForms: {
+  # FIX: this needs to be flushed out
+    "grama": "gramas", "metro": "metros", "litro": "litros", "segundo": "segundos",
+    "minuto": "minutos", "hora": "horas", "dia": "dias", "semana": "semanas", "ano": "anos",
+    "grau": "graus", "grau Celsius": "graus Celsius", "grau Fahrenheit": "graus Fahrenheit",
+    "radiano": "radianos", "tonelada": "toneladas",
+    "ampere": "amperes", "candela": "candelas", "kelvin": "kelvin", "mol": "mols",
+    "becquerel": "becquerels", "coulomb": "coulombs", "farad": "farads", "gray": "grays",
+    "henry": "henries", "hertz": "hertz", "joule": "joules", "katal": "katais",
+    "lúmen": "lúmens", "lux": "lux", "newton": "newtons", "ohm": "ohms",
+    "pascal": "pascals", "siemens": "siemens", "sievert": "sieverts", "tesla": "teslas",
+    "volt": "volts", "watt": "watts", "weber": "webers", "byte": "bytes", "bit": "bits",
+    "revolução por minuto": "revoluções por minuto",
+  }
+
+# Lines starting with "#" are a comment
+# Each definition in this file is of the form
+# - name: { "...", "..." "..." }
+# For numbers, 
+# - name: [] "...", "..." "..." ]
+
+
+# ----------------  Cardinal and Ordinal Numbers  --------------------------
+# The following definitions are used to convert numbers to words
+# The are mainly used for ordinals, of which there are two cases:
+# 1. Regular ordinals: first, second, third, ...
+# 2. Ordinals used in the denominator of fractions (e.g, one half, one third)
+#    When used in the denominator of fractions, a plural version might be
+#    used (e.g., two halves, two thirds)
+# Although a lot of languages are regular after a few entries, for generality,
+# the following lists should be filled out even though they are the same
+# or easily derived from others in many languages (e.g, an 's' is added for plurals).
+# The larger ordinal numbers (e.g, millionth) is used when there are only
+# '0's after that decimal place (e.g., 23000000).:w
+
+# All definitions start 0, 10, 100, etc.
+
+# The definitions for the "ones" should extend until a regular pattern begins
+#   The minimum length is 10.
+
+# For Portuguese, a regular pattern starts at twenty
+- NumbersOnes: [
+        "zero", "um", "dois", "três", "quatro", "cinco", "seis", "sete", "oito", "nove",
+        "dez", "onze", "doze", "treze", "catorze", "quinze", "dezesseis",
+        "dezessete", "dezoito", "dezenove"
+    ]
+
+- NumbersOrdinalOnes: [
+        "zero", "primeiro", "segundo", "terceiro", "quarto", "quinto", "sexto", "sétimo", "oitavo", "nono",
+        "décimo", "décimo primeiro", "décimo segundo", "décimo terceiro", "décimo quarto", "décimo quinto", "décimo sexto",
+        "décimo sétimo", "décimo oitavo", "décimo nono"
+    ]
+
+- NumbersOrdinalPluralOnes: [
+        "zeros", "primeiros", "segundos", "terços", "quartos", "quintos", "sextos", "sétimos", "oitavos", "nonos",
+        "décimos", "décimos primeiros", "décimos segundos", "décimos terceiros", "décimos quartos", "décimos quintos", "décimos sextos",
+        "décimos sétimos", "décimos oitavos", "décimos nonos"
+    ]
+
+    # stop when regularity begins
+- NumbersOrdinalFractionalOnes: [
+        "zero", "primeiro", "meio"
+    ]
+
+    # stop when regularity begins
+- NumbersOrdinalFractionalPluralOnes: [
+        "zeros", "primeiros", "meios"
+    ]
+
+
+    # What to use for multiples of 10
+- NumbersTens: [
+        "", "dez", "vinte", "trinta", "quarenta", "cinquenta", "sessenta", "setenta", "oitenta", "noventa"
+    ]
+
+- NumbersOrdinalTens: [
+        "", "décimo", "vigésimo", "trigésimo", "quadragésimo", "quinquagésimo", "sexagésimo", "septuagésimo", "octogésimo", "nonagésimo"
+    ]
+
+- NumbersOrdinalPluralTens: [
+        "", "décimos", "vigésimos", "trigésimos", "quadragésimos", "quinquagésimos", "sexagésimos", "septuagésimos", "octogésimos", "nonagésimos"
+    ]
+
+
+- NumbersHundreds: [
+      "", "cem", "duzentos", "trezentos", "quatrocentos", "quinhentos",
+        "seiscentos", "setecentos", "oitocentos", "novecentos"
+    ]
+
+- NumbersOrdinalHundreds: [
+      "", "centésimo", "ducentésimo", "trecentésimo", "quadringentésimo", "quingentésimo",
+        "seiscentésimo", "septingentésimo", "octingentésimo", "nongentésimo"
+    ]
+
+- NumbersOrdinalPluralHundreds: [
+      "", "centésimos", "ducentésimos", "trecentésimos", "quadringentésimos", "quingentésimos",
+        "seiscentésimos", "septingentésimos", "octingentésimos", "nongentésimos"
+    ]
+      
+
+    # At this point, hopefully the language is regular. If not, code needs to be written
+- NumbersLarge: [
+        "", "mil", "milhão", "bilhão", "trilhão", "quatrilhão",
+        "quintilhão", "sextilhão", "septilhão", "octilhão", "nonilhão",
+    ]
+      
+- NumbersOrdinalLarge: [
+        "", "milésimo", "milionésimo", "bilionésimo", "trilionésimo", "quatrilionésimo",
+        "quintilionésimo", "sextilionésimo", "septilionésimo", "octilionésimo", "nonilionésimo"
+    ]
+      
+- NumbersOrdinalPluralLarge: [
+        "", "milésimos", "milionésimos", "bilionésimos", "trilionésimos", "quatrilionésimos",
+        "quintilionésimos", "sextilionésimos", "septilionésimos", "octilionésimos", "nonilionésimos"
+    ]

--- a/Rules/Languages/pt/navigate.yaml
+++ b/Rules/Languages/pt/navigate.yaml
@@ -1,0 +1,1750 @@
+---
+# Documentation:
+#
+# The general form for many rules is:
+# 1. Say the command if this is first rule to fire (MatchCounter) and depending upon "NavVerbosity"s value
+#    This will increment MatchCounter so that the command won't be spoken again
+# 2. Say info about moving into/out of 2D structures
+# 3. Set some variables and possibly recurse.
+#    If stopping, "NavNode" should be set.
+#
+# The meaning of NavVerbosity:
+# * Verbose -- always echo the command and end points (e.g., "can't move right")
+# * Medium -- only echo the command for obscure commands like the placemarker commands; also say end points
+# * Terse -- no echo of commands or end points
+# 
+# For the second item, a common set of rules is used. These rules require the variable "Move2D"
+# to be set along with "Child2D", where "Move2D" is either 'in' or 'out'.
+#
+# In addition, the navigation rules make use of two functions:
+#
+# int DistanceFromLeaf(node, leftSide, treat2DElementsAsTokens)
+#   Returns the distance (number of children) until a leaf is reached by traversing the leftmost/rightmost child
+#   If 'treat2DElementsAsTokens' is true, then 2D notations such as fractions are treated like leaves 
+#   A leaf has distance == 0
+#
+# EdgeNode(node, "left"/"right", stopNodeName)
+#   Returns the stopNode if at left/right edge of named ancestor node. 'stopNodeName' can also be "2D"
+#   If the stopNode isn't found, the original node is returned
+#  Note: if stopNodeName=="math", then punctuation is taken into account since it isn't really part of the math
+#
+# A few other variables are of importance to Navigation
+# NavMode -- Enhanced, Simple, Character
+# ReadZoomLevel -- -1 for Enhanced, otherwise the distance from leaf the rules should maintain
+# PlaceMarkerIndex
+
+# Note: the rules for saying a command and announcing what is said when moving in/out of a 2d exprs are hacks
+# They depend upon special variables "SayCommand" and "Move2D" being set and if they are, the rules are activated.
+# If/when functions can be defined in a rules file, it is likely these would be much better done via those functions
+#   as they would likely be much more efficient and also cleaner.
+
+# Rules for announcing the command
+- name: say-command
+  tag: "!*"
+  match: "$SayCommand != ''"   # value should be '', 'true', or 'false'
+  variables: [Prefix: "''"]
+  replace:
+  - test:
+    - if: "$MatchCounter = 0 and $SayCommand = 'true'"
+      then_test:
+      - if: "self::m:math and starts-with($NavCommand, 'ZoomOut')"
+        then: [t: "diminuiu totalmente o zoom", pause: "medium"]
+      - else_if: "IsNode(., 'leaf') and starts-with($NavCommand, 'ZoomIn')"
+        then:
+        - test:
+          - if: "string-length(.) = 1"
+            then: [t: "ampliado totalmente"]       # phrase('zoomed in all of the way')
+          - else_if: "$NavNodeOffset = 0"
+            then: [t: "ampliado para o primeiro caractere"]   # phrase('zoomed in to first character')
+            else: [t: "ampliado para o caractere"]          # phrase('zoomed in to character')
+        - pause: "medium"
+        else:
+        - test:
+          - if: "starts-with($NavCommand, 'Zoom')"
+            then: [set_variables: [Prefix: "'zoom'"]]          # phrase('zoom' in to see more details)     
+          - else_if: "starts-with($NavCommand, 'Move')"
+            then: [set_variables: [Prefix: "'move'"]]          # phrase('move' to next entry in table)     
+          - else_if: "starts-with($NavCommand, 'Read')"
+            then: [set_variables: [Prefix: "'read'"]]          # phrase('read' to next entry in table)     
+          - else_if: "starts-with($NavCommand, 'Describe')"
+            then: [set_variables: [Prefix: "'describe'"]]      # phrase('describe' to next entry in table)
+        - test:
+            if: "$Prefix != ''"
+            then:
+            - x: "$Prefix"
+            - test:
+              - if: "substring($NavCommand, string-length($Prefix)+1) = 'In'"
+                then: [t: "para dentro"]                                  # phrase(zoom 'in' to see more details)
+              - else_if: "substring($NavCommand, string-length($Prefix)+1) = 'InAll'"
+                # HACK: '\uF8FE' is used internally for the concatenation char by 'ct' -- this gets "ed" concatenated to "zoom"
+                then: [t: "\uF8FE totalmente para dentro"]                     # phrase(zoom 'out all of the way' to see more details)
+              - else_if: "substring($NavCommand, string-length($Prefix)+1) = 'Out'"
+                then: [t: "para fora"]                                 # phrase(zoom 'out' to see more details)
+              - else_if: "substring($NavCommand, string-length($Prefix)+1) = 'OutAll'"
+                # HACK: '\uF8FE' is used internally for the concatenation char by 'ct' -- this gets "ed" concatenated to "zoom"
+                then: [t: "\uF8FE totalmente para fora"]                     # phrase(zoom 'out all of the way' to see more details)
+              - else_if: "substring($NavCommand, string-length($Prefix)+1) = 'Next'"
+                then: [t: "direita"]                               # phrase(move to the 'right')
+              - else_if: "substring($NavCommand, string-length($Prefix)+1) = 'Previous'"
+                then: [t: "esquerda"]                                # phrase(move to the 'left')
+              - else_if: "substring($NavCommand, string-length($Prefix)+1) = 'Current'"
+                then: [t: "atual"]                                 # phrase(who is the 'current' president)
+              - else_if: "substring($NavCommand, string-length($Prefix)+1) = 'LineStart'"
+                then: [t: "para o início da linha"]                                 # phrase(move 'to start of line')
+              - else_if: "substring($NavCommand, string-length($Prefix)+1) = 'LineEnd'"
+                then: [t: "para o fim da linha"]                                 # phrase(move 'to end of line')
+            - pause: "medium"
+  - set_variables: [MatchCounter: "$MatchCounter + 1"]
+
+- name: into-or-out-of-silent
+  tag: "*"
+  # saying "out of row n" is not very useful, so skip it
+  match: "$Move2D != '' and (not(@data-from-mathml) or @data-from-mathml = name(.)) and
+          (name(.)='mrow' or name(.) = 'mtr' or name(.) = 'mlabeledtr' or @data-from-mathml = 'mtable')"
+  replace: []
+
+- name: into-or-out-of-mtr
+  tag: [mtr, mlabeledtr]
+  match: "$Move2D = 'in'"
+  replace:
+  - t: "coluna"
+  - x: "count($Child2D/preceding-sibling::*)+1"
+  - pause: "medium"
+
+- name: into-or-out-of-mmultiscripts
+  tag: "*"
+  match: "$Move2D != '' and (@data-from-mathml='mmultiscripts' or self::m:mmultiscripts)"
+  replace:
+  - test:
+      if: "name($Child2D)!='none'"
+      then:
+      - with:
+          variables:
+          - NumPrecedingSiblings: "count($Child2D/preceding-sibling::*)"
+          replace:
+          - x: "$Move2D"
+          - test:
+            - if: "$NumPrecedingSiblings=0"
+              then: [t: "base"]                 # phrase(the 'base' of the power)
+            - else_if: "$Child2D/preceding-sibling::*[self::m:mprescripts]" # are we before mprescripts and hence are postscripts
+              then:
+              - test:   # in postscripts -- base shifts by one
+                  if: "$NumPrecedingSiblings mod 2 = 0" 
+                  then: [t: "subscrito"]       # phrase(x with 'subscript' 2)
+                  else: [t: "sobrescrito"]     # phrase(x with 'superscript' 2)
+              else:
+              - test:
+                  if: "$NumPrecedingSiblings mod 2 = 0"
+                  then: [t: "pré-sobrescrito"]    # phrase(x with 'pre-superscript' 2)
+                  else: [t: "pré-subscrito"]      # phrase(x with 'pre-subscript' 2)
+          - pause: "medium"
+
+# Rules for speaking what happens when moving into or out of a notation
+- name: into-or-out-of-default
+  tag: "*"
+  # saying "out of row n" is not very useful, so skip it
+  # match: "$Move2D != '' and @data-from-mathml and @data-from-mathml != name(.) and count(*)>1 and @data-from-mathml != 'mtable'"
+  match: "$Move2D != '' and not(self::m:math or @data-from-mathml = 'mtable' or  @data-from-mathml = 'mtd') "
+  replace:
+  - with:
+      variables:
+      - PartNumber: "count($Child2D/preceding-sibling::*)"
+      - PartName: "GetNavigationPartName(name(.), $PartNumber)"
+      replace:
+      - x: "$Move2D"
+      - test:
+        - if: "$PartName != ''"
+          then: [x: "$PartName"]
+        - else_if: "count(*) = 1"
+          then_test:
+            if: "$NavVerbosity = 'Verbose'"
+            then: [x: "translate(name(.), '-_', ' ')"]      # e.g., "in absolute value"
+          else:
+          - t: "parte"         # phrase(the 'part' of the expression)
+          - x: "count($Child2D/preceding-sibling::*) + 1"
+      - pause: "medium"
+
+- name: default-move
+  # nothing to do (not 2D) -- need to catch $Move2D though so rules based on NavCommand don't trigger
+  tag: "*"
+  match: "$Move2D != ''"
+  replace: []
+
+# ********* Go back to last position ***************
+# This is first since start/end position shouldn't matter
+- name: move-last-location
+
+
+  tag: "*"
+  match: "$NavCommand = 'MoveLastLocation'"
+  replace:
+  - test:
+      if: "$NavVerbosity != 'Terse'"
+      then:
+      - test:
+        - if: "$PreviousNavCommand = 'ZoomIn'"
+          then: [t: "desfazer zoom"]                       # phrase('undo zoom in')
+        - else_if: "$PreviousNavCommand = 'ZoomOut'"
+          then: [t: "desfazer zoom"]                      # phrase('undo zoom out')
+        - else_if: "$PreviousNavCommand = 'ZoomInAll'"
+          then: [t: "desfazer o zoom totalmente"]        # phrase('undo zooming in all of the way')
+        - else_if: "$PreviousNavCommand = 'ZoomOutAll'"
+          then: [t: "desfazer o zoom totalmente"]       # phrase('undo zooming out all of the way')
+        - else_if: "$PreviousNavCommand = 'MovePrevious' or $PreviousNavCommand = 'MovePreviousZoom'"
+          then: [t: "desfazer mover para a esquerda"]                     # phrase('undo move left')
+        - else_if: "$PreviousNavCommand = 'MoveNext' or $PreviousNavCommand = 'MoveNextZoom'"
+          then: [t: "desfazer mover para a direita"]                    # phrase('undo move right')
+        - else_if: "$PreviousNavCommand = 'None'"
+          then: [t: "nenhum comando anterior"]                # phrase('no previous command')
+      - pause: "medium"
+  - set_variables: [NavNode: "@id"]
+
+# many times, for typographic reasons, people include punctuation at the end of a math expr
+# these rules detect that and skip speaking it (should be similar regular rule)
+- name: skip-punct-at-end-zoom-in
+  tag: mrow
+  match:
+  - "($NavCommand = 'ZoomIn' or $NavCommand = 'ZoomInAll' or $NavCommand = 'MoveNextZoom' or $NavCommand = 'MovePreviousZoom') and"
+  - " parent::m:math and count(*)=2 and"
+  - " *[2][translate(.,'.,;:?', '')='']"
+  replace:
+  - x: "*[1]"
+
+# ********* ZoomIn  ***************
+- name: zoom-in-leaf
+  tag: "*"
+  match: "($NavCommand = 'ZoomIn' or $NavCommand = 'ZoomInAll') and IsNode(., 'leaf')"
+  replace:
+  - with:
+      variables: [SayCommand: "string($NavVerbosity != 'Terse')"]
+      replace: [x: "."]
+  - test:
+      if: "$ReadZoomLevel !=-1"
+      then:
+      - set_variables: [ReadZoomLevel: "0"]
+  - set_variables:
+      - NavNode: "@id"
+      - NavNodeOffset: "IfThenElse(string-length(.) > 1 and $MatchCounter = 1 and $NavNodeOffset = 0, '1', '0')"
+
+# special case of zooming into a table -- move to the first row (if only one row, first column)
+- name: zoom-in-table
+  tag: "*"
+  match: "$NavCommand = 'ZoomIn' and (name(.) = 'mtable' or (count(*)=1 and *[1][@data-from-mathml='mtable']))"
+  replace:
+  - with:
+      variables: [SayCommand: "string($NavVerbosity = 'Verbose')"]
+      replace: [x: "."]
+  - set_variables: [NavNode: "IfThenElse(count(*)=1, (*[1]/*[1]/@id), (*[1]/@id))"]
+
+- name: zoom-in-mrow-in-math
+  # zooming in only once is meaningless because 'math' has only a single child and it was spoken at the math level -- dig inside and do it again 
+  tag: math
+  match: "$NavCommand = 'ZoomIn' or $NavCommand = 'MoveNextZoom' or $NavCommand = 'MovePreviousZoom'"
+  replace:
+  - test:
+      if: "$NavCommand = 'MovePreviousZoom'"
+      then: [x: "*[last()]"]
+      else: [x: "*[1]"]
+
+- # For msqrt and menclose, if the single child isn't an mrow, don't zoom in
+  name: zoom-in-again
+  tag: "*"
+  match:
+  - "($NavCommand = 'ZoomIn' or "
+  - "  ($NavCommand = 'MoveNextZoom' or $NavCommand = 'MovePreviousZoom') and $NavMode='Enhanced') and "
+  - "count(*)=1 and
+     (*[1][self::m:mrow or @data-from-mathml='mrow'] and
+      not(@data-from-mathml='msqrt' or self::m:msqrt or @data-from-mathml='menclose' or self::m:menclose))"
+  replace:
+  - with:
+      variables: [SayCommand: "string($NavVerbosity = 'Verbose')"]
+      replace: [x: "."]
+  - test:
+      if: "not(*[1][self::m:mrow or @data-from-mathml='mrow'])"
+      then:
+      - with:
+          variables: [Move2D: "'in'", Child2D: "IfThenElse($NavCommand = 'MovePreviousZoom', (*[last()]), (*[1]))"]   # phrase('in' the denominator)
+          replace: [x: "IfThenElse($NavCommand = 'MovePreviousZoom', 1, $Child2D)"]
+  - test:
+      if: "$NavCommand = 'MovePreviousZoom'"
+      then: [x: "*[last()]"]
+      else: [x: "*[1]"]
+
+- name: zoom-in-enhanced
+  tag: "*"
+  match: "$NavCommand = 'ZoomIn' and $NavMode='Enhanced'"
+  replace:
+  - with:
+      variables: [SayCommand: "string($NavVerbosity = 'Verbose')"]
+      replace: [x: "."]
+  - test:
+    - if: "self::m:mtr or self::m:mlabeledtr"
+      then:
+      - with:
+          variables: [Move2D: "'in'", Child2D: "*[1]/*[1]"]   # phrase('in' the denominator)
+          replace: [x: "."]
+      - set_variables: [NavNode: "*[1]/*[1]/@id"] # skip mtd
+    - else_if: "*[1][self::m:mrow and (IsBracketed(., '(', ')', false) or IsBracketed(., '[', ']', false))]" # auto zoom
+      then:
+      - with:
+          variables: [Move2D: "'in'", Child2D: "*[1]"]   # phrase('in' the denominator)
+          replace: [x: "."]
+      - set_variables: [NavNode: "*[1]/*[2]/@id"]        # skip parens/brackets
+      else:
+      - with:
+          variables: [Move2D: "'in'", Child2D: "*[1]"]        # phrase('in' the denominator)
+          replace: [x: "."]
+      # "(...)" to get around some weird parse bug"
+      - set_variables: 
+          - NavNode: "*[1]/@id"
+          - NavNodeOffset: "IfThenElse(*[1]/@data-id-offset, (*[1]/@data-id-offset), '0')"
+
+
+- name: zoom-in-simple
+  tag: "*"
+  match: "$NavCommand = 'ZoomIn' and $NavMode='Simple'"
+  replace:
+  - with:
+      variables: [SayCommand: "string($NavVerbosity = 'Verbose')"]
+      replace: [x: "."]
+  - test:
+      if: "$MatchCounter > 1 and IsNode(., '2D')"
+      then:
+      - set_variables:       # time to stop, not going "in" to next thing, so before "Move2D"
+          - NavNode: "@id"
+          - NavNodeOffset: "IfThenElse(@data-id-offset, @data-id-offset, '0')"
+      else:
+      - with:
+          variables: [Move2D: "'in'", Child2D: "*[1]"]        # phrase('in' the denominator)
+          replace: [x: "."]
+      - x: "*[1]"
+
+  # At this point, we are zooming in on a non-2D element, non-leaf in Character mode
+- name: zoom-in-2D-character
+  tag: "*"
+  match: "$NavCommand = 'ZoomIn' and (IsNode(., '2D') or not(IsNode(., 'mathml')))"
+  replace:
+  - with:
+      variables: [SayCommand: "string($NavVerbosity = 'Verbose')"]
+      replace: [x: "."]
+  - with:
+      variables: [Move2D: "'in'", Child2D: "*[1]"]          # phrase('in' the denominator)
+      replace: [x: "."]
+  - test:
+      if: "$NavMode = 'Simple'"
+      then:
+      - set_variables: [NavNode: "*[1]/@id"]
+      else:
+      - with:
+          variables: [NavCommand: "'MoveNextZoom'"]
+          replace: [x: "*[1]"]
+
+  # At this point, we are zooming in on a non-2D element, non-leaf in Character mode
+- name: zoom-in-default
+  tag: "*"
+  match: "$NavCommand = 'ZoomIn'"
+  replace:
+  - with:
+      variables: [SayCommand: "string($NavVerbosity = 'Verbose')"]
+      replace: [x: "."]
+  - x: "*[1]"
+
+
+- name: zoom-in-all-default
+  tag: "*"
+  match: "$NavCommand = 'ZoomInAll'"
+  replace:
+  - with:
+      variables: [SayCommand: "string($NavVerbosity = 'Verbose')"]
+      replace: [x: "."]
+  - with:
+      variables: [Move2D: "'in'", Child2D: "*[1]"]              # phrase('in' the denominator)
+      replace: [x: "."]
+  - x: "*[1]"
+
+- name: zoom-out
+  tag: math
+  match: "$NavCommand = 'ZoomOut' or $NavCommand = 'ZoomOutAll'"
+  replace:
+  - with:
+      variables: [SayCommand: "string($NavVerbosity != 'Terse')"]
+      replace: [x: "."]
+  - set_variables: [NavNode: "*[1]/@id"] # no-op for $NavCommand = 'ZoomOut'
+
+- name: skip-punct-at-end-zoom-out
+  tag: mrow
+  match:
+  - "($NavCommand = 'ZoomOut' or $NavCommand = 'ZoomOutAll') and"
+  - " parent::m:math and count(*)=2 and"
+  - " *[2][translate(.,'.,;:?', '')='']"
+  replace:
+  - x: ".."
+
+- name: zoom-out-top
+  tag: "*"
+  match:
+  - "($NavCommand = 'ZoomOut' or $NavCommand = 'ZoomOutAll') and"
+  - "parent::m:math"
+  replace:
+  - x: ".." # let math rule deal with it
+
+- name: zoom-out-all-default
+  tag: "*"
+  match: "$NavCommand = 'ZoomOutAll'"
+  replace:
+  - with:
+      variables: [SayCommand: "string($NavVerbosity = 'Verbose')"]
+      replace: [x: "."]
+  - with:
+      variables: [Move2D: "'out of'", Child2D: "."]
+      replace: [x: ".."]
+  - x: ".."
+
+# deal with internal zooming: MoveNextZoom and MovePreviousZoom
+
+# start with Enhanced mode
+- name: move-zoom-enhanced
+  tag: "*"
+  match:
+  - "($NavCommand = 'MoveNextZoom' or $NavCommand = 'MovePreviousZoom') and "
+  - "$NavMode = 'Enhanced'"
+  replace:
+  - with:
+      variables: [Move2D: "'in'", Child2D: "*[1]"]            # phrase('in' the denominator)
+      replace: [x: "."]
+  - test:
+    - if: "count(*)> 1 or IsNode(., 'leaf') or
+           @data-from-mathml='msqrt' or self::m:msqrt or @data-from-mathml='menclose' or self::m:menclose"
+      then:
+      - set_variables:
+          - NavNode: "@id"
+          - NavNodeOffset: "IfThenElse(@data-id-offset, @data-id-offset, '0')"
+      else: [x: "*[1]"]
+
+- name: move-next-zoom-not-enhanced
+  # $ReadZoomLevel must be >= 0
+  tag: "*"
+  match: "$NavCommand = 'MoveNextZoom'"
+  replace:
+  #don't bother with MatchCounter since we only get here if > 1
+  - test:
+      if: "IsNode(., 'leaf') or $ReadZoomLevel >= DistanceFromLeaf(., false, $NavMode!='Character')"
+      then:
+      # - with:
+      #     variables: [Move2D: "'in'", Child2D: "following-sibling::*[1]"]    # phrase('in' the denominator)
+      #     replace: [x: ".."]
+      - set_variables:
+          - NavNode: "@id"
+          - NavNodeOffset: "IfThenElse(@data-id-offset, @data-id-offset, '0')"
+      else:
+      - with:
+          variables: [Move2D: "'in'", Child2D: "*[1]"]                        # phrase('in' the denominator)
+          replace: [x: "."]
+      - x: "*[1]"
+
+- name: move-previous-zoom-not-enhanced
+  # $ReadZoomLevel must be >= 0
+  tag: "*"
+  match: "$NavCommand = 'MovePreviousZoom'"
+  replace:
+  #don't bother with MatchCounter since we only get here if > 1
+  - test:
+      if: "$ReadZoomLevel >= DistanceFromLeaf(., true, $NavMode!='Character')"
+      then:
+      # - with:
+      #     variables: [Move2D: "'in'", Child2D: "preceding-sibling::*[1]"]     # phrase('in' the denominator)
+      #     replace: [x: ".."]
+      - set_variables:
+          - NavNode: "@id"
+          - NavNodeOffset: "IfThenElse(@data-id-offset, @data-id-offset, '0')"
+      else:
+      - with:
+          variables: [Move2D: "'in'", Child2D: "*[last()]"]                     # phrase('in' the denominator)
+          replace: [x: "."]
+      - x: "*[last()]"
+
+# ********* ZoomOut  ***************
+- name: zoom-out-default
+  tag: mtd
+  match: "$Move2D = '' and ($NavCommand = 'ZoomOut')"
+  replace:
+  - with:
+      variables: [SayCommand: "string($NavVerbosity = 'Verbose')"]
+      replace: [x: "."]
+  # we need to speak it here
+  # - t: "linha"                                                  # phrase(the first 'row' of the matrix)
+  #   # if we let the speech rules speak the row, it is given just the MathML for the row, so the row # will always be '1'
+  # - x: "count(../preceding-sibling::*)+1"
+  # - pause: medium
+  - set_variables:
+      - NavNode: "../@id"
+      - NavNodeOffset: "IfThenElse(../@data-id-offset, ../@data-id-offset, '0')"
+
+- name: zoom-out
+  # a row around a single element -- these might duplicate the position/offset, so we jump an extra level here  
+  tag: "*"
+  match: "$NavCommand = 'ZoomOut'"
+  replace:
+  - with:
+      variables: [SayCommand: "string($NavVerbosity = 'Verbose')"]
+      replace: [x: "."]
+  - test:
+    - if: "$NavNodeOffset > 0 and IsNode(., 'leaf')"  # Inside leaf -- just reset offset, intent offset doesn't change
+      then:
+      - set_variables: [NavNodeOffset: "0"]
+      # NavNode remains the same
+    - else_if: "$NavMode='Enhanced' and parent::*[self::m:mrow and (IsBracketed(., '(', ')', false) or IsBracketed(., '[', ']', false))]"
+      then: [x: ".."] # auto-zoom: move out a level and retry
+      else:
+      - with:
+          variables: [Move2D: "'out of'", Child2D: "."]   # phrase('out of' the denominator)
+          replace: [x: ".."]
+      - test:
+          if: "parent::m:mtd"
+          then: [x: ".."]
+          else:
+          - test:
+              if: "DEBUG($ReadZoomLevel)!=-1"
+              then: [set_variables: [ReadZoomLevel: "DistanceFromLeaf(.., true, $NavMode!='Character')"]]
+          - set_variables:
+              - NavNode: "../@id"
+              - NavNodeOffset: "IfThenElse(../@data-id-offset, ../@data-id-offset, '0')"
+
+# ********* MoveStart/End  ***************
+- name: math-move-to-start-or-end
+  tag: math
+  match: "$NavCommand = 'MoveStart' or $NavCommand = 'MoveLineStart' or $NavCommand = 'MoveEnd' or $NavCommand = 'MoveLineEnd'"
+  replace:
+  - with:
+      variables: [MatchCounter: "$MatchCounter + 1"]
+      replace:
+      - test:
+          if: "$NavVerbosity = 'Verbose'"
+          then:
+          - test:
+            - if: "$NavCommand = 'MoveStart'"
+              then: [t: "mover para o início da matemática"]                  # phrase('move to start of math')
+            - else_if: "$NavCommand = 'MoveLineStart'"
+              then: [t: "mover para o início da linha"]                  # phrase('move to start of line')
+            - else_if: "$NavCommand = 'MoveEnd'"
+              then: [t: "mover para o final da matemática"]                    # phrase('move to end of math')
+              else: [t: "mover para o fim da linha"] # "$NavCommand = 'MoveLineEnd'"  # phrase('move to end of line')
+          - pause: "medium"
+      - test:
+          if: "$NavCommand = 'MoveStart' or $NavCommand = 'MoveLineStart'"
+          then:
+          # move inside of the mrow inside of 'math' or inside the fraction, etc  (hence two levels down)
+          # Note: an apparent bug in the xpath code doesn't let me use IfThenElse for the 2 if: then: below
+          - with:
+              variables: [NavCommand: "'MoveNextZoom'"]
+              replace:
+              - test:
+                  if: "*[1]/*[1]"    # could be a <math><mi>x</mi></math>, so no grandchild
+                  then: [x: "*[1]/*[1]"]
+                  else: [x: "*[1]"]
+          else:
+          - with:
+              variables: [NavCommand: "'MovePreviousZoom'"]
+              replace:
+              - test:
+                  if: "*[last()]/*[last()]"  # could be a <math><mi>x</mi></math>, so no grandchild
+                  then: [x: "*[last()]/*[last()]"]
+                  else: [x: "*[last()]"]
+
+# We stop when the parent is 2d (e.g., frac), but not if in leaf base of msub/msup/msubsup/mmultiscripts because that's really on the same line
+- name: move-to-start-or-end-2d
+  tag: "*"
+  match:
+  - "($NavCommand = 'MoveLineStart' or $NavCommand = 'MoveLineEnd') and IsNode(.., '2D') and"
+  - "not( IsNode(., 'leaf') and"
+  - "     parent::*[1][self::m:msub or self::m:msup or self::m:msubsup or self::m:mmultiscripts or"
+  - "                 @data-from-mathml and"
+  - "                  (@data-from-mathml='msub' or @data-from-mathml='msup' or"
+  - "                   @data-from-mathml='msubsup' or @data-from-mathml='mmultiscripts')"
+  - "                 ] )"
+  replace:
+  - test:
+      if: "$NavVerbosity = 'Verbose'"
+      then:
+      - test:
+          if: "$NavCommand = 'MoveLineStart'"
+          then: [t: "mover para o início da linha"]                                # phrase('move to start of line')
+          else: [t: "mover para o fim da linha"] # "$NavCommand = 'MoveLineEnd'"  # phrase('move to end of line')
+      - pause: "medium"
+  - test:
+      if: "self::m:mrow or @data-from-mathml = 'mrow'"
+      then_test:
+        if: "$NavCommand = 'MoveLineStart'"
+        then:
+        - with:
+            variables: [NavCommand: "'MoveNextZoom'"]
+            replace: [x: "*[1]"]
+        else:
+        - with:
+            variables: [NavCommand: "'MovePreviousZoom'"]
+            replace: [x: "*[last()]"]
+      else: [set_variables: [NavNode: "@id"]]
+
+- name: move-to-start-or-end-default
+  tag: "*"
+  match: "$NavCommand = 'MoveStart' or $NavCommand = 'MoveLineStart' or $NavCommand = 'MoveEnd' or $NavCommand = 'MoveLineEnd'"
+  replace:
+  - with:
+      variables: [MatchCounter: "$MatchCounter + 1"]
+      replace: [x: ".."]
+
+# Table-related movement
+# Typically, we need to zoom out to the mtd level, then we move the appropriate direction
+- name: not-in-table
+
+
+  tag: math
+  match:
+  - "$NavCommand='MoveCellPrevious' or $NavCommand='MoveCellNext' or"
+  - "$NavCommand='MoveCellUp' or $NavCommand='MoveCellDown' or"
+  - "$NavCommand='MoveColumnStart' or $NavCommand='MoveColumnEnd' or"
+  - "$NavCommand='ReadCellCurrent'"
+  replace:
+  - t: "não na tabela"                               # phrase('not in table')
+  - pause: long
+  - set_variables: [SpeakExpression: "'false'"]
+
+- name: move-cell-previous
+  tag: mtd
+  match: "$NavCommand='MoveCellPrevious'"
+  replace:
+  - test:
+      if: "preceding-sibling::*"
+      then:
+      - test:
+          if: "$NavVerbosity = 'Verbose'"
+          then:
+          - t: "mover para a esquerda"                        # phrase('move left')
+          - pause: short
+      - test:
+          if: "$NavVerbosity != 'Terse'"
+          then:
+          - t: "coluna"                           # phrase(the first 'column' of the table)
+          - x: "count(preceding-sibling::*)"
+          - pause: medium
+      - test:
+          if: "$NavMode='Character'"
+          then:
+          - with:
+              variables: [NavCommand: "'MovePreviousZoom'"]
+              replace: [x: "preceding-sibling::*[1]"]
+          else:
+          - set_variables: [NavNode: "preceding-sibling::*[1]/*[1]/@id"]
+      else:
+      - t: "nenhuma coluna anterior"                 # phrase('no previous column' in the table)
+      - set_variables: [SpeakExpression: "'false'"]
+
+- name: move-cell-next
+  tag: mtd
+  match: "$NavCommand='MoveCellNext'"
+  replace:
+  - test:
+      if: "following-sibling::*"
+      then:
+      - test:
+          if: "$NavVerbosity = 'Verbose'"
+          then:
+          - t: "mover para a direita"                     # phrase('move right')
+          - pause: short
+      - test:
+          if: "$NavVerbosity != 'Terse'"
+          then:
+          - t: "coluna"                         # phrase(the first 'column' in the table)
+          - x: "count(preceding-sibling::*)+2"
+          - pause: medium
+      - test:
+          if: "$NavMode='Character'"
+          then:
+          - with:
+              variables: [NavCommand: "'MoveNextZoom'"]
+              replace: [x: "following-sibling::*[1]"]
+          else:
+          - set_variables: [NavNode: "following-sibling::*[1]/*[1]/@id"]
+      else:
+      - t: "nenhuma próxima coluna"                  # phrase('no next column' in the table)
+      - set_variables: [SpeakExpression: "'false'"]
+
+- name: move-cell-up
+  tag: mtd
+  match: "$NavCommand='MoveCellUp'"
+  replace:
+  - test:
+      if: "../preceding-sibling::*"
+      then:
+      - with:
+          variables: [Column: "count(preceding-sibling::*)+1"] # store this because otherwise the value is used in the wrong context below
+          replace:
+          - test:
+              if: "$NavVerbosity = 'Verbose'"
+              then:
+              - t: "mover para cima"                             # phrase('move up' to previous row in the table)
+              - pause: short
+          - test:
+              if: "$NavVerbosity != 'Terse'"
+              then:
+              - t: "linha"                                 # phrase(the previous 'row' in the table)
+              - x: "count(../preceding-sibling::*)"
+              - pause: short
+              - t: "coluna"                              # phrase(the previous 'column' in the table)
+              - x: "count(preceding-sibling::*)+1"
+              - pause: medium
+          - test:
+              if: "$NavMode='Character'"
+              then:
+              - with:
+                  variables: [NavCommand: "'MoveNextZoom'"]
+                  replace: [x: "../preceding-sibling::*[1]/*[$Column]"]
+              else:
+              - set_variables: [NavNode: "../preceding-sibling::*[1]/*[$Column]/*[1]/@id"]
+      else:
+      - t: "nenhuma linha anterior"                            # phrase('no previous row' in the table)
+      - set_variables: [SpeakExpression: "'false'"]
+
+- name: move-cell-down
+  tag: mtd
+  match: "$NavCommand='MoveCellDown'"
+  replace:
+  - test:
+      if: "../following-sibling::*"
+      then:
+      - with:
+          variables: [Column: "count(preceding-sibling::*)+1"] # store this because otherwise the value is used in the wrong context below
+          replace:
+          - test:
+              if: "$NavVerbosity = 'Verbose'"
+              then:
+              - t: "mover para baixo"                          # phrase('move down' to the next row in the table)
+              - pause: short
+          - test:
+              if: "$NavVerbosity != 'Terse'"
+              then:
+              - t: "linha"                                # phrase(the next 'row' in the table)
+              - x: "count(../preceding-sibling::*)+2"
+              - pause: short
+              - t: "coluna"                             # phrase(the next 'column' in the table)
+              - x: "count(preceding-sibling::*)+1"
+              - pause: medium
+          - test:
+              if: "$NavMode='Character'"
+              then:
+              - with:
+                  variables: [NavCommand: "'MoveNextZoom'"]
+                  replace: [x: "../following-sibling::*[1]/*[$Column]"]
+              else:
+              - set_variables: [NavNode: "../following-sibling::*[1]/*[$Column]/*[1]/@id"]
+      else:
+      - t: "nenhuma próxima linha"                                # phrase('no next row' in the table)
+      - set_variables: [SpeakExpression: "'false'"]
+
+- name: move-cell-up
+  tag: [mtr, mlabeledtr]
+  match: "$NavCommand='MoveCellUp'"
+  replace:
+  - test:
+      if: "$NavVerbosity = 'Verbose'"
+      then:
+      - t: "mover para a linha anterior"                              # phrase('move to previous row' in the table)
+      - pause: medium
+  - test:
+      if: "preceding-sibling::*"
+      then:
+      - test:
+          if: "$NavMode='Character'"
+          then:
+          - with:
+              variables: [NavCommand: "'MoveNextZoom'"]
+              replace: [x: "preceding-sibling::*[1]"]
+          else:
+          - set_variables: [NavNode: "preceding-sibling::*[1]/@id"]
+      else:
+      - t: "nenhuma linha anterior"                          # phrase('no previous row' in the table)
+      - set_variables: [SpeakExpression: "'false'"]
+
+- name: move-cell-down
+  tag: [mtr, mlabeledtr]
+  match: "$NavCommand='MoveCellDown'"
+  replace:
+  - test:
+      if: "$NavVerbosity = 'Verbose'"
+      then:
+      - t: "mover para a próxima linha"                          # phrase('move to next row' in the table)
+      - pause: medium
+  - test:
+      if: "following-sibling::*"
+      then:
+      - test:
+          if: "$NavMode='Character'"
+          then:
+          - with:
+              variables: [NavCommand: "'MoveNextZoom'"]
+              replace: [x: "following-sibling::*[1]"]
+          else:
+          - set_variables: [NavNode: "following-sibling::*[1]/@id"]
+      else:
+      - t: "nenhuma próxima linha"                          # phrase('no next row' in the table)
+      - set_variables: [SpeakExpression: "'false'"]
+
+- name: move-cell-previous
+  # if a row is selected, there is no previous/next column, so this is trivial
+  tag: [mtr, mlabeledtr]
+  match: "$NavCommand='MoveCellPrevious'"
+  replace:
+  - test:
+      if: "$NavVerbosity = 'Verbose'"
+      then:
+      - t: "mover para a coluna anterior"                              # phrase('move to previous column' in the table)
+      - pause: medium
+  - t: "nenhuma coluna anterior"                          # phrase('no previous column' in the table)
+  - set_variables: [SpeakExpression: "'false'"]
+
+- name: move-cell-next
+  # if a row is selected, there is no previous/next column, so this is trivial
+  tag: [mtr, mlabeledtr]
+  match: "$NavCommand='MoveCellNext'"
+  replace:
+  - test:
+      if: "$NavVerbosity = 'Verbose'"
+      then:
+      - t: "mover para a próxima coluna"                              # phrase('move to next column' in the table)
+      - pause: medium
+  - t: "nenhuma próxima linha"                          # phrase('no next row' in the table)
+  - set_variables: [SpeakExpression: "'false'"]
+
+- name: default-read-cell
+  tag: "*"
+  match: "$NavCommand='ReadCellCurrent'"
+  replace:
+  - with:
+      variables: [MTD: "ancestor::m:mtd"]
+      replace:
+      - test:
+          if: "$MTD"
+          then:
+          - test:
+              if: "$NavVerbosity = 'Verbose'"
+              then:
+              - t: "ler a entrada atual"                         # phrase('read current entry' in the table)
+              - pause: medium
+          - test:
+              if: "$NavVerbosity != 'Terse'"
+              then:
+              - t: "linha"                                        # phrase(the previous 'row' in the table)
+              - x: "count($MTD[1]/../preceding-sibling::*)+1"
+              - pause: short
+              - t: "coluna"                                     # phrase(the previous 'column' in the table)
+              - x: "count($MTD[1]/preceding-sibling::*)+1"
+              - pause: short
+          - set_variables: [NavNode: "$MTD[1]/*[1]/@id"]
+          else:
+          - t: "não na tabela"                                   # phrase('not in table' or matrix)
+          - pause: long
+          - set_variables: [SpeakExpression: "'false'"]
+
+# mtd ? ( $NavCommand='MoveColumnStart' )
+# => MoveColStart {
+#       ruleRef = name(^^match);
+#       column = index(match);
+#       ::StartPosition = ^^match[0][index(match)][0].dfs;
+#       ::EndPosition = ^^match[0][index(match)][0].offset;
+#   };
+
+# mtd ? ( $NavCommand='MoveColumnEnd' )
+# => MoveColEnd {
+#       ruleRef = name(^^match);
+#       column = index(match);
+#       ::StartPosition = ^^match[count(^^match)-1][index(match)][0].dfs;
+#       ::EndPosition = ^^match[count(^^match)-1][index(match)][0].offset;
+#   };
+
+
+
+# # Rules for columnar math (mstack and mlongdiv) -- each row is an msrow or mscarries except for the start of mlongdiv
+# # FIX:  not dealing with different number of digits on different lines
+# # FIX:  not dealing with + (etc) on same line if they are on the right side (Dutch, others)
+# # FIX:  not dealing with intervening msline (say it and move on??)
+# # FIX:  not dealing with carries well
+# # FIX:  not dealing with navigation of first three children of mlongdiv
+# char ? ( has_parent(match, 2) && name(^match)=="mn" && name(^^match)=="msrow" &&
+#         ($NavCommand="MovePrevious" || $NavCommand='MoveCellPrevious') && has_previous(match) )
+# => MoveCell {
+#       ruleRef = name(^^match);
+#       wordRef = "previous";
+#       ::StartPosition = previous(match).dfs;
+#       ::EndPosition = previous(match).offset;
+#   };
+
+# # no previous child -- in first column -- don't move
+# char ? ( has_parent(match, 2) && name(^match)=="mn" && name(^^match)=="msrow" &&
+#         ($NavCommand="MovePrevious" || $NavCommand='MoveCellPrevious' ) )
+# => MoveCell {
+#       ruleRef = name(^^match);
+#       wordRef = "previous";
+#       childIndex = -1;                   # key to know what to say for each notation
+#       ::SpeakAfterMove = false;
+#   };
+
+# char ? ( has_parent(match, 2) && name(^match)=="mn" && name(^^match)=="msrow" &&
+#         ($NavCommand="MoveNext" || $NavCommand='MoveCellNext') && has_next(match) )
+# => MoveCell {
+#       ruleRef = name(^^match);
+#       wordRef = "next";
+#       ::StartPosition = next(match).dfs;
+#       ::EndPosition = next(match).offset;
+#   };
+
+# # no next child -- in first column -- don't move
+# char ? ( has_parent(match, 2) && name(^match)=="mn" && name(^^match)=="msrow" &&
+#         ($NavCommand="MoveNext" || $NavCommand='MoveCellNext' ) )
+# => MoveCell {
+#       ruleRef = name(^^match);
+#       wordRef = "next";
+#       childIndex = -1;                   # key to know what to say for each notation
+#       ::SpeakAfterMove = false;
+#   };
+
+# char ? ( has_parent(match, 2) && name(^match)=="mn" && name(^^match)=="msrow" &&
+#         $NavCommand='MoveCellUp' && has_previous(^^match) )
+# => MoveCell {
+#       ruleRef = name(^^match);
+#       wordRef = "up";
+#       ::StartPosition = ^^^match[index(^^match)-1][-1][index(match)-count(^match)].dfs;
+#       ::EndPosition = ^^^match[index(^^match)-1][-1][index(match)-count(^match)].offset;
+#   };
+
+# # no previous child -- in first column -- don't move
+# char ? ( has_parent(match, 2) && name(^match)=="mn" && name(^^match)=="msrow" &&
+#         $NavCommand='MoveCellUp' )
+# => MoveCell {
+#       ruleRef = name(^^match);
+#       wordRef = "up";
+#       childIndex = -1;                   # key to know what to say for each notation
+#       ::SpeakAfterMove = false;
+#   };
+
+# char ? ( has_parent(match, 2) && name(^match)=="mn" && name(^^match)=="msrow" &&
+#         $NavCommand='MoveCellDown' && has_next(^^match) )
+# => MoveCell {
+#       ruleRef = name(^^match);
+#       wordRef = "down";
+#       ::StartPosition = ^^^match[index(^^match)+1][-1][index(match)-count(^match)].dfs;
+#       ::EndPosition = ^^^match[index(^^match)+1][-1][index(match)-count(^match)].offset;
+#   };
+
+# # no previous child -- in first column -- don't move
+# char ? ( has_parent(match, 2) && name(^match)=="mn" && name(^^match)=="msrow" &&
+#         $NavCommand='MoveCellDown' )
+# => MoveCell {
+#       ruleRef = name(^^match);
+#       wordRef = "down";
+#       childIndex = -1;                   # key to know what to say for each notation
+#       ::SpeakAfterMove = false;
+#   };
+
+# char ? ( has_parent(match, 2) && name(^match)=="mn" && name(^^match)=="msrow" &&
+#           $NavCommand='MoveColumnStart' )
+# => MoveColStart {
+#       ruleRef = name(^^match);
+#       column = index(match);
+#       ::StartPosition = ^^^match[0][-1][index(match)-count(^match)].dfs;
+#       ::EndPosition = ^^^match[0][-1][index(match)-count(^match)].offset;
+#   };
+
+# char ? ( has_parent(match, 2) && name(^match)=="mn" && name(^^match)=="msrow" &&
+#           $NavCommand='MoveColumnEnd' )
+# => MoveColEnd {
+#       ruleRef = name(^^match);
+#       column = index(match);
+#       ::StartPosition = ^^^match[count(^^^match)-1][-1][index(match)-count(^match)].dfs;
+#       ::EndPosition = ^^^match[count(^^^match)-1][-1][index(match)-count(^match)].offset;
+#   };
+
+# any ? ( (name(match)=="mn" || name(match)=="none") &&
+#         has_parent(match) && name(^match)=="mscarries" &&
+#         ($NavCommand="MovePrevious" || $NavCommand='MoveCellPrevious') && has_previous(match) )
+# => MoveCell {
+#       ruleRef = name(^match);
+#       wordRef = "previous";
+#       ::StartPosition = previous(match).dfs;
+#       ::EndPosition = previous(match).offset;
+#   };
+
+# # no previous child -- in first column -- don't move
+# any ? ( (name(match)=="mn" || name(match)=="none") &&
+#         has_parent(match) && name(^match)=="mscarries" &&
+#         ($NavCommand="MovePrevious" || $NavCommand='MoveCellPrevious') )
+# => MoveCell {
+#       ruleRef = name(^match);
+#       wordRef = "previous";
+#       childIndex = -1;                   # key to know what to say for each notation
+#       ::SpeakAfterMove = false;
+#   };
+
+# any ? ( (name(match)=="mn" || name(match)=="none") &&
+#         has_parent(match) && name(^match)=="mscarries" &&
+#         ($NavCommand="MoveNext" || $NavCommand='MoveCellNext') && has_next(match) )
+# => MoveCell {
+#       ruleRef = name(^match);
+#       wordRef = "next";
+#       ::StartPosition = next(match).dfs;
+#       ::EndPosition = next(match).offset;
+#   };
+
+# # no next child -- in last column -- don't move
+# any ? ( (name(match)=="mn" || name(match)=="none") &&
+#         has_parent(match) && name(^match)=="mscarries" &&
+#         ($NavCommand="MoveNext" || $NavCommand='MoveCellNext') )
+# => MoveCell {
+#       ruleRef = name(^match);
+#       wordRef = "next";
+#       childIndex = -1;                   # key to know what to say for each notation
+#       ::SpeakAfterMove = false;
+#   };
+
+# any ? ( (name(match)=="mn" || name(match)=="none") &&
+#         has_parent(match) && name(^match)=="mscarries" &&
+#         $NavCommand='MoveCellUp' && has_previous(^match) )
+# => MoveCell {
+#       ruleRef = name(^match);
+#       wordRef = "up";
+#       ::StartPosition = ^^match[index(^match)-1][index(match)-count(^match)].dfs;
+#       ::EndPosition = ^^match[index(^match)-1][index(match)-count(^match)].offset;
+#   };
+
+# # no previous child -- in first row -- don't move
+# any ? ( (name(match)=="mn" || name(match)=="none") &&
+#         has_parent(match) && name(^match)=="mscarries" &&
+#         $NavCommand='MoveCellUp' )
+# => MoveCell {
+#       ruleRef = name(^match);
+#       wordRef = "up";
+#       childIndex = -1;                   # key to know what to say for each notation
+#       ::SpeakAfterMove = false;
+#   };
+
+# any ? ( (name(match)=="mn" || name(match)=="none") &&
+#         has_parent(match) && name(^match)=="mscarries" &&
+#         $NavCommand='MoveCellDown' && has_next(^match) )
+# => MoveCell {
+#       ruleRef = name(^match);
+#       wordRef = "down";
+#       ::StartPosition = ^^match[index(^match)+1][-1][index(match)-count(^match)].dfs;
+#       ::EndPosition = ^^match[index(^match)+1][-1][index(match)-count(^match)].offset;
+#   };
+
+# # no next child -- in last row -- don't move
+# any ? ( (name(match)=="mn" || name(match)=="none") &&
+#         has_parent(match) && name(^match)=="mscarries" &&
+#         $NavCommand='MoveCellDown' )
+# => MoveCell {
+#       ruleRef = name(^match);
+#       wordRef = "down";
+#       childIndex = -1;                   # key to know what to say for each notation
+#       ::SpeakAfterMove = false;
+#   };
+
+# mn ? ( has_parent(match, 2) && name(^match)=="mn" && name(^^match)=="msrow" &&
+#           $NavCommand='MoveColumnStart' )
+# => MoveColStart {
+#       ruleRef = name(^^match);
+#       column = index(match);
+#       ::StartPosition = ^^^match[0][-1][index(match)-count(^match)].dfs;
+#       ::EndPosition = ^^^match[0][-1][index(match)-count(^match)].offset;
+#   };
+
+# mn ? ( has_parent(match, 2) && name(^match)=="mn" && name(^^match)=="msrow" &&
+#           $NavCommand='MoveColumnEnd' )
+# => MoveColEnd {
+#       ruleRef = name(^^match);
+#       column = index(match);
+#       ::StartPosition = ^^^match[count(^^^match)-1][-1][index(match)-count(^match)].dfs;
+#       ::EndPosition = ^^^match[count(^^^match)-1][-1][index(match)-count(^match)].offset;
+#   };
+
+
+
+- name: default-cell-move
+
+  tag: "*"
+  match:
+  - "$NavCommand='MoveCellPrevious' or $NavCommand='MoveCellNext' or"
+  - "$NavCommand='MoveCellUp' or $NavCommand='MoveCellDown' or"
+  - "$NavCommand='MoveColumnStart' or $NavCommand='MoveColumnEnd' or"
+  - "$NavCommand='ReadCellCurrent'"
+  replace:
+  - test:
+      if: "ancestor::m:mtd"
+      then:
+      - x: "ancestor::m:mtd[1]" # try again on an mtd node
+      else:
+      - t: "não na tabela"                                               # phrase('not in table' or matrix)
+      - pause: long
+      - set_variables: [SpeakExpression: "'false'"]
+
+# ========  Move/Read/Describe Next rules =================
+
+
+- name: move-next-character
+  tag: [mn, mi, mtext]
+  match: 
+  - "($NavCommand = 'MoveNext' or $NavCommand = 'ReadNext' or $NavCommand = 'DescribeNext' or $NavCommand = 'MoveNextZoom') and"
+  - "$NavNodeOffset > 0 and"
+  - "($NavNodeOffset < string-length(.) or name(EdgeNode(., 'right', 'math'))!='math')" # not at edge of math
+  replace:
+  - test:
+      if: "$NavNodeOffset < string-length(.)"
+      then:
+      - with:
+          variables: [SayCommand: "string($NavVerbosity = 'Verbose')"]
+          replace: [x: "."]
+      - set_variables: [NavNodeOffset: "$NavNodeOffset + 1"]
+      else:
+      - with:
+          variables: [SayCommand: "string($NavVerbosity = 'Verbose')"]
+          replace: [x: "."]
+      - set_variables: [NavNodeOffset: "0"]
+      - x: "."
+
+# skip 'none'
+- name: move-next-none
+  tag: [none, mprescripts]
+  match: 
+  - "($NavCommand = 'MoveNext' or $NavCommand = 'ReadNext' or $NavCommand = 'DescribeNext' or $NavCommand = 'DescribePrevious' or $NavCommand = 'MoveNextZoom') and"
+  - "parent::*[1][name(.)='mmultiscripts'] and following-sibling::*"
+  replace:
+  - with:
+      variables: [Following: "following-sibling::*[1]"]
+      replace:
+      # two 'none's in a row -- move over and try again; one 'none', zoom in on next 
+      - test:
+          if: "$Following[name(.)='none']"
+          then: [x: "$Following"]
+          else:
+          - with:
+              variables: [Move2D: "'in'", Child2D: "$Following"]        # phrase('in' the denominator)
+              replace: [x: ".."]
+          - with:
+              variables: [NavCommand: "'MoveNextZoom'"]
+              replace: [x: "$Following"]
+
+
+
+# skip invisible chars except for Enhanced mode when "times" should be read
+- name: move-next-invisible
+  tag: "*"
+  match:
+  - "($NavCommand = 'MoveNext' or $NavCommand = 'ReadNext' or $NavCommand = 'DescribeNext') and"
+  - "following-sibling::*[1][name(.)='mo' and translate(., '\u2061\u2062\u2063\u2064', '')='']"
+  replace:
+  - with:
+      variables: [SayCommand: "string($NavVerbosity = 'Verbose')"]
+      replace: [x: "."]
+  - test:
+      if: "following-sibling::*[1][.='\u2062' or .='\u2064'] and
+           ($NavMode='Enhanced' or ($NavMode='Simple' and following-sibling::*[2][not(IsNode(., 'mathml'))]))"   # invisible times and plus
+      then: [set_variables: [NavNode: "following-sibling::*[1]/@id"]]
+      else: [x: "following-sibling::*[1]"]
+
+- name: move-next-no-auto-zoom-at-edge
+  # at edge of 2D and in a mode where moving right isn't an option
+  tag: "*"
+  variables: [EdgeNode: "EdgeNode(., 'right', '2D')"]
+  match: "$NavCommand = 'MoveNext' and $NavMode!='Character' and not($AutoZoomOut) and $EdgeNode/@id!=@id"
+  replace:
+  - test:
+      if: "$MatchCounter = 0 and $NavVerbosity = 'Verbose'"
+      then:
+      - t: "não consigo mover para a direita"                              # phrase('cannot move right')
+      - pause: medium
+  - with:
+      variables:
+      - Move2D: "'end of'"
+      - Child2D: "$EdgeNode/*[last()]"
+      - MatchCounter: $MatchCounter + 1
+      replace: [x: "$EdgeNode"]
+  - pause: long
+  - set_variables: [SpeakExpression: "'false'"]
+
+- name: move-next-no-auto-zoom-at-edge-math
+  # at edge of math -- no where to go (must be after we rule out being at the edge of 2D) because we want to speak that
+  tag: "*"
+  match:
+  - "($NavCommand = 'MoveNext' or $NavCommand = 'ReadNext' or $NavCommand = 'DescribeNext') and"
+  - "(self::m:math or name(EdgeNode(., 'right', 'math'))='math')" # at edge of math
+  replace:
+  - test:
+      if: "$MatchCounter = 0 and $NavVerbosity = 'Verbose'"
+      then:
+      - t: "não pode"                                          # phrase('cannot' move right in expression)
+      - test:
+        - if: "$NavCommand = 'MoveNext'"
+          then: [t: "mover"]                                  # phrase('move' to next entry in table)     
+        - else_if: "$NavCommand = 'ReadNext'"
+          then: [t: "ler"]                                  # phrase('read' next entry in table)     
+          else: [t: "descrever"]                              # phrase('describe' next entry in table)     
+      - t: "direita"                              # phrase(move 'right')
+      - pause: short
+  - t: "fim da matemática"                              # phrase(move 'end of math')
+  - pause: long
+  - set_variables: [SpeakExpression: "'false'"]
+
+- name: move-next-auto-zoom-up-one-level
+  # Last child or in auto-zoom'd in-- move up a level and try again 
+  # Note: we've already checked the for the case where we are at an edge and should not AutoZoomOut
+  tag: "*"
+  match:
+  - "($NavCommand = 'MoveNext' or $NavCommand = 'ReadNext' or $NavCommand = 'DescribeNext') and"
+  - "( not(following-sibling::*) or"
+  - "  ( $NavMode='Enhanced' and "
+  - "    count(following-sibling::*)=1 and (IsBracketed(.., '(', ')') or IsBracketed(.., '[', ']'))"
+  - "  )"
+  - ")"
+  replace:
+  - with:
+      variables: [SayCommand: "string($NavVerbosity = 'Verbose')"]
+      replace: [x: "."]
+  - test:
+      if: "following-sibling::*"
+      then:
+      - with:
+          variables: [Move2D: "'in'", Child2D: "."]             # phrase('in' the denominator)
+          replace: [x: ".."]
+      else:
+      - with:
+          variables: [Move2D: "'out of'", Child2D: "."]
+          replace: [x: ".."]
+  - x: ".."
+
+# At this point, if XXXNext, then we know there is must be a right sibling
+- name: move-next-default
+  tag: mtd
+  match: "$Move2D = '' and ($NavCommand = 'MoveNext' or $NavCommand = 'ReadNext' or $NavCommand = 'DescribeNext')"
+  replace:
+  - with:
+      variables: [SayCommand: "string($NavVerbosity = 'Verbose')"]
+      replace: [x: "."]
+  - test:
+      if: "following-sibling::*"
+      then:
+      - test:
+          if: "$NavVerbosity = 'Verbose'"
+          then:
+          - t: "coluna"                                       # phrase(the previous 'column' in the table)
+          - x: "count(preceding-sibling::*)+2"
+          - pause: short
+      - test:
+          if: "$NavMode = 'Character'"
+          then:
+          - with:
+              variables: [NavCommand: "'MoveNextZoom'"]
+              replace: [x: "following-sibling::*[1]"]
+          else: [set_variables: [NavNode: "following-sibling::*[1]/*[1]/@id"]]
+      else:
+      - x: ".." # try again at the row level
+
+- name: move-next-default
+  tag: [mtr, mlabeledtr]
+  match: "$Move2D = '' and
+          ($NavCommand = 'MoveNext' or $NavCommand = 'ReadNext' or $NavCommand = 'DescribeNext') and
+          following-sibling::*"
+  replace:
+  - with:
+      variables: [SayCommand: "string($NavVerbosity = 'Verbose')"]
+      replace: [x: "."]
+  - test:
+      if: "$NavMode = 'Character'"
+      then:
+      - with:
+          variables: [NavCommand: "'MoveNextZoom'"]
+          replace: [x: "following-sibling::*[1]"]
+      else:
+      - set_variables: [NavNode: "following-sibling::*[1]/@id"]
+
+- name: move-next-auto-zoom-parens
+  # auto-zoom into next child if next child is parenthesized expr
+  tag: "*"
+  match:
+  - "($NavCommand = 'MoveNext' or $NavCommand = 'ReadNext' or $NavCommand = 'DescribeNext') and"
+  - "$NavMode='Enhanced' and"
+  - "parent::m:mrow and following-sibling::* and"
+  - "following-sibling::*[1][self::m:mrow and count(*)=3 and " #exclude empty parens
+  - "                        (IsBracketed(., '(', ')') or IsBracketed(., '[', ']'))"
+  - "                       ]"
+  replace:
+  - with:
+      variables: [SayCommand: "string($NavVerbosity = 'Verbose')"]
+      replace: [x: "."]
+  - set_variables: [NavNode: "following-sibling::*[1]/*[2]/@id"]
+
+# normal cases for MoveNext
+- name: move-next-locked-zoom-level
+  # locked zoom level
+  tag: "*"
+  match:
+  - "($NavCommand = 'MoveNext' or $NavCommand = 'ReadNext' or $NavCommand = 'DescribeNext') and"
+  - "$ReadZoomLevel>=0"
+  replace:
+  - with:
+      variables: [SayCommand: "string($NavVerbosity = 'Verbose')"]
+      replace: [x: "."]
+  - test:
+      # if in base (nothing before), we must be moving to a script, so "in" will be said
+      if: "preceding-sibling::* and following-sibling::*[1][name(.)='none']"
+      then:
+      - with:
+          variables: [Move2D: "'out of'", Child2D: "."]
+          replace: [x: ".."]
+      - x: "following-sibling::*[1]"
+      else:
+      - with:
+          variables: [Move2D: "'in'", Child2D: "following-sibling::*[1]"]       # phrase('in' the denominator)
+          replace: [x: ".."]
+      - with:
+          variables: [NavCommand: "'MoveNextZoom'"]
+          replace: [x: "following-sibling::*[1]"]
+
+- name: move-next-default
+  tag: "*"
+  match: "$NavCommand = 'MoveNext' or $NavCommand = 'ReadNext' or $NavCommand = 'DescribeNext'"
+  replace:
+  - with:
+      variables: [SayCommand: "string($NavVerbosity = 'Verbose')"]
+      replace: [x: "."]
+  - test:
+      if: "following-sibling::*[1][@data-from-mathml='none' or @data-from-mathml='mprescripts']"
+      then: [x: "following-sibling::*[1]"]
+      else:
+      - test:
+          if: "IsNode(.., '2D') or not(IsNode(.., 'mathml'))"
+          then:
+          - with:
+              variables: [Move2D: "'in'", Child2D: "following-sibling::*[1]"]           # phrase('in' the denominator)
+              replace: [x: ".."]
+      - set_variables: [NavNode: "following-sibling::*[1]/@id"]
+
+# ========  Move/Read/Describe Previous rules =================
+
+# skip 'none'
+- name: move-previous-none
+  tag: [none, mprescripts]
+  match: 
+  - "($NavCommand = 'MovePrevious' or $NavCommand = 'ReadPrevious' or $NavCommand = 'DescribePrevious' or $NavCommand = 'MovePreviousZoom') and"
+  - "parent::*[1][name(.)='mmultiscripts'] and preceding-sibling::*"
+  replace:
+  - with:
+      variables: [Preceding: "preceding-sibling::*[1]"]
+      replace:
+      # two 'none's in a row -- move over and try again; one 'none', zoom in on preceding 
+      - test:
+          if: "$Preceding[name(.)='none']"
+          then: [x: "$Preceding"]
+          else:
+          - with:
+              variables: [Move2D: "'in'", Child2D: "$Preceding"]          # phrase('in' the denominator)
+              replace: [x: ".."]
+          - with:
+              variables: [NavCommand: "'MovePreviousZoom'"]
+              replace: [x: "$Preceding"]
+
+
+# skip invisible chars except for Enhanced mode when "times" should be read
+- name: move-previous-invisible
+  tag: "*"
+  match:
+  - "($NavCommand = 'MovePrevious' or $NavCommand = 'ReadPrevious' or $NavCommand = 'DescribePrevious') and"
+  - "preceding-sibling::*[1][name(.)='mo' and translate(., '\u2061\u2062\u2063\u2064', '')='']"
+  replace:
+  - with:
+      variables: [SayCommand: "string($NavVerbosity = 'Verbose')"]
+      replace: [x: "."]
+  - test:
+      if: "preceding-sibling::*[1][.='\u2062' or .='\u2064'] and $NavMode='Enhanced'"   # invisible times and plus
+      then: [set_variables: [NavNode: "preceding-sibling::*[1]/@id"]]
+      else: [x: "preceding-sibling::*[1]"]
+
+# two rules for when can't move left
+- name: move-previous-no-auto-zoom-at-edge
+  # at edge of 2D and in a mode where moving left isn't an option
+  tag: "*"
+  variables: [EdgeNode: "EdgeNode(., 'left', '2D')"]
+  match: "$NavCommand = 'MovePrevious' and $NavMode!='Character' and not($AutoZoomOut) and $EdgeNode/@id!=@id"
+  replace:
+  - test:
+      if: "$MatchCounter = 0 and $NavVerbosity = 'Verbose' and $NavCommand = 'MovePrevious'"
+      then:
+      - t: "não é possível mover para a esquerda"                                   # phrase('cannot move left' in expression)
+      - pause: medium
+  - with:
+      variables:
+      - Move2D: "'end of'"
+      - Child2D: "$EdgeNode/*[1]"
+      - MatchCounter: $MatchCounter + 1
+      replace: [x: "$EdgeNode"]
+  - pause: long
+
+- name: move-previous-no-auto-zoom-at-edge-of-math
+  # at edge of math -- no where to go (must be after we rule out being at the edge of 2D) because we want to speak that
+  tag: "*"
+  match:
+  - "($NavCommand = 'MovePrevious' or $NavCommand = 'ReadPrevious' or $NavCommand = 'DescribePrevious') and"
+  - "(self::m:math or name(EdgeNode(., 'left', 'math'))='math')"
+  replace:
+  - t: "início da matemática"                                              # phrase('start of math')
+  - pause: long
+  - set_variables: [SpeakExpression: "'false'"]
+
+- name: move-previous-at-end
+  tag: "*"
+  match:
+  - "($NavCommand = 'MovePrevious' or $NavCommand = 'ReadPrevious' or $NavCommand = 'DescribePrevious') and"
+  - "name(EdgeNode(., 'left', 'math'))='math'" # at edge of math
+  replace:
+  - test:
+      if: "$MatchCounter = 0 and $NavVerbosity = 'Verbose'"
+      then:
+      - t: "não pode mover-se para a esquerda"                      # phrase('cannot move left')
+      - pause: short
+  - with:
+      variables: [Move2D: "'start of'", Child2D: "."]
+      replace: [x: "."]
+  - pause: long
+  - set_variables: [SpeakExpression: "'false'"]
+
+- name: move-prev-character
+  tag: [mn, mi, mtext]
+  match: 
+  - "($NavCommand = 'MovePrevious' or $NavCommand = 'ReadPrevious' or $NavCommand = 'DescribePrevious' or $NavCommand = 'MovePreviousZoom') and"
+  - "$NavNodeOffset > 0 and"
+  - "($NavNodeOffset > 1 or name(EdgeNode(., 'left', 'math'))!='math')" # not at edge of math
+  replace:
+  - test:
+      if: "$NavNodeOffset > 1"
+      then:
+      - with:
+          variables: [SayCommand: "string($NavVerbosity = 'Verbose')"]
+          replace: [x: "."]
+      - set_variables: [NavNodeOffset: "$NavNodeOffset - 1"]
+      else:
+      - with:
+          variables: [SayCommand: "string($NavVerbosity = 'Verbose')"]
+          replace: [x: "."]
+      - set_variables: [NavNodeOffset: "0"]
+      - x: "."
+
+- name: move-previous-auto-zoom-up-one-level
+  # Last child or in auto-zoom'd in-- move up a level and try again 
+  # Note: we've already checked the for the case where we are at an edge and should not AutoZoomOut
+  tag: "*"
+  match:
+  - "($NavCommand = 'MovePrevious' or $NavCommand = 'ReadPrevious' or $NavCommand = 'DescribePrevious') and"
+  - "( not(preceding-sibling::*) or"
+  - "  ( $NavMode='Enhanced' and "
+  - "    count(preceding-sibling::*)=1 and (IsBracketed(.., '(', ')') or IsBracketed(.., '[', ']'))"
+  - "  )"
+  - ")"
+  replace:
+  - with:
+      variables: [SayCommand: "string($NavVerbosity = 'Verbose')"]
+      replace: [x: "."]
+  - test:
+      if: "preceding-sibling::*"
+      then:
+      - with:
+          variables: [Move2D: "'in'", Child2D: "."]             # phrase('in' the denominator)
+          replace: [x: ".."]
+      else:
+      - with:
+          variables: [Move2D: "'out of'", Child2D: "."]
+          replace: [x: ".."]
+  - x: ".."
+
+- name: move-previous-auto-zoom-parens
+  # auto-zoom into previous child if previous child is parenthesized expr
+  # Note: there is an asymmetry here from MoveNext because the base of a scripted might have parens for grouping, but not true for the script
+  tag: "*"
+  match:
+  - "($NavCommand = 'MovePrevious' or $NavCommand = 'ReadPrevious' or $NavCommand = 'DescribePrevious') and"
+  - "$NavMode='Enhanced' and"
+  - "preceding-sibling::* and"
+  - "(parent::m:mrow or parent::m:msub or parent::m:msup or"
+  - " (count(preceding-sibling::*)=1 and (parent::m:msubsup or parent::m:mmultiscripts))"  # make sure moving into base
+  - ") and"
+  - "preceding-sibling::*[1][self::m:mrow and count(*)=3 and " #exclude empty parens
+  - "       (IsBracketed(., '(', ')') or IsBracketed(., '[', ']'))"
+  - "   ]"
+  replace:
+  - with:
+      variables: [SayCommand: "string($NavVerbosity = 'Verbose')"]
+      replace: [x: "."]
+  - test:
+      if: "not(parent::m:mrow)"
+      then:
+      - with:
+          variables: [Move2D: "'in'", Child2D: "preceding-sibling::*[1]"]         # phrase('in' the denominator)
+          replace: [x: ".."]
+  - set_variables: [NavNode: "preceding-sibling::*[1]/*[2]/@id"]
+
+# normal cases for MovePrevious
+
+- name: move-previous-default
+  tag: mtd
+  match: "$Move2D = '' and
+          ($NavCommand = 'MovePrevious' or $NavCommand = 'ReadPrevious' or $NavCommand = 'DescribePrevious') and
+          preceding-sibling::*"
+  replace:
+  - with:
+      variables: [SayCommand: "string($NavVerbosity = 'Verbose')"]
+      replace: [x: "."]
+  - test:
+      if: "$NavVerbosity = 'Verbose'"
+      then:
+      - t: "coluna"                               # phrase(the first 'column' in the table)
+      - x: "count(preceding-sibling::*)"
+      - pause: short
+  - test:
+      if: "$NavMode = 'Character'"
+      then:
+      - with:
+          variables: [NavCommand: "'MovePreviousZoom'"]
+          replace: [x: "preceding-sibling::*[1]"]
+      else: [set_variables: [NavNode: "preceding-sibling::*[1]/*[last()]/@id"]]
+
+- name: move-previous-default
+  tag: [mtr, mlabeledtr]
+  match: "$Move2D = '' and ($NavCommand = 'MovePrevious' or $NavCommand = 'ReadPrevious' or $NavCommand = 'DescribePrevious')"
+  replace:
+  - with:
+      variables: [SayCommand: "string($NavVerbosity = 'Verbose')"]
+      replace: [x: "."]
+  - test:
+      if: "preceding-sibling::*"
+      then:
+      - test:
+          if: "$NavMode = 'Character'"
+          then:
+          - with:
+              variables: [NavCommand: "'MovePreviousZoom'"]
+              replace: [x: "preceding-sibling::*[1]"]
+          else:
+          - set_variables: [NavNode: "preceding-sibling::*[1]/@id"]
+      else: [x: ".."] # try again for after
+
+- name: move-previous-locked-zoom-level
+  # locked zoom level
+  tag: "*"
+  match:
+  - "($NavCommand = 'MovePrevious' or $NavCommand = 'ReadPrevious' or $NavCommand = 'DescribePrevious') and"
+  - "$ReadZoomLevel>=0"
+  replace:
+  - with:
+      variables: [SayCommand: "string($NavVerbosity = 'Verbose')"]
+      replace: [x: "."]
+  - test:
+      # if moving into base (nothing before), we must be moving to the base, so "in" will be said
+      if: "count(preceding-sibling::*) > 2 and preceding-sibling::*[1][name(.)='none']"
+      then:
+      - with:
+          variables: [Move2D: "'out of'", Child2D: "."]
+          replace: [x: ".."]
+      - x: "preceding-sibling::*[1]"          # skip over 'none'
+      else:
+      - with:
+          variables: [Move2D: "'in'", Child2D: "preceding-sibling::*[1]"]               # phrase('in' the denominator)
+          replace: [x: ".."]
+      - with:
+          variables: [NavCommand: "'MovePreviousZoom'"]
+          replace: [x: "preceding-sibling::*[1]"]
+
+- name: move-previous-default
+  tag: "*"
+  match: "$NavCommand = 'MovePrevious' or $NavCommand = 'ReadPrevious' or $NavCommand = 'DescribePrevious'"
+  replace:
+  - with:
+      variables: [SayCommand: "string($NavVerbosity = 'Verbose')"]
+      replace: [x: "."]
+  - test:
+      if: "preceding-sibling::*[1][@data-from-mathml='none' or @data-from-mathml='mprescripts']"
+      then: [x: "preceding-sibling::*[1]"]
+      else:
+      - test:
+          if: "IsNode(.., '2D') or not(IsNode(.., 'mathml'))"
+          then:
+          - with:
+              variables: [Move2D: "'in'", Child2D: "preceding-sibling::*[1]"]           # phrase('in' the denominator)
+              replace: [x: ".."]
+      - set_variables: [NavNode: "preceding-sibling::*[1]/@id"]
+
+# ********* ReadZoomLevel toggle ***************
+# These set ::NavMode
+
+- name: toggle-mode-up
+  tag: "*"
+  match: "$NavCommand = 'ToggleZoomLockUp'"
+  replace:
+  - test:
+    - if: "$NavMode = 'Enhanced'"
+      then:
+      - t: "caráter"                                                # phrase(a mathematical 'character')
+      - set_variables: [NavMode: "'Character'", ReadZoomLevel: "1"]
+    - else_if: "$NavMode = 'Character'"
+      then:
+      - t: "simples"                                                   # phrase(a 'simple' way to do something)
+      - set_variables: [NavMode: "'Simple'", ReadZoomLevel: "1"]
+    - else:
+      - t: "aprimorada"                                                 # phrase(an 'enhanced' way to do something)
+      - set_variables: [NavMode: "'Enhanced'", ReadZoomLevel: "-1"]
+  - t: "modo"                                                         # phrase(a simple 'mode' of use)
+  - pause: long
+  - test:
+    - if: "$NavMode != 'Enhanced'" # potentially need to zoom to the sibling
+      then:
+      - with:
+          variables: [MatchCounter: "$MatchCounter + 1", NavCommand: "'MoveNextZoom'"]
+          replace: [x: "."]
+
+- name: toggle-mode-down
+  tag: "*"
+  match: "$NavCommand = 'ToggleZoomLockDown'"
+  replace:
+  - test:
+    - if: "$NavMode = 'Enhanced'"
+      then:
+      - t: "simples"                                                 # phrase(a 'simple' way to do something)
+      - set_variables: [NavMode: "'Simple'", ReadZoomLevel: "1"]
+    - else_if: "$NavMode = 'Character'"
+      then:
+      - t: "aprimorada"                                               # phrase(an 'enhanced' way to do something)
+      - set_variables: [NavMode: "'Enhanced'", ReadZoomLevel: "-1"]
+    - else:
+      - t: "caráter"                                              # phrase(a mathematical 'character')
+      - set_variables: [NavMode: "'Character'", ReadZoomLevel: "1"]
+  - t: "modo"                                                       # phrase(a simple 'mode' of use)
+  - pause: long
+  - test:
+    - if: "$NavMode != 'Enhanced'" # potentially need to zoom to the sibling
+      then:
+      - with:
+          variables: [MatchCounter: "$MatchCounter + 1", NavCommand: "'MoveNextZoom'"]
+          replace: [x: "."]
+
+- name: toggle-speech-describe
+  tag: "*"
+  match: "$NavCommand = 'ToggleSpeakMode'"
+  replace:
+  - test:
+      if: "$Overview = 'true'"
+      then:
+      - t: "falar expressão após movimento"                # phrase('speak expression after move')
+      - pause: long
+      - set_variables: [Overview: "'false'"]
+      else:
+      - t: "visão geral da expressão após a mudança"          # phrase('overview of expression after move')
+      - pause: long
+      - set_variables: [Overview: "'true'"]
+
+- name: current
+  tag: "*"
+  match: "$NavCommand = 'ReadCurrent' or $NavCommand = 'DescribeCurrent'"
+  replace:
+  - test:
+      if: "$NavVerbosity = 'Verbose'"
+      then:
+      - test:
+        - if: "$NavCommand = 'ReadCurrent'"
+          then: [t: "ler"]                                  # phrase('read' next entry in table) 
+          else: [t: "descrever"]                              # phrase('describe' next entry in table)     
+      - t: "atual"                                         # phrase('current' entry in table)
+      - pause: long
+  - set_variables: [NavNode: "@id"]
+
+# this needs to be near the end because we only test for 'Describe', "Read", etc., and we don't want to get 'DescribeNext', etc.
+- name: placemarker
+
+  tag: "*"
+  match:
+  - "starts-with($NavCommand, 'Read') or "
+  - "starts-with($NavCommand, 'Describe') or "
+  - "starts-with($NavCommand, 'MoveTo')"
+  replace:
+  - test:
+      if: "$NavVerbosity != 'Terse'"
+      then:
+      - test:
+        - if: "starts-with($NavCommand, 'Read')"
+          then: [t: "ler"]                                  # phrase('read' next entry in table)     
+        - else_if: "starts-with($NavCommand, 'Describe')"
+          then: [t: "descrever"]                              # phrase('describe' next entry in table)     
+        - else_if: "starts-with($NavCommand, 'MoveTo')"
+          then: [t: "mover para"]                              # phrase('move to' the next entry in table) 
+          else: [t: "definir"]                                   # phrase('set' the value of the next entry in table) 
+      - t: "espaço reservado"                                     # phrase('placeholder' for the value)
+      - x: "$PlaceMarkerIndex"
+      - pause: long
+  - set_variables: [NavNode: "$PlaceMarker"]
+
+- name: set-placemarker
+  tag: "*"
+  match: "starts-with($NavCommand, 'SetPlacemarker')"
+  replace:
+  - test:
+      if: "$NavVerbosity != 'Terse'"
+      then:
+      - t: "definir espaço reservado"                                 # phrase('set placeholder' to the value) 
+      - x: "$PlaceMarkerIndex"
+      - pause: long
+  - set_variables: [NavNode: "@id"]
+
+# ********* WhereAmI  ***************
+
+# FIX: WhereAmI needs support from the Rust code to loop around and do speech at each iteration.
+#      Alternatively, it could insert a special token that Rust code does a "replace" on with the speech (e.g. SPEECH_AT{id})
+#      or a new command "speak" which takes a node id
+- name: where-am-i-start
+  tag: "*"
+  match: "($NavCommand = 'WhereAmI' or $NavCommand = 'WhereAmIAll') and $MatchCounter = 0"
+  replace:
+  - translate: "@id"
+  - pause: long
+  - with:
+      variables: [MatchCounter: "$MatchCounter + 1"]
+      replace: [x: ".."]
+
+- name: where-am-i-stop
+  tag: "*"
+  match:
+  - "($NavCommand = 'WhereAmI' or $NavCommand = 'WhereAmIAll') and $MatchCounter > 0 and"
+  # stopping conditions
+  - "(self::m:math or "
+  - " parent::*[self::m:math and (count(*)=1 or (count(*)=2 and *[2][.=',' or .='.' or .=';' or .='?']) ) ] "
+  - ")"
+  replace:
+  - test:
+      if: "$NavCommand = 'WhereAmI'"
+      then:
+      - t: "dentro de nada mais"                         # phrase('inside of nothing more') 
+      - pause: long
+      - set_variables: [SpeakExpression: "'false'"]
+      else:
+      - t: "dentro"                                         # phrase('inside' a big expression) 
+      - pause: medium
+  - set_variables: [NavNode: "@id"]
+
+- name: where-am-i-middle
+  tag: "*"
+  match: "$NavCommand = 'WhereAmI' or $NavCommand = 'WhereAmIAll'"
+  replace:
+  - t: "dentro"                                           # phrase('inside' a big expression)
+  - pause: medium
+  - test:
+    - if: "$NavMode='Enhanced' and parent::*[self::m:mrow and (IsBracketed(., '(', ')', false) or IsBracketed(., '[', ']', false))]"
+      then: [x: ".."] # auto-zoom up
+    - else_if: "$NavCommand = 'WhereAmI'"
+      then: [set_variables: [NavNode: "@id"]]
+      else:
+      - translate: "@id"
+      - pause: long
+      - x: '..'

--- a/Rules/Languages/pt/overview.yaml
+++ b/Rules/Languages/pt/overview.yaml
@@ -1,0 +1,120 @@
+---
+# Provide an overview/outline/description of the math
+# MathPlayer just tried to shorten things like "mfrac" by just saying "fraction"
+#   For mrow, it say up to 5 operands and just say "and n more things" for the rest
+# This results in strings of varying length. Given human memory is about 7 words long,
+#   it would be better to aim for 7 words (maybe aim for a range of 6-10 words).
+# Idea:
+#   Start by generating a terse form of the speech
+#   At every step when the strings are being joined
+#     a) if the #words <= 7, return the joined string
+#     b) otherwise, set verbosity to 'overview' and regenerate the expression and use that
+# There is a balance that you want to maximize the info given, so 10 words is likely better then 3.
+#   That might mean that at the top level, we may want to allow the first few children to expand
+
+
+- name: overview-default
+  tag: [mfrac, fraction]
+  match: "."
+  replace:
+  - test:
+      if: "IsNode(*[1], 'simple') and IsNode(*[2], 'simple')"
+      then:
+      - x: "*[1]"
+      - t: "sobre"
+      - x: "*[2]"
+      else:
+      - t: "fração"
+
+- name: overview-default
+  tag: [msqrt, "square-root"]
+  match: "."
+  replace:
+  - t: "raiz quadrada"
+  - test:
+      if: "IsNode(*[1], 'simple')"
+      then:
+      - test:
+          if: "$Verbosity!='Terse'"
+          then: [t: "de"]
+      - x: "*[1]"
+
+- name: overview-default
+  tag: [mroot, root]
+  match: "."
+  replace:
+  - test:
+      if: "*[2][self::m:mn]"
+      then_test:
+      - if: "*[2][.='2']"
+        then: [t: "raiz quadrada"]
+      - else_if: "*[2][.='3']"
+        then: [t: "raiz cúbica"]
+      - else_if: "*[2][not(contains(., '.'))]"
+        then: [x: "ToOrdinal(*[2])", t: "raiz"]
+      else:
+      - test:
+          if: "*[2][self::m:mi][string-length(.)=1]"
+          then:
+          - x: "*[2]"
+          - pronounce: [text: "-th", ipa: "θ", sapi5: "th", eloquence: "T"]
+          else: [x: "*[2]"]
+      - t: "raiz"
+  - test:
+      if: "IsNode(*[1], 'simple')"
+      then:
+      - test:
+          if: "$Verbosity!='Terse'"
+          then: [t: "de"]
+      - x: "*[1]"
+
+- name: matrix-override
+  tag: mrow
+  match:
+  - "*[2][self::m:mtable] and"
+  - "(IsBracketed(., '(', ')') or IsBracketed(., '[', ']') or IsBracketed(., '|', '|'))"
+  replace:
+  - t: "o"
+  - x: count(*[2]/*)
+  - t: "por"
+  - x: count(*[2]/*[self::m:mtr][1]/*)
+  - test:
+      if: "*[1][.='|']" # just need to check the first bracket since we know it must be (, [, or |
+      then: [t: "determinante"]
+      else: [t: "matriz"]
+
+- name: overview-default
+  tag: mtable
+  match: "."
+  replace:
+  - t: "o"
+  - x: count(*[2]/*)
+  - t: "por"
+  - x: count(*[2]/*[self::m:mtr][1]/*)
+  - t: "tabela"
+
+- name: short-mrow
+  tag: mrow
+  match: "count(*)<6"
+  replace:
+  - insert:
+      nodes: "*"
+      replace: [pause: auto]
+
+- name: long-mrow
+  tag: mrow
+  match: "."
+  replace:
+  - x: "*[1]"
+  - pause: auto
+  - x: "*[2]"
+  - pause: auto
+  - x: "*[3]"
+  - pause: auto
+  - x: "*[4]"
+  - pause: auto
+  - x: "*[5]"
+  - pause: auto
+  - t: "e assim por diante"
+
+- include: "SimpleSpeak_Rules.yaml"

--- a/Rules/Languages/pt/unicode-full.yaml
+++ b/Rules/Languages/pt/unicode-full.yaml
@@ -1,0 +1,3625 @@
+---
+
+
+ - "¢": [t: "centavos"]                         	#  0xa2	(en: 'cents', google translation)
+ - "£": [t: "libras"]                           	#  0xa3	(en: 'pounds', google translation)
+ - "¤": [t: "sinal de moeda"]                   	#  0xa4	(en: 'currency sign', google translation)
+ - "¥": [t: "iene"]                             	#  0xa5	(en: 'yen', google translation)
+ - "¦": [t: "barra quebrada"]                   	#  0xa6	(en: 'broken bar', google translation)
+ - "§": [t: "seção"]                            	#  0xa7	(en: 'section', google translation)
+ - "¨": [t: "ponto duplo"]                      	#  0xa8	(en: 'double dot', google translation)
+ - "©": [t: "direitos autorais"]                	#  0xa9	(en: 'copyright', google translation)
+ - "ª": [t: "indicador ordinal feminino"]       	#  0xaa	(en: 'feminine ordinal indicator', google translation)
+ - "«": [t: "aspas de ângulo duplo apontando para a esquerda"]	#  0xab	(en: 'left-pointing double angle quote mark', google translation)
+ - "¯":                                         	#  0xaf
+     - test:
+        if: "ancestor::m:modified-variable and preceding-sibling::*[1][self::m:mi]"
+        then: [t: "bar"]                        	# 	(google translation)
+        else: [t: "linha"]                      	# 	(en: 'line', google translation)
+ - "²": [t: "dois"]                             	#  0xb2	(en: 'two', google translation)
+ - "³": [t: "três"]                             	#  0xb3	(en: 'three', google translation)
+ - "µ": [t: "micro"]                            	#  0xb5	(google translation)
+ - "¹": [t: "um"]                               	#  0xb9	(en: 'one', google translation)
+ - "º": [t: "indicador ordinal masculino"]      	#  0xb9	(en: 'masculine ordinal indicator', google translation)
+ - "¡": [t: "ponto de exclamação invertido"]    	#  0xa1	(en: 'inverted exclamation mark', google translation)
+ - "¶": [t: "marca de parágrafo"]               	#  0xb6	(en: 'paragraph mark', google translation)
+ - "¿": [t: "ponto de interrogação invertido"]  	#  0xbf	(en: 'inverted question mark', google translation)
+
+ - "ʰ": [t: "modificador pequeno h"]            	#  0x2b0	(en: 'modifier small h', google translation)
+ - "ʱ": [t: "modificador pequeno h com gancho"] 	#  0x2b1	(en: 'modifier small h with hook', google translation)
+ - "ʲ": [t: "modificador pequeno j"]            	#  0x2b2	(en: 'modifier small j', google translation)
+ - "ʳ": [t: "modificador pequeno r"]            	#  0x2b3	(en: 'modifier small r', google translation)
+ - "ʴ": [t: "modificador pequeno virou r"]      	#  0x2b4	(en: 'modifier small turned r', google translation)
+ - "ʵ": [t: "modificador pequeno transformado em r com gancho"]	#  0x2b5	(en: 'modifier small turned r with hook', google translation)
+ - "ʶ":                                         	#  0x2b6
+    - t: "modificador pequeno invertido"        	# 	(en: 'modifier small inverted', google translation)
+    - spell: "translate('R', 'R', 'R')"
+
+ - "ʷ": [t: "modificador pequeno w"]            	#  0x2b7	(en: 'modifier small w', google translation)
+ - "ʸ": [t: "modificador pequeno y"]            	#  0x2b8	(en: 'modifier small y', google translation)
+ - "ʹ": [t: "modificador primo"]                	#  0x2b9	(en: 'modifier prime', google translation)
+ - "ʺ": [t: "modificador duplo primo"]          	#  0x2ba	(en: 'modifier double prime', google translation)
+ - "ʻ": [t: "modificador virou vírgula"]        	#  0x2bb	(en: 'modifier turned comma', google translation)
+ - "ʼ": [t: "apóstrofo modificador"]            	#  0x2bc	(en: 'modifier apostrophe', google translation)
+ - "ʽ": [t: "modificador vírgula invertida"]    	#  0x2bd	(en: 'modifier reversed comma', google translation)
+ - "ʾ": [t: "modificador meio anel direito"]    	#  0x2be	(en: 'modifier right half ring', google translation)
+ - "ʿ": [t: "modificador meio anel esquerdo"]   	#  0x2bf	(en: 'modifier left half ring', google translation)
+ - "ˀ": [t: "modificador de parada glótica"]    	#  0x2c0	(en: 'modifier glottal stop', google translation)
+ - "ˁ": [t: "modificador de parada glótica invertida"]	#  0x2c1	(en: 'modifier reversed glottal stop', google translation)
+ - "˂": [t: "modificador ponta de seta para a esquerda"]	#  0x2c2	(en: 'modifier left arrowhead', google translation)
+ - "˃": [t: "modificador ponta de seta para a direita"]	#  0x2c3	(en: 'modifier right arrowhead', google translation)
+ - "˄": [t: "modificador ponta de seta para cima"]	#  0x2c4	(en: 'modifier up arrowhead', google translation)
+ - "˅": [t: "modificador ponta de seta para baixo"]	#  0x2c5	(en: 'modifier down arrowhead', google translation)
+ - "ˆ": [t: "modificador de acento circunflexo"]	#  0x2c6	(en: 'modifier circumflex accent', google translation)
+ - "ˇ": [t: "verificar"]                        	#  0x2c7	(en: 'check', google translation)
+ - "ˈ": [t: "linha vertical modificadora"]      	#  0x2c8	(en: 'modifier vertical line', google translation)
+ - "ˉ": [t: "modificador macron"]               	#  0x2c9	(en: 'modifier macron', google translation)
+ - "ˊ": [t: "modificador de acento agudo"]      	#  0x2ca	(en: 'modifier acute accent', google translation)
+ - "ˋ": [t: "modificador de acento grave"]      	#  0x2cb	(en: 'modifier grave accent', google translation)
+ - "ˌ": [t: "modificador linha vertical baixa"] 	#  0x2cc	(en: 'modifier low vertical line', google translation)
+ - "ˍ": [t: "modificador baixo macron"]         	#  0x2cd	(en: 'modifier low macron', google translation)
+ - "ˎ": [t: "modificador de acento grave baixo"]	#  0x2ce	(en: 'modifier low grave accent', google translation)
+ - "ˏ": [t: "modificador de acento agudo baixo"]	#  0x2cf	(en: 'modifier low acute accent', google translation)
+ - "ː": [t: "modificador dois pontos triangulares"]	#  0x2d0	(en: 'modifier triangular colon', google translation)
+ - "ˑ": [t: "modificador meio cólon triangular"]	#  0x2d1	(en: 'modifier half triangular colon', google translation)
+ - "˒": [t: "modificador centralizado no meio anel direito"]	#  0x2d2	(en: 'modifier centered right half ring', google translation)
+ - "˓": [t: "modificador centralizado no meio anel esquerdo"]	#  0x2d3	(en: 'modifier centered left half ring', google translation)
+ - "˔": [t: "modificador para cima tadck"]      	#  0x2d4	(en: 'modifier up tadck', google translation)
+ - "˕": [t: "modificador para baixo"]           	#  0x2d5	(en: 'modifier down tack', google translation)
+ - "˖": [t: "sinal de mais modificador"]        	#  0x2d6	(en: 'modifier plus sign', google translation)
+ - "˗": [t: "sinal de menos modificador"]       	#  0x2d7	(en: 'modifier minus sign', google translation)
+ - "˘": [t: "breve"]                            	#  0x2d8	(google translation)
+ - "˙": [t: "ponto"]                            	#  0x2d9	(en: 'dot', google translation)
+ - "˚": [t: "anel acima"]                       	#  0x2da	(en: 'ring above', google translation)
+ - "˛": [t: "ogonek"]                           	#  0x2db	(google translation)
+ - "˜": [t: "pequeno til"]                      	#  0x2dc	(en: 'small tilde', google translation)
+ - "˝": [t: "acento agudo duplo"]               	#  0x2dd	(en: 'double acute accent', google translation)
+ - "˞": [t: "gancho rótico modificador"]        	#  0x2de	(en: 'modifier rhotic hook', google translation)
+ - "˟": [t: "modificador de acento cruzado"]    	#  0x2df	(en: 'modifier cross accent', google translation)
+ - "ˠ": [t: "modificador gama pequena"]         	#  0x2e0	(en: 'modifier small gamma', google translation)
+ - "ˡ": [t: "modificador pequeno l"]            	#  0x2e1	(en: 'modifier small l', google translation)
+ - "ˢ": [t: "modificador pequeno s"]            	#  0x2e2	(en: 'modifier small s', google translation)
+ - "ˣ": [t: "modificador pequeno x"]            	#  0x2e3	(en: 'modifier small x', google translation)
+ - "ˤ": [t: "modificador pequena parada glótica invertida"]	#  0x2e4	(en: 'modifier small reversed glottal stop', google translation)
+ - "˥": [t: "barra de tom extra-alta modificadora"]	#  0x2e5	(en: 'modifier extra-high tone bar', google translation)
+ - "˦": [t: "barra modificadora de tom alto"]   	#  0x2e6	(en: 'modifier high tone bar', google translation)
+ - "˧": [t: "barra modificadora de tons médios"]	#  0x2e7	(en: 'modifier mid tone bar', google translation)
+ - "˨": [t: "barra de tom baixo modificadora"]  	#  0x2e8	(en: 'modifier low tone bar', google translation)
+ - "˩": [t: "barra de tom extra-baixa modificadora"]	#  0x2e9	(en: 'modifier extra-low tone bar', google translation)
+ - "˪": [t: "modificador yin marca de tom de partida"]	#  0x2ea	(en: 'modifier yin departing tone mark', google translation)
+ - "˫": [t: "modificador yang marca de tom de partida"]	#  0x2eb	(en: 'modifier yang departing tone mark', google translation)
+ - "ˬ": [t: "voz modificadora"]                 	#  0x2ec	(en: 'modifier voicing', google translation)
+ - "˭": [t: "modificador não aspirado"]         	#  0x2ed	(en: 'modifier unaspirated', google translation)
+ - "ˮ": [t: "modificador apóstrofo duplo"]      	#  0x2ee	(en: 'modifier double apostrophe', google translation)
+ - "˯": [t: "modificador ponta de seta para baixo"]	#  0x2ef	(en: 'modifier low down arrowhead', google translation)
+ - "˰": [t: "modificador ponta de seta para baixo"]	#  0x2f0	(en: 'modifier low up arrowhead', google translation)
+ - "˱": [t: "modificador ponta de seta inferior esquerda"]	#  0x2f1	(en: 'modifier low left arrowhead', google translation)
+ - "˲": [t: "modificador ponta de seta inferior à direita"]	#  0x2f2	(en: 'modifier low right arrowhead', google translation)
+ - "˳": [t: "modificador de anel baixo"]        	#  0x2f3	(en: 'modifier low ring', google translation)
+ - "˴": [t: "modificador de acento grave médio"]	#  0x2f4	(en: 'modifier middle grave accent', google translation)
+ - "˵": [t: "modificador acento grave duplo médio"]	#  0x2f5	(en: 'modifier middle double grave accent', google translation)
+ - "˶": [t: "modificador médio duplo acento agudo"]	#  0x2f6	(en: 'modifier middle double acute accent', google translation)
+ - "˷": [t: "modificador til baixo"]            	#  0x2f7	(en: 'modifier low tilde', google translation)
+ - "˸": [t: "modificador levantado dois pontos"]	#  0x2f8	(en: 'modifier raised colon', google translation)
+ - "˹": [t: "modificador começa tom alto"]      	#  0x2f9	(en: 'modifier begin high tone', google translation)
+ - "˺": [t: "modificador final tom alto"]       	#  0x2fa	(en: 'modifier end high tone', google translation)
+ - "˻": [t: "modificador começa tom baixo"]     	#  0x2fb	(en: 'modifier begin low tone', google translation)
+ - "˼": [t: "modificador final tom baixo"]      	#  0x2fc	(en: 'modifier end low tone', google translation)
+ - "˽": [t: "prateleira modificadora"]          	#  0x2fd	(en: 'modifier shelf', google translation)
+ - "˾": [t: "modificador prateleira aberta"]    	#  0x2fe	(en: 'modifier open shelf', google translation)
+ - "˿": [t: "modificador seta baixa para a esquerda"]	#  0x2ff	(en: 'modifier low left arrow', google translation)
+ - "̈": [t: "embelezamento de diérese"]         	#  0x308	(en: 'diaeresis embellishment', google translation)
+ - "̉": [t: "gancho acima do enfeite"]          	#  0x309	(en: 'hook above embellishment', google translation)
+ - "̊": [t: "anel acima do enfeite"]            	#  0x30a	(en: 'ring above embellishment', google translation)
+ - "̋": [t: "embelezamento com acento agudo duplo"]	#  0x30b	(en: 'double acute accent embellishment', google translation)
+ - "̌": [t: "verificar"]                        	#  0x30c	(en: 'check', google translation)
+ - "̍": [t: "linha vertical acima do enfeite"]  	#  0x30d	(en: 'vertical line above embellishment', google translation)
+ - "̎": [t: "linha vertical dupla acima do enfeite"]	#  0x30e	(en: 'double vertical line above embellishment', google translation)
+ - "̏": [t: "enfeite com acento grave duplo"]   	#  0x30f	(en: 'double grave accent embellishment', google translation)
+ - "̐": [t: "enfeite de candrabindu"]           	#  0x310	(en: 'candrabindu embellishment', google translation)
+ - "̑": [t: "embelezamento breve invertido"]    	#  0x311	(en: 'inverted breve embellishment', google translation)
+ - "̒": [t: "virou vírgula acima do enfeite"]   	#  0x312	(en: 'turned comma above embellishment', google translation)
+ - "̓": [t: "vírgula acima do enfeite"]         	#  0x313	(en: 'comma above embellishment', google translation)
+ - "̔": [t: "vírgula invertida acima do embelezamento"]	#  0x314	(en: 'reversed comma above embellishment', google translation)
+ - "̕": [t: "vírgula acima do enfeite direito"] 	#  0x315	(en: 'comma above right embellishment', google translation)
+ - "̖": [t: "acento grave abaixo do embelezamento"]	#  0x316	(en: 'grave accent below embellishment', google translation)
+ - "̗": [t: "acento agudo abaixo do embelezamento"]	#  0x317	(en: 'acute accent below embellishment', google translation)
+ - "̘": [t: "aderência esquerda abaixo do enfeite"]	#  0x318	(en: 'left tack below embellishment', google translation)
+ - "̙": [t: "aderência direita abaixo do enfeite"]	#  0x319	(en: 'right tack below embellishment', google translation)
+ - "̚": [t: "ângulo esquerdo acima do enfeite"] 	#  0x31a	(en: 'left angle above embellishment', google translation)
+ - "̛": [t: "enfeite de chifre"]                	#  0x31b	(en: 'horn embellishment', google translation)
+ - "̜": [t: "meio anel esquerdo abaixo do enfeite"]	#  0x31c	(en: 'left half ring below embellishment', google translation)
+ - "̝": [t: "para cima abaixo do embelezamento"]	#  0x31d	(en: 'up tack below embellishment', google translation)
+ - "̞": [t: "aderência abaixo do enfeite"]      	#  0x31e	(en: 'down tack below embellishment', google translation)
+ - "̟": [t: "sinal de mais abaixo do enfeite"]  	#  0x31f	(en: 'plus sign below embellishment', google translation)
+ - "̠": [t: "sinal de menos abaixo do enfeite"] 	#  0x320	(en: 'minus sign below embellishment', google translation)
+ - "̡": [t: "gancho palatalizado abaixo do enfeite"]	#  0x321	(en: 'palatalized hook below embellishment', google translation)
+ - "̢": [t: "gancho retroflex abaixo do enfeite"]	#  0x322	(en: 'retroflex hook below embellishment', google translation)
+ - "̣": [t: "ponto abaixo do enfeite"]          	#  0x323	(en: 'dot below embellishment', google translation)
+ - "̤": [t: "trema abaixo do embelezamento"]    	#  0x324	(en: 'diaeresis below embellishment', google translation)
+ - "̥": [t: "anel abaixo do enfeite"]           	#  0x325	(en: 'ring below embellishment', google translation)
+ - "̦": [t: "vírgula abaixo do embelezamento"]  	#  0x326	(en: 'comma below embellishment', google translation)
+ - "̧": [t: "enfeite de cedilha"]               	#  0x327	(en: 'cedilla embellishment', google translation)
+ - "̨": [t: "enfeite ogonek"]                   	#  0x328	(en: 'ogonek embellishment', google translation)
+ - "̩": [t: "linha vertical abaixo do enfeite"] 	#  0x329	(en: 'vertical line below embellishment', google translation)
+ - "̪": [t: "ponte abaixo do embelezamento"]    	#  0x32a	(en: 'bridge below embellishment', google translation)
+ - "̫": [t: "arco duplo invertido abaixo do embelezamento"]	#  0x32b	(en: 'inverted double arch below embellishment', google translation)
+ - "̬": [t: "caron abaixo do embelezamento"]    	#  0x32c	(en: 'caron below embellishment', google translation)
+ - "̭": [t: "acento circunflexo abaixo do embelezamento"]	#  0x32d	(en: 'circumflex accent below embellishment', google translation)
+ - "̮": [t: "breve abaixo do embelezamento"]    	#  0x32e	(en: 'breve below embellishment', google translation)
+ - "̯": [t: "breve invertido abaixo do embelezamento"]	#  0x32f	(en: 'inverted breve below embellishment', google translation)
+ - "̰": [t: "til abaixo do embelezamento"]      	#  0x330	(en: 'tilde below embellishment', google translation)
+ - "̱": [t: "macron abaixo do embelezamento"]   	#  0x331	(en: 'macron below embellishment', google translation)
+ - "̲": [t: "enfeite de linha baixa"]           	#  0x332	(en: 'low line embellishment', google translation)
+ - "̳": [t: "enfeite de linha dupla baixa"]     	#  0x333	(en: 'double low line embellishment', google translation)
+ - "̴": [t: "enfeite de sobreposição de til"]   	#  0x334	(en: 'tilde overlay embellishment', google translation)
+ - "̵": [t: "enfeite de sobreposição de traço curto"]	#  0x335	(en: 'short stroke overlay embellishment', google translation)
+ - "̶": [t: "enfeite de sobreposição de traço longo"]	#  0x336	(en: 'long stroke overlay embellishment', google translation)
+ - "̷": [t: "enfeite de sobreposição de solidus curto"]	#  0x337	(en: 'short solidus overlay embellishment', google translation)
+ - "̸": [t: "enfeite de sobreposição de solidus longo"]	#  0x338	(en: 'long solidus overlay embellishment', google translation)
+ - "̹": [t: "meio anel direito abaixo do enfeite"]	#  0x339	(en: 'right half ring below embellishment', google translation)
+ - "̺": [t: "ponte invertida abaixo do enfeite"]	#  0x33a	(en: 'inverted bridge below embellishment', google translation)
+ - "̻": [t: "quadrado abaixo do enfeite"]       	#  0x33b	(en: 'square below embellishment', google translation)
+ - "̼": [t: "gaivota abaixo do enfeite"]        	#  0x33c	(en: 'seagull below embellishment', google translation)
+ - "̽": [t: "x acima do enfeite"]               	#  0x33d	(en: 'x above embellishment', google translation)
+ - "̾": [t: "embelezamento de til vertical"]    	#  0x33e	(en: 'vertical tilde embellishment', google translation)
+ - "̿": [t: "enfeite de linha dupla"]           	#  0x33f	(en: 'double overline embellishment', google translation)
+ - "̀": [t: "embelezamento de marca de tom grave"]	#  0x340	(en: 'grave tone mark embellishment', google translation)
+ - "́": [t: "embelezamento de marca de tom agudo"]	#  0x341	(en: 'acute tone mark embellishment', google translation)
+ - "͆": [t: "ponte acima"]                      	#  0x346	(en: 'bridge above', google translation)
+
+ - "ΪΫϏ":                                       	#  0x3aa, 0x3ab, 0x3cf
+    - test: 
+        if: "$CapitalLetters_Beep"
+        then:
+        - audio:
+            value: "beep.mp4"
+            replace: []
+    - test: 
+        if: "$CapitalLetters_UseWord"
+        then_test:
+          if: "$SpeechOverrides_CapitalLetters = ''"
+          then_test:
+            if: "$Impairment = 'Blindness'"
+            then: [t: "maiúsculas"]             	# 	(en: 'cap', google translation)
+          else: [x: "$SpeechOverrides_CapitalLetters"] 
+    - pitch:
+        value: "$CapitalLetters_Pitch"
+        replace: [spell: "translate('.', 'ΪΫϏ', 'ιυϗ')"]
+    - t: "com dialítica"                        	# 	(en: 'with dialytika', google translation)
+ - "ϊ": [t: "iota com dialítica"]               	#  0x3ca	(en: 'iota with dialytika', google translation)
+ - "ϋ": [t: "upsilon com dialítica"]            	#  0x3cb	(en: 'upsilon with dialytika', google translation)
+ - "ό": [t: "omicron com tonos"]                	#  0x3cc	(en: 'omicron with tonos', google translation)
+ - "ύ": [t: "upsilon com tonos"]                	#  0x3cd	(en: 'upsilon with tonos', google translation)
+ - "ώ": [t: "ômega com tonos"]                  	#  0x3ce	(en: 'omega with tonos', google translation)
+ - "ϐ": [t: "beta"]                             	#  0x3d0	(google translation)
+ - "ϑ": [t: "teta"]                             	#  0x3d1	(en: 'theta', google translation)
+ - "ϒ": [t: "upsilon com gancho"]               	#  0x3d2	(en: 'upsilon with hook', google translation)
+ - "ϓ": [t: "upsilon com agudo e anzol"]        	#  0x3d3	(en: 'upsilon with acute and hook', google translation)
+ - "ϔ": [t: "upsilon com trema e gancho"]       	#  0x3d4	(en: 'upsilon with diaeresis and hook', google translation)
+ - "ϗ": [t: "kai"]                              	#  0x3d7	(google translation)
+ - "Ϙ": [t: "koppa arcaico maiúsculo"]          	#  0x3d8	(en: 'cap archaic koppa', google translation)
+ - "ϙ": [t: "koppa arcaico"]                    	#  0x3d9	(en: 'archaic koppa', google translation)
+ - "А-Я":                                       	#  0x410 - 0x42f
+    - test: 
+        if: "$CapitalLetters_Beep"
+        then:
+        - audio:
+            value: "beep.mp4"
+            replace: []
+    - test: 
+        if: "$CapitalLetters_UseWord"
+        then_test:
+          if: "$SpeechOverrides_CapitalLetters = ''"
+          then_test:
+            if: "$Impairment = 'Blindness'"
+            then: [t: "maiúsculas"]             	# 	(en: 'cap', google translation)
+          else: [x: "$SpeechOverrides_CapitalLetters"] 
+    - pitch:
+        value: "$CapitalLetters_Pitch"
+        replace: [spell: "translate('.', 'АБВГДЕЖЗИЙКЛМНОПРСТУФХЦЧШЩЪЫЬЭЮЯ', 'абвгдежзийклмнопрстуфхцчшщъыьэюя')"]
+ - "а": [t: "a"]                                	#  0x430	(google translation)
+ - "б": [t: "ser"]                              	#  0x431	(en: 'be', google translation)
+ - "в": [t: "eu"]                               	#  0x432	(en: 've', google translation)
+ - "г": [t: "ah"]                               	#  0x433	(en: 'ghe', google translation)
+ - "д": [t: "de"]                               	#  0x434	(google translation)
+ - "е": [t: "ou seja"]                          	#  0x435	(en: 'ie', google translation)
+ - "ж": [t: "zhe"]                              	#  0x436	(google translation)
+ - "з": [t: "zé"]                               	#  0x437	(en: 'ze', google translation)
+ - "и": [t: "i"]                                	#  0x438	(google translation)
+ - "й": [t: "curto eu"]                         	#  0x439	(en: 'short i', google translation)
+ - "к": [t: "sim"]                              	#  0x43a	(en: 'ka', google translation)
+ - "л": [t: "el"]                               	#  0x43b	(google translation)
+ - "м": [t: "em"]                               	#  0x43c	(google translation)
+ - "н": [t: "en"]                               	#  0x43d	(google translation)
+ - "о": [t: "o"]                                	#  0x43e	(google translation)
+ - "п": [t: "pe"]                               	#  0x43f	(google translation)
+ - "р": [t: "er"]                               	#  0x440	(google translation)
+ - "с": [t: "é"]                                	#  0x441	(en: 'es', google translation)
+ - "т": [t: "você"]                             	#  0x442	(en: 'te', google translation)
+ - "у": [t: "u"]                                	#  0x443	(google translation)
+ - "ф": [t: "ef"]                               	#  0x444	(google translation)
+ - "х": [t: "ha"]                               	#  0x445	(google translation)
+ - "ц": [t: "tse"]                              	#  0x446	(google translation)
+ - "ч": [t: "che"]                              	#  0x447	(google translation)
+ - "ш": [t: "xa"]                               	#  0x448	(en: 'sha', google translation)
+ - "щ": [t: "shcha"]                            	#  0x449	(google translation)
+ - "ъ": [t: "sinal difícil"]                    	#  0x44a	(en: 'hard sign', google translation)
+ - "ы": [t: "sim"]                              	#  0x44b	(en: 'yeru', google translation)
+ - "ь": [t: "sinal suave"]                      	#  0x44c	(en: 'soft sign', google translation)
+ - "э": [t: "e"]                                	#  0x44d	(google translation)
+ - "ю": [t: "você"]                             	#  0x44e	(en: 'yu', google translation)
+ - "я": [t: "sim"]                              	#  0x44f	(en: 'ya', google translation)
+ - "؆": [t: "raiz cúbica árabe-índica"]         	#  0x606	(en: 'Arabic-Indic cube root', google translation)
+ - "؇": [t: "quarta raiz árabe-índica"]         	#  0x607	(en: 'Arabic-Indic fourth root', google translation)
+ - "؈": [t: "raio árabe"]                       	#  0x608	(en: 'Arabic ray', google translation)
+ - "‐": [t: "hífen"]                            	#  0x2010	(en: 'hyphen', google translation)
+ - "‑": [t: "hífen"]                            	#  0x2011	(en: 'hyphen', google translation)
+ - "‒": [t: "traço de figura"]                  	#  0x2012	(en: 'figure dash', google translation)
+ - "–": [t: "em traço"]                         	#  0x2013	(en: 'en dash', google translation)
+ - "—": [t: "travessão"]                        	#  0x2014	(en: 'em dash', google translation)
+ - "―": [t: "barra horizontal"]                 	#  0x2015	(en: 'horizontal bar', google translation)
+ - "‖": [t: "linha vertical dupla"]             	#  0x2016	(en: 'double vertical line', google translation)
+ - "†": [t: "punhal"]                           	#  0x2020	(en: 'dagger', google translation)
+ - "‡": [t: "punhal duplo"]                     	#  0x2021	(en: 'double dagger', google translation)
+
+ - " - ": [t: " "]                              	#  0x2000 - 0x2007	(google translation)
+
+ - "•":                                         	#  0x2022
+    - test: 
+        if: "@data-chem-formula-op"
+        then: [t: "ponto"]                      	# 	(en: 'dot', google translation)
+        else: [t: "bala"]                       	# 	(en: 'bullet', google translation)
+
+ - "‰": [t: "por mil"]                          	#  0x2030	(en: 'per mille', google translation)
+ - "‱": [t: "por dez mil"]                      	#  0x2031	(en: 'per ten thousand', google translation)
+ - "′": [t: "melhor"]                           	#  0x2032	(en: 'prime', google translation)
+ - "″": [t: "duplo primo"]                      	#  0x2033	(en: 'double prime', google translation)
+ - "‴": [t: "triplo primo"]                     	#  0x2034	(en: 'triple prime', google translation)
+ - "‵": [t: "primo invertido"]                  	#  0x2035	(en: 'reversed prime', google translation)
+ - "‶": [t: "duplo primo invertido"]            	#  0x2036	(en: 'reversed double prime', google translation)
+ - "‷": [t: "triplo primo invertido"]           	#  0x2037	(en: 'reversed triple prime', google translation)
+ - "‸": [t: "para o"]                           	#  0x2038	(en: 'to the', google translation)
+ - "‹": [t: "aspas de ângulo apontador único para a esquerda"]	#  0x2039	(en: 'single left pointing angle quote mark', google translation)
+ - "›": [t: "aspas de ângulo reto único"]       	#  0x203a	(en: 'single right pointing angle quote mark', google translation)
+ - "‼":                                         	#  0x203c
+    - test:
+        if: "ancestor-or-self::*[contains(@data-intent-property, ':literal:')]"
+        then: [t: "duplo ponto de exclamação"]  	#  0x203c	(en: 'double exclamation point', google translation)
+        else: [t: "fatorial duplo"]             	#  0x203c	(en: 'double factorial', google translation)
+ - "⁄":                                         	#  0x2044
+    - test:
+        if: "ancestor-or-self::*[contains(@data-intent-property, ':literal:')]"
+        then: [t: "barra grande"]               	#  0x203c	(en: 'large slash', google translation)
+        else: [t: "dividido por"]               	#  0x203c	(en: 'divided by', google translation)
+ - "⁅": [t: "colchete esquerdo com pena"]       	#  0x2045	(en: 'left square bracket with quill', google translation)
+ - "⁆": [t: "colchete direito com pena"]        	#  0x2046	(en: 'right square bracket with quill', google translation)
+ - "※": [t: "marca de referência"]              	#  0x203b	(en: 'reference mark', google translation)
+ - "‿": [t: "sob gravata"]                      	#  0x203F	(en: 'under tie', google translation)
+ - "⁀": [t: "gravata"]                          	#  0x2040	(en: 'tie', google translation)
+ - "⁎": [t: "asterisco baixo"]                  	#  0x204e	(en: 'low asterisk', google translation)
+ - "⁏": [t: "ponto e vírgula invertido"]        	#  0x204f	(en: 'reversed semicolon', google translation)
+ - "⁐": [t: "fechar-se"]                        	#  0x2050	(en: 'close up', google translation)
+ - "⁑": [t: "dois asteriscos verticais"]        	#  0x2051	(en: 'two vertical asterisks', google translation)
+ - "⁒": [t: "sinal de menos comercial"]         	#  0x2052	(en: 'commercial minus sign', google translation)
+ - "⁗": [t: "quádruplo primo"]                  	#  0x2057	(en: 'quadruple prime', google translation)
+ - "⁠": [t: ""]                                 	#  0x2060
+ - "⁰": [t: "à potência zero"]                  	#  0x2070	(en: 'to the zeroth power', google translation)
+ - "ⁱ": [t: "elevado à i-ésima potência"]       	#  0x2071	(en: 'to the i-th power', google translation)
+ - "⁴": [t: "à quarta potência"]                	#  0x2074	(en: 'to the fourth power', google translation)
+ - "⁵": [t: "à quinta potência"]                	#  0x2075	(en: 'to the fifth power', google translation)
+ - "⁶": [t: "à sexta potência"]                 	#  0x2076	(en: 'to the sixth power', google translation)
+ - "⁷": [t: "à sétima potência"]                	#  0x2077	(en: 'to the seventh power', google translation)
+ - "⁸": [t: "à potência ath"]                   	#  0x2078	(en: 'to the eighth power', google translation)
+ - "⁹": [t: "à nona potência"]                  	#  0x2079	(en: 'to the ninth power', google translation)
+ - "⁺": [t: "sinal de mais sobrescrito"]        	#  0x207a	(en: 'superscript plus sign', google translation)
+ - "⁻": [t: "sobrescrito menos"]                	#  0x207b	(en: 'superscript minus', google translation)
+ - "⁼": [t: "sinal de igual sobrescrito"]       	#  0x207c	(en: 'superscript equals sign', google translation)
+ - "⁽": [t: "sobrescrito parênteses esquerdo"]  	#  0x207d	(en: 'superscript left parenthesis', google translation)
+ - "⁾": [t: "sobrescrito entre parênteses à direita"]	#  0x207e	(en: 'superscript right parenthesis', google translation)
+ - "ⁿ": [t: "à enésima potência"]               	#  0x207f	(en: 'to the ennth power', google translation)
+ - "₀": [t: "abaixo de zero"]                   	#  0x2080	(en: 'sub zero', google translation)
+ - "₁": [t: "sub um"]                           	#  0x2081	(en: 'sub one', google translation)
+ - "₂": [t: "sub dois"]                         	#  0x2082	(en: 'sub two', google translation)
+ - "₃": [t: "sub três"]                         	#  0x2083	(en: 'sub three', google translation)
+ - "₄": [t: "sub quatro"]                       	#  0x2084	(en: 'sub four', google translation)
+ - "₅": [t: "sub cinco"]                        	#  0x2085	(en: 'sub five', google translation)
+ - "₆": [t: "sub seis"]                         	#  0x2086	(en: 'sub six', google translation)
+ - "₇": [t: "sub sete"]                         	#  0x2087	(en: 'sub seven', google translation)
+ - "₈": [t: "sub em"]                           	#  0x2088	(en: 'sub eight', google translation)
+ - "₉": [t: "sub nove"]                         	#  0x2089	(en: 'sub nine', google translation)
+ - "₊": [t: "sinal de mais subscrito"]          	#  0x208a	(en: 'subscript plus sign', google translation)
+ - "₋": [t: "sinal de menos subscrito"]         	#  0x208b	(en: 'subscript minus sign', google translation)
+ - "₌": [t: "sinal de igual ao subscrito"]      	#  0x208c	(en: 'subscript equals sign', google translation)
+ - "₍": [t: "subscrito parênteses esquerdo"]    	#  0x208d	(en: 'subscript left parenthesis', google translation)
+ - "₎": [t: "subscrito parênteses direito"]     	#  0x208e	(en: 'subscript right parenthesis', google translation)
+ - "ₐ": [t: "sub a"]                            	#  0x2090	(en: 'sub A', google translation)
+ - "ₑ": [t: "sub e"]                            	#  0x2091	(en: 'sub E', google translation)
+ - "ₒ": [t: "sub o"]                            	#  0x2092	(en: 'sub O', google translation)
+ - "ₓ": [t: "subx"]                             	#  0x2093	(en: 'sub X', google translation)
+ - "ₕ": [t: "sub h"]                            	#  0x2095	(en: 'sub H', google translation)
+ - "ₖ": [t: "sub k"]                            	#  0x2096	(en: 'sub K', google translation)
+ - "ₗ": [t: "sub l"]                            	#  0x2097	(en: 'sub L', google translation)
+ - "ₘ": [t: "sub m"]                            	#  0x2098	(en: 'sub M', google translation)
+ - "ₙ": [t: "sub n"]                            	#  0x2099	(en: 'sub N', google translation)
+ - "ₚ": [t: "sub p"]                            	#  0x209a	(en: 'sub P', google translation)
+ - "ₛ": [t: "sub s"]                            	#  0x209b	(en: 'sub S', google translation)
+ - "ₜ": [t: "sub t"]                            	#  0x209c	(en: 'sub T', google translation)
+ - "₠": [t: "unidades atuais europeias"]        	#  0x20a0	(en: 'european currenty units', google translation)
+ - "₡": [t: "dois pontos"]                      	#  0x20a1	(en: 'colons', google translation)
+ - "₢": [t: "cruzeiro"]                         	#  0x20a2	(google translation)
+ - "₣": [t: "franco"]                           	#  0x20a3	(en: 'franc', google translation)
+ - "₤": [t: "lira"]                             	#  0x20a4	(google translation)
+ - "₥": [t: "moinhos"]                          	#  0x20a5	(en: 'mills', google translation)
+ - "₦": [t: "naira"]                            	#  0x20a6	(google translation)
+ - "₧": [t: "peseta"]                           	#  0x20a7	(google translation)
+ - "₨": [t: "rúpias"]                           	#  0x20a8	(en: 'rupees', google translation)
+ - "₩": [t: "ganho"]                            	#  0x20a9	(en: 'won', google translation)
+ - "₪": [t: "novos siquels"]                    	#  0x20aa	(en: 'new sheqels', google translation)
+ - "₫": [t: "dong"]                             	#  0x20ab	(google translation)
+ - "€": [t: "euros"]                            	#  0x20ac	(google translation)
+ - "₭": [t: "kip"]                              	#  0x20ad	(google translation)
+ - "₮": [t: "tugrik"]                           	#  0x20ae	(google translation)
+ - "₯": [t: "dracma"]                           	#  0x20af	(en: 'drachma', google translation)
+ - "₰": [t: "centavos alemães"]                 	#  0x20b0	(en: 'german pennies', google translation)
+ - "₱": [t: "pesos"]                            	#  0x20b1	(google translation)
+ - "₲": [t: "guaranis"]                         	#  0x20b2	(google translation)
+ - "₳": [t: "austrais"]                         	#  0x20b3	(en: 'australs', google translation)
+ - "₴": [t: "hryvnias"]                         	#  0x20b4	(google translation)
+ - "₵": [t: "cedis"]                            	#  0x20b5	(google translation)
+ - "₶": [t: "livre tournois"]                   	#  0x20b6	(google translation)
+ - "₷": [t: "spesmilos"]                        	#  0x20b7	(google translation)
+ - "₸": [t: "tenges"]                           	#  0x20b8	(google translation)
+ - "₹": [t: "rúpias indianas"]                  	#  0x20b9	(en: 'indian rupees', google translation)
+ - "₺": [t: "liras turcas"]                     	#  0x20ba	(en: 'turkish liras', google translation)
+ - "⃐": [t: "arpão esquerdo acima do enfeite"]  	#  0x20d0	(en: 'left harpoon above embellishment', google translation)
+ - "⃑": [t: "arpão direito acima do enfeite"]   	#  0x20d1	(en: 'right harpoon above embellishment', google translation)
+ - "⃒": [t: "enfeite de sobreposição de linha vertical longa"]	#  0x20d2	(en: 'long vertical line overlay embellishment', google translation)
+ - "⃓": [t: "enfeite de sobreposição de linha vertical curta"]	#  0x20d3	(en: 'short vertical line overlay embellishment', google translation)
+ - "⃔": [t: "seta no sentido anti-horário acima do enfeite"]	#  0x20d4	(en: 'anticlockwise arrow above embellishment', google translation)
+ - "⃕": [t: "seta no sentido horário acima do enfeite"]	#  0x20d5	(en: 'clockwise arrow above embellishment', google translation)
+ - "⃖": [t: "seta para a esquerda acima do enfeite"]	#  0x20d6	(en: 'left arrow above embellishment', google translation)
+ - "⃗": [t: "seta para a direita acima do enfeite"]	#  0x20d7	(en: 'right arrow above embellishment', google translation)
+ - "⃘": [t: "enfeite de sobreposição de anel"]  	#  0x20d8	(en: 'ring overlay embellishment', google translation)
+ - "⃙": [t: "enfeite de sobreposição de anel no sentido horário"]	#  0x20d9	(en: 'clockwise ring overlay embellishment', google translation)
+ - "⃚": [t: "enfeite de sobreposição de anel no sentido anti-horário"]	#  0x20da	(en: 'anticlockwise ring overlay embellishment', google translation)
+ - "⃛": [t: "ponto triplo"]                     	#  0x20db	(en: 'triple dot', google translation)
+ - "⃜": [t: "ponto quádruplo"]                  	#  0x20dc	(en: 'quadruple dot', google translation)
+ - "⃝": [t: "enfeite de círculo envolvente"]    	#  0x20dd	(en: 'enclosing circle embellishment', google translation)
+ - "⃞": [t: "embelezamento quadrado envolvente"]	#  0x20de	(en: 'enclosing square embellishment', google translation)
+ - "⃟": [t: "envolvendo enfeite de diamante"]   	#  0x20df	(en: 'enclosing diamond embellishment', google translation)
+ - "⃠": [t: "embelezamento de barra invertida do círculo envolvente"]	#  0x20e0	(en: 'enclosing circle backslash embellishment', google translation)
+ - "⃡": [t: "seta esquerda direita acima do enfeite"]	#  0x20e1	(en: 'left right arrow above embellishment', google translation)
+ - "⃢": [t: "enfeite de tela envolvente"]       	#  0x20e2	(en: 'enclosing screen embellishment', google translation)
+ - "⃣": [t: "embelezamento de chave maiúscula"] 	#  0x20e3	(en: 'enclosing keycap embellishment', google translation)
+ - "⃤": [t: "envolvendo embelezamento de triângulo apontando para cima"]	#  0x20e4	(en: 'enclosing upward pointing triangle embellishment', google translation)
+ - "⃥": [t: "embelezamento de sobreposição de solidus reverso"]	#  0x20e5	(en: 'reverse solidus overlay embellishment', google translation)
+ - "⃦": [t: "enfeite de traço vertical duplo"]  	#  0x20e6	(en: 'double verticle stroke embellishment', google translation)
+ - "⃧": [t: "enfeite de símbolo de anuidade"]   	#  0x20e7	(en: 'annuity symbol embellishment', google translation)
+ - "⃨": [t: "subponto triplo"]                  	#  0x20e8	(en: 'triple underdot', google translation)
+ - "⃩": [t: "ponte larga acima do embelezamento"]	#  0x20e9	(en: 'wide bridge above embellishment', google translation)
+ - "⃪": [t: "enfeite de sobreposição de seta para a esquerda"]	#  0x20ea	(en: 'left arrow overlay embellishment', google translation)
+ - "⃫": [t: "enfeite de sobreposição de solidus duplo longo"]	#  0x20eb	(en: 'long double solidus overlay embellishment', google translation)
+ - "⃬": [t: "arpão direito com enfeite de farpa"]	#  0x20ec	(en: 'right harpoon with barb down embellishment', google translation)
+ - "⃭": [t: "arpão esquerdo com enfeite de farpa"]	#  0x20ed	(en: 'left harpoon with barb down embellishment', google translation)
+ - "⃮": [t: "seta para a esquerda abaixo do enfeite"]	#  0x20ee	(en: 'left arrow below embellishment', google translation)
+ - "⃯": [t: "seta para a direita abaixo do enfeite"]	#  0x20ef	(en: 'right arrow below embellishment', google translation)
+ - "⃰": [t: "asterisco acima do enfeite"]       	#  0x20f0	(en: 'asterisk above embellishment', google translation)
+ - "℄": [t: "símbolo da linha central"]         	#  0x2104	(en: 'center line symbol', google translation)
+ - "℅": [t: "cuidar de"]                        	#  0x2105	(en: 'care of', google translation)
+ - "℆": [t: "cada um"]                          	#  0x2106	(en: 'cada una', google translation)
+ - "ℇ": [t: "constante de euler"]               	#  0x2107	(en: 'euler's constant', google translation)
+ - "℈": [t: "escrúpulos"]                       	#  0x2108	(en: 'scruples', google translation)
+ - "℉": [t: "graus fahrenheit"]                 	#  0x2109	(en: 'degrees fahrenheit', google translation)
+ - "ℊ": [t: "cursiva g"]                        	#  0x210a	(en: 'script g', google translation)
+ - "ℌℑℨℭ":                                      	#  0x210c, 0x2111, 0x2128, 0x212d
+    - t: "gótica"                              	# 	(en: 'fraktur', google translation)
+    - spell: "translate('.', 'ℌℑℨℭ', 'HIZC')"
+
+ - "ℍℙℾℿ":                                      	#  0x210d, 0x2119, 0x213e, 0x213f
+    - t: "dupla escrita"                          	# 	(en: 'double struck', google translation)
+    - spell: "translate('.', 'ℍℙℾℿ', 'HPΓΠ')" 
+
+ - "ℎ": [t: "constante de planck"]              	#  0x210e	(en: 'planck constant', google translation)
+ - "ℏ": [t: "h barra"]                          	#  0x210f	(en: 'h bar', google translation)
+
+ - "ℐℒ℘ℬℰℱℳ":                                   	#  0x2110, 0x2112, 0x2118, 0x2130, 0x2131, 0x2133
+    - t: "cursiva"                              	# 	(en: 'script', google translation)
+    - spell: "translate('.', 'ℐℒ℘ℬℰℱℳ', 'ILPBEFM')"
+
+ - "℔": [t: "libras"]                           	#  0x2114	(en: 'pounds', google translation)
+ - "№": [t: "número"]                           	#  0x2116	(en: 'number', google translation)
+ - "℥": [t: "onças"]                            	#  0x2125	(en: 'ounces', google translation)
+ - "Ω": [t: "ohms"]                             	#  0x2126	(google translation)
+ - "℧": [t: "mhos"]                             	#  0x2127	(google translation)
+ - "℩": [t: "virou iota"]                       	#  0x2129	(en: 'turned iota', google translation)
+ - "K": [t: "kelvin"]                           	#  0x212a	(google translation)
+ - "Å": [t: "angstroms"]                        	#  0x212b	(google translation)
+ - "ℯ": [t: "cursiva e"]                        	#  0x212f	(en: 'script e', google translation)
+
+   # coalesced some chars that use cap letters
+ - "Ⅎ℺⅁⅂⅃⅄":                                    	#  0x2132, 0x213a, 0x2141, 0x2142, 0x2143, 0x2144
+    - test:
+      - if: "'.' = '℺'"
+        then: [t: "girado"]                     	# 	(en: 'rotated', google translation)
+      - else_if: "'.' = 'Ⅎ'"
+        then: [t: "virou"]                      	# 	(en: 'turned', google translation)
+      - else_if: "'.' = '⅃'"
+        then: [t: "sem serifa invertida"]       	# 	(en: 'reversed sans-serif', google translation)
+        else: [t: "virou sem serifa"]           	# 	(en: 'turned sans-serif', google translation)
+    - spell: "translate('.', 'Ⅎ℺⅁⅂⅃⅄', 'FQGLLY')"
+
+ - "ℴ": [t: "cursiva o"]                        	#  0x2134	(en: 'script o', google translation)
+ - "ℵ": [t: "primeiro cardeal transfinito"]     	#  0x2135	(en: 'first transfinite cardinal', google translation)
+ - "ℶ": [t: "segundo cardeal transfinito"]      	#  0x2136	(en: 'second transfinite cardinal', google translation)
+ - "ℷ": [t: "terceiro cardeal transfinito"]     	#  0x2137	(en: 'third transfinite cardinal', google translation)
+ - "ℸ": [t: "quarto cardeal transfinito"]       	#  0x2138	(en: 'fourth transfinite cardinal', google translation)
+ - "ℼ": [t: "pi em dupla escrita"]                	#  0x213c	(en: 'double struck pi', google translation)
+ - "ℽ": [t: "gama em dupla escrita"]              	#  0x213d	(en: 'double struck gamma', google translation)
+ - "⅀": [t: "somatória n-ária dupla"]           	#  0x2140	(en: 'double struck n-ary summation', google translation)
+ - "⅋": [t: "virou e comercial"]                	#  0x214b	(en: 'turned ampersand', google translation)
+ - "⅌": [t: "por"]                              	#  0x214c	(en: 'per', google translation)
+ - "ⅎ": [t: "virou f"]                          	#  0x214e	(en: 'turned F', google translation)
+ - "¼": [t: "um quarto"]                        	#  0x00bc	(en: 'one quarter', google translation)
+ - "½": [t: "metade"]                           	#  0x00bd	(en: 'one half', google translation)
+ - "¾": [t: "três quartos"]                     	#  0x00be	(en: 'three quarters', google translation)
+ - "⅐": [t: "um sétimo"]                        	#  0x2150	(en: 'one seventh', google translation)
+ - "⅑": [t: "um nono"]                          	#  0x2151	(en: 'one ninth', google translation)
+ - "⅒": [t: "um décimo"]                        	#  0x2152	(en: 'one tenth', google translation)
+ - "⅓": [t: "um terço"]                         	#  0x2153	(en: 'one third', google translation)
+ - "⅔": [t: "dois terços"]                      	#  0x2154	(en: 'two thirds', google translation)
+ - "⅕": [t: "um quinto"]                        	#  0x2155	(en: 'one fifth', google translation)
+ - "⅖": [t: "dois quintos"]                     	#  0x2156	(en: 'two fifths', google translation)
+ - "⅗": [t: "três quintos"]                     	#  0x2157	(en: 'three fifths', google translation)
+ - "⅘": [t: "quatro quintos"]                   	#  0x2158	(en: 'four fifths', google translation)
+ - "⅙": [t: "um sexto"]                         	#  0x2159	(en: 'one sixth', google translation)
+ - "⅚": [t: "cinco sextos"]                     	#  0x215a	(en: 'five sixths', google translation)
+ - "⅛": [t: "um oitavo"]                        	#  0x215b	(en: 'one eighth', google translation)
+ - "⅜": [t: "três oitavos"]                      	#  0x215c	(en: 'three eighths', google translation)
+ - "⅝": [t: "cinco oitavos"]                     	#  0x215d	(en: 'five eighths', google translation)
+ - "⅞": [t: "sete oitavos"]                      	#  0x215e	(en: 'seven eighths', google translation)
+ - "⅟": [t: "um sobre"]                         	#  0x215f	(en: 'one over', google translation)
+ - "Ⅰ": [t: "I"]                                	#  0x2160	(google translation)
+ - "Ⅱ": [t: "i i"]                              	#  0x2161	(en: 'I I', google translation)
+ - "Ⅲ": [t: "i i i"]                           	#  0x2162	(en: 'I I I', google translation)
+ - "Ⅳ": [t: "i vê"]                            	#  0x2163	(en: 'I V', google translation)
+ - "Ⅴ": [t: "V"]                                	#  0x2164	(google translation)
+ - "Ⅵ": [t: "vê i"]                            	#  0x2165	(en: 'V I', google translation)
+ - "Ⅶ": [t: "vê i i"]                          	#  0x2166	(en: 'V I I', google translation)
+ - "Ⅷ": [t: "vê i i i"]                        	#  0x2167	(en: 'V I I I', google translation)
+ - "Ⅸ": [t: "i xis"]                           	#  0x2168	(en: 'I X', google translation)
+ - "Ⅹ": [t: "X"]                                	#  0x2169	(google translation)
+ - "Ⅺ": [t: "xis i"]                           	#  0x216a	(en: 'X I', google translation)
+ - "Ⅻ": [t: "xis i i"]                         	#  0x216b	(en: 'X I I', google translation)
+ - "Ⅼ": [t: "L"]                                	#  0x216c	(google translation)
+ - "Ⅽ": [t: "C"]                                	#  0x216d	(google translation)
+ - "Ⅾ": [t: "D"]                                	#  0x216e	(google translation)
+ - "Ⅿ": [t: "M"]                                	#  0x216f	(google translation)
+ - "ⅰ": [t: "I"]                                	#  0x2170	(google translation)
+ - "ⅱ": [t: "i i"]                              	#  0x2171	(en: 'I I', google translation)
+ - "ⅲ": [t: "i i i"]                           	#  0x2172	(en: 'I I I', google translation)
+ - "ⅳ": [t: "i vê"]                            	#  0x2173	(en: 'I V', google translation)
+ - "ⅴ": [t: "V"]                                	#  0x2174	(google translation)
+ - "ⅵ": [t: "vê i"]                            	#  0x2175	(en: 'V I', google translation)
+ - "ⅶ": [t: "vê i i"]                          	#  0x2176	(en: 'V I I', google translation)
+ - "ⅷ": [t: "vê i i i"]                        	#  0x2177	(en: 'V I I I', google translation)
+ - "ⅸ": [t: "i xis"]                           	#  0x2178	(en: 'I X', google translation)
+ - "ⅹ": [t: "X"]                                	#  0x2179	(google translation)
+ - "ⅺ": [t: "xis i"]                           	#  0x217a	(en: 'X I', google translation)
+ - "ⅻ": [t: "xis i i"]                         	#  0x217b	(en: 'X I I', google translation)
+ - "ⅼ": [t: "L"]                                	#  0x217c	(google translation)
+ - "ⅽ": [t: "C"]                                	#  0x217d	(google translation)
+ - "ⅾ": [t: "D"]                                	#  0x217e	(google translation)
+ - "ⅿ": [t: "M"]                                	#  0x217f	(google translation)
+ - "↉": [t: "zero terços"]                      	#  0x2189	(en: 'zero thirds', google translation)
+ - "↔": [t: "seta para a esquerda e para a direita"]	#  0x2194	(en: 'left right arrow', google translation)
+ - "↕": [t: "seta para cima e para baixo"]      	#  0x2195	(en: 'up down arrow', google translation)
+ - "↖": [t: "seta noroeste"]                    	#  0x2196	(en: 'north west arrow', google translation)
+ - "↗":                                         	#  0x2197
+    - test:
+        if: "ancestor::*[2][self::m:limit]"
+        then: [t: "abordagens por baixo"]       	# 	(en: 'approaches from below', google translation)
+        else: [t: "seta nordeste"]              	# 	(en: 'north east arrow', google translation)
+
+ - "↘":                                         	#  0x2198
+    - test:
+        if: "ancestor::*[2][self::m:limit]"
+        then: [t: "abordagens de cima"]         	# 	(en: 'approaches from above', google translation)
+        else: [t: "seta sudeste"]               	# 	(en: 'south east arrow', google translation)
+
+ - "↙": [t: "seta sudoeste"]                    	#  0x2199	(en: 'south west arrow', google translation)
+ - "↚": [t: "seta para a esquerda com traço"]   	#  0x219a	(en: 'left arrow with stroke', google translation)
+ - "↛": [t: "seta para a direita com traço"]    	#  0x219b	(en: 'right arrow with stroke', google translation)
+ - "↜": [t: "seta de onda esquerda"]            	#  0x219c	(en: 'left wave arrow', google translation)
+ - "↝": [t: "seta de onda direita"]             	#  0x219d	(en: 'right wave arrow', google translation)
+ - "↞": [t: "seta de duas pontas para a esquerda"]	#  0x219e	(en: 'left two headed arrow', google translation)
+ - "↟": [t: "seta de duas pontas para cima"]    	#  0x219f	(en: 'up two headed arrow', google translation)
+ - "↠": [t: "seta de duas pontas para a direita"]	#  0x21a0	(en: 'right two headed arrow', google translation)
+ - "↡": [t: "seta para baixo de duas pontas"]   	#  0x21a1	(en: 'down two headed arrow', google translation)
+ - "↢": [t: "seta para a esquerda com cauda"]   	#  0x21a2	(en: 'left arrow with tail', google translation)
+ - "↣": [t: "seta para a direita com cauda"]    	#  0x21a3	(en: 'right arrow with tail', google translation)
+ - "↤": [t: "seta para a esquerda da barra"]    	#  0x21a4	(en: 'left arrow from bar', google translation)
+ - "↥": [t: "seta para cima da barra"]          	#  0x21a5	(en: 'up arrow from bar', google translation)
+ - "↦": [t: "seta para a direita da barra"]     	#  0x21a6	(en: 'right arrow from bar', google translation)
+ - "↧": [t: "seta para baixo da barra"]         	#  0x21a7	(en: 'down arrow from bar', google translation)
+ - "↨": [t: "seta para cima e para baixo com base"]	#  0x21a8	(en: 'up down arrow with base', google translation)
+ - "↩": [t: "seta para a esquerda com gancho"]  	#  0x21a9	(en: 'left arrow with hook', google translation)
+ - "↪": [t: "seta para a direita com gancho"]   	#  0x21aa	(en: 'right arrow with hook', google translation)
+ - "↫": [t: "seta para a esquerda com loop"]    	#  0x21ab	(en: 'left arrow with loop', google translation)
+ - "↬": [t: "seta para a direita com loop"]     	#  0x21ac	(en: 'right arrow with loop', google translation)
+ - "↭": [t: "seta de onda esquerda direita"]    	#  0x21ad	(en: 'left right wave arrow', google translation)
+ - "↮": [t: "seta esquerda para a direita com traço"]	#  0x21ae	(en: 'left right arrow with stroke', google translation)
+ - "↯": [t: "seta para baixo em zigue-zague"]   	#  0x21af	(en: 'down zigzag arrow', google translation)
+ - "↰": [t: "seta para cima com ponta para a esquerda"]	#  0x21b0	(en: 'up arrow with tip left', google translation)
+ - "↱": [t: "seta para cima com ponta para a direita"]	#  0x21b1	(en: 'up arrow with tip right', google translation)
+ - "↲": [t: "seta para baixo com ponta para a esquerda"]	#  0x21b2	(en: 'down arrow with tip left', google translation)
+ - "↳": [t: "seta para baixo com ponta para a direita"]	#  0x21b3	(en: 'down arrow with tip right', google translation)
+ - "↴": [t: "seta para a direita com canto para baixo"]	#  0x21b4	(en: 'right arrow with corner down', google translation)
+ - "↵": [t: "seta para baixo com canto esquerdo"]	#  0x21b5	(en: 'down arrow with corner left', google translation)
+ - "↶": [t: "seta semicírculo superior no sentido anti-horário"]	#  0x21b6	(en: 'anticlockwise top semicircle arrow', google translation)
+ - "↷": [t: "seta semicírculo superior no sentido horário"]	#  0x21b7	(en: 'clockwise top semicircle arrow', google translation)
+ - "↸": [t: "seta noroeste para barra longa"]   	#  0x21b8	(en: 'north west arrow to long bar', google translation)
+ - "↹": [t: "seta para a esquerda para a barra sobre a seta para a direita para a barra"]	#  0x21b9	(en: 'left arrow to bar over right arrow to bar', google translation)
+ - "↺": [t: "seta de círculo aberto no sentido anti-horário"]	#  0x21ba	(en: 'anticlockwise open circle arrow', google translation)
+ - "↻": [t: "seta de círculo aberto no sentido horário"]	#  0x21bb	(en: 'clockwise open circle arrow', google translation)
+ - "↼": [t: "deixou o arpão levantado"]         	#  0x21bc	(en: 'left harpoon up', google translation)
+ - "↽": [t: "deixou o arpão abaixado"]          	#  0x21bd	(en: 'left harpoon down', google translation)
+ - "↾": [t: "arpão certo"]                      	#  0x21be	(en: 'up harpoon right', google translation)
+ - "↿": [t: "arpão à esquerda"]                 	#  0x21bf	(en: 'up harpoon left', google translation)
+ - "⇀": [t: "arpão certo para cima"]            	#  0x21c0	(en: 'right harpoon up', google translation)
+ - "⇁": [t: "arpão direito para baixo"]         	#  0x21c1	(en: 'right harpoon down', google translation)
+ - "⇂": [t: "para baixo arpão para a direita"]  	#  0x21c2	(en: 'down harpoon right', google translation)
+ - "⇃": [t: "para baixo arpão para a esquerda"] 	#  0x21c3	(en: 'down harpoon left', google translation)
+ - "⇄": [t: "seta para a direita sobre a seta para a esquerda"]	#  0x21c4	(en: 'right arrow over left arrow', google translation)
+ - "⇅": [t: "seta para cima à esquerda da seta para baixo"]	#  0x21c5	(en: 'up arrow left of down arrow', google translation)
+ - "⇆": [t: "seta para a esquerda sobre a seta para a direita"]	#  0x21c6	(en: 'left arrow over right arrow', google translation)
+ - "⇇": [t: "setas emparelhadas à esquerda"]    	#  0x21c7	(en: 'left paired arrows', google translation)
+ - "⇈": [t: "setas emparelhadas"]               	#  0x21c8	(en: 'up paired arrows', google translation)
+ - "⇉": [t: "setas emparelhadas à direita"]     	#  0x21c9	(en: 'right paired arrows', google translation)
+ - "⇊": [t: "setas emparelhadas para baixo"]    	#  0x21ca	(en: 'down paired arrows', google translation)
+ - "⇋": [t: "arpão esquerdo sobre o arpão direito"]	#  0x21cb	(en: 'left harpoon over right harpoon', google translation)
+ - "⇌": [t: "arpão direito sobre o arpão esquerdo"]	#  0x21cc	(en: 'right harpoon over left harpoon', google translation)
+ - "⇍": [t: "seta dupla para a esquerda com traço"]	#  0x21cd	(en: 'left double arrow with stroke', google translation)
+ - "⇎": [t: "seta dupla esquerda direita com traço"]	#  0x21ce	(en: 'left right double arrow with stroke', google translation)
+ - "⇏": [t: "seta dupla para a direita com traço"]	#  0x21cf	(en: 'right double arrow with stroke', google translation)
+ - "⇐": [t: "seta dupla para a esquerda"]       	#  0x21d0	(en: 'left double arrow', google translation)
+ - "⇑": [t: "seta dupla para cima"]             	#  0x21d1	(en: 'up double arrow', google translation)
+ - "⇓": [t: "seta dupla para baixo"]            	#  0x21d3	(en: 'down double arrow', google translation)
+ - "⇔": [t: "se e somente se"]                  	#  0x21d4	(en: 'if and only if', google translation)
+ - "⇕": [t: "seta dupla para cima e para baixo"]	#  0x21d5	(en: 'up down double arrow', google translation)
+ - "⇖": [t: "seta dupla noroeste"]              	#  0x21d6	(en: 'north west double arrow', google translation)
+ - "⇗": [t: "seta dupla nordeste"]              	#  0x21d7	(en: 'north east double arrow', google translation)
+ - "⇘": [t: "seta dupla sudeste"]               	#  0x21d8	(en: 'south east double arrow', google translation)
+ - "⇙": [t: "seta dupla sudoeste"]              	#  0x21d9	(en: 'south west double arrow', google translation)
+ - "⇚": [t: "seta tripla para a esquerda"]      	#  0x21da	(en: 'left triple arrow', google translation)
+ - "⇛": [t: "seta tripla para a direita"]       	#  0x21db	(en: 'right triple arrow', google translation)
+ - "⇜": [t: "seta ondulada para a esquerda"]    	#  0x21dc	(en: 'left squiggle arrow', google translation)
+ - "⇝": [t: "seta ondulada para a direita"]     	#  0x21dd	(en: 'right squiggle arrow', google translation)
+ - "⇞": [t: "seta para cima com traço duplo"]   	#  0x21de	(en: 'up arrow with double stroke', google translation)
+ - "⇟": [t: "seta para baixo com traço duplo"]  	#  0x21df	(en: 'down arrow with double stroke', google translation)
+ - "⇠": [t: "seta tracejada para a esquerda"]   	#  0x21e0	(en: 'left dashed arrow', google translation)
+ - "⇡": [t: "seta tracejada para cima"]         	#  0x21e1	(en: 'up dashed arrow', google translation)
+ - "⇢": [t: "seta tracejada para a direita"]    	#  0x21e2	(en: 'right dashed arrow', google translation)
+ - "⇣": [t: "seta tracejada para baixo"]        	#  0x21e3	(en: 'down dashed arrow', google translation)
+ - "⇤": [t: "seta para a esquerda para a barra"]	#  0x21e4	(en: 'left arrow to bar', google translation)
+ - "⇥": [t: "seta para a direita para a barra"] 	#  0x21e5	(en: 'right arrow to bar', google translation)
+ - "⇦": [t: "seta branca para a esquerda"]      	#  0x21e6	(en: 'left white arrow', google translation)
+ - "⇧": [t: "seta branca para cima"]            	#  0x21e7	(en: 'up white arrow', google translation)
+ - "⇨": [t: "seta branca para a direita"]       	#  0x21e8	(en: 'right white arrow', google translation)
+ - "⇩": [t: "seta branca para baixo"]           	#  0x21e9	(en: 'down white arrow', google translation)
+ - "⇪": [t: "seta branca para cima da barra"]   	#  0x21ea	(en: 'up white arrow from bar', google translation)
+ - "⇫": [t: "seta branca no pedestal"]          	#  0x21eb	(en: 'up white arrow on pedestal', google translation)
+ - "⇬": [t: "seta branca no pedestal com barra horizontal"]	#  0x21ec	(en: 'up white arrow on pedestal with horizontal bar', google translation)
+ - "⇭": [t: "seta branca no pedestal com barra vertical"]	#  0x21ed	(en: 'up white arrow on pedestal with vertical bar', google translation)
+ - "⇮": [t: "seta dupla branca para cima"]      	#  0x21ee	(en: 'up white double arrow', google translation)
+ - "⇯": [t: "seta dupla branca no pedestal"]    	#  0x21ef	(en: 'up white double arrow on pedestal', google translation)
+ - "⇰": [t: "seta branca para a direita da parede"]	#  0x21f0	(en: 'right white arrow from wall', google translation)
+ - "⇱": [t: "seta noroeste para canto"]         	#  0x21f1	(en: 'north west arrow to corner', google translation)
+ - "⇲": [t: "seta sudeste para canto"]          	#  0x21f2	(en: 'south east arrow to corner', google translation)
+ - "⇳": [t: "seta branca para cima e para baixo"]	#  0x21f3	(en: 'up down white arrow', google translation)
+ - "⇴": [t: "seta para a direita com um pequeno círculo"]	#  0x21f4	(en: 'right arrow with small circle', google translation)
+ - "⇵": [t: "seta para baixo à esquerda da seta para cima"]	#  0x21f5	(en: 'down arrow left of up arrow', google translation)
+ - "⇶": [t: "três setas para a direita"]        	#  0x21f6	(en: 'three right arrows', google translation)
+ - "⇷": [t: "seta para a esquerda com traço vertical"]	#  0x21f7	(en: 'left arrow with vertical stroke', google translation)
+ - "⇸": [t: "seta para a direita com traço vertical"]	#  0x21f8	(en: 'right arrow with vertical stroke', google translation)
+ - "⇹": [t: "seta esquerda para a direita com traço vertical"]	#  0x21f9	(en: 'left right arrow with vertical stroke', google translation)
+ - "⇺": [t: "seta para a esquerda com traço vertical duplo"]	#  0x21fa	(en: 'left arrow with double vertical stroke', google translation)
+ - "⇻": [t: "seta para a direita com traço vertical duplo"]	#  0x21fb	(en: 'right arrow with double vertical stroke', google translation)
+ - "⇼": [t: "seta esquerda para a direita com traço vertical duplo"]	#  0x21fc	(en: 'left right arrow with double vertical stroke', google translation)
+ - "⇽": [t: "seta com cabeça aberta para a esquerda"]	#  0x21fd	(en: 'left open headed arrow', google translation)
+ - "⇾": [t: "seta com cabeça aberta para a direita"]	#  0x21fe	(en: 'right open headed arrow', google translation)
+ - "⇿": [t: "seta de cabeça aberta esquerda direita"]	#  0x21ff	(en: 'left right open headed arrow', google translation)
+ - "∀": [t: "para todos"]                       	#  0x2200	(en: 'for all', google translation)
+ - "∁":                                         	#  0x2201
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [ot: "o"]                        	# 	(en: 'the', google translation)
+     - t: "complemento de"                      	# 	(en: 'complement of', google translation)
+ - "∃": [t: "existe"]                           	#  0x2203	(en: 'there exists', google translation)
+ - "∄": [t: "não existe"]                       	#  0x2204	(en: 'there does not exist', google translation)
+ - "∅": [t: "conjunto vazio"]                   	#  0x2205	(en: 'empty set', google translation)
+ - "∇": [t: "nabla"]                            	#  0x2207	(google translation)
+ - "∋": [t: "contém o membro"]                  	#  0x220b	(en: 'contains the member', google translation)
+ - "∌": [t: "não contém o membro"]              	#  0x220c	(en: 'does not contain the member', google translation)
+ - "∍": [t: "contém o membro"]                  	#  0x220d	(en: 'contains the member', google translation)
+ - "∎": [t: "fim da prova"]                     	#  0x220e	(en: 'end of proof', google translation)
+ - "∏": [t: "produto"]                          	#  0x220f	(en: 'product', google translation)
+ - "∑": [t: "soma"]                             	#  0x2211	(en: 'sum', google translation)
+ - "−": [t: "menos"]                            	#  0x2212	(en: 'minus', google translation)
+ - "∓": [t: "menos ou mais"]                    	#  0x2213	(en: 'minus or plus', google translation)
+ - "∔": [t: "ponto mais"]                       	#  0x2214	(en: 'dot plus', google translation)
+ - "∕": [t: "dividido por"]                     	#  0x2215	(en: 'divided by', google translation)
+ - "∖": [t: "definir menos"]                    	#  0x2216	(en: 'set minus', google translation)
+ - "∗": [t: "vezes"]                            	#  0x2217	(en: 'times', google translation)
+ - "∘": [t: "composto com"]                     	#  0x2218	(en: 'composed with', google translation)
+ - "∙":                                         	#  0x2219
+    - test: 
+        if: "@data-chem-formula-op"
+        then: [t: "ponto"]                      	# 	(en: 'dot', google translation)
+        else: [t: "vezes"]                      	# 	(en: 'times', google translation)
+
+ - "∛":                                         	#  0x221b
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [ot: "o"]                        	# 	(en: 'the', google translation)
+     - t: "raiz cúbica de"                      	# 	(en: 'cube root of', google translation)
+ - "∜":                                         	#  0x221c
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [ot: "o"]                        	# 	(en: 'the', google translation)
+     - t: "quarta raiz de"                      	# 	(en: 'fourth root of', google translation)
+ - "∞": [t: "infinidade"]                       	#  0x221e	(en: 'infinity', google translation)
+ - "∟": [t: "ângulo reto"]                      	#  0x221f	(en: 'right angle', google translation)
+ - "∠": [t: "ângulo"]                           	#  0x2220	(en: 'angle', google translation)
+ - "∡": [t: "ângulo medido"]                    	#  0x2221	(en: 'measured angle', google translation)
+ - "∢": [t: "ângulo esférico"]                  	#  0x2222	(en: 'spherical angle', google translation)
+ - "∣": [t: "divide"]                           	#  0x2223	(en: 'divides', google translation)
+ - "∤": [t: "não divide"]                       	#  0x2224	(en: 'does not divide', google translation)
+ - "∧": [t: "e"]                                	#  0x2227	(en: 'and', google translation)
+ - "∨": [t: "ou"]                               	#  0x2228	(en: 'or', google translation)
+ - "∩": [t: "interseção"]                       	#  0x2229	(en: 'intersection', google translation)
+ - "∪": [t: "união"]                            	#  0x222a	(en: 'union', google translation)
+ - "∫": [t: "integrante"]                       	#  0x222b	(en: 'integral', google translation)
+ - "∬": [t: "integral dupla"]                   	#  0x222c	(en: 'double integral', google translation)
+ - "∭": [t: "integral tripla"]                  	#  0x222d	(en: 'triple integral', google translation)
+ - "∮": [t: "integral de contorno"]             	#  0x222e	(en: 'contour integral', google translation)
+ - "∯": [t: "integral de superfície"]           	#  0x222f	(en: 'surface integral', google translation)
+ - "∰": [t: "integral de volume"]               	#  0x2230	(en: 'volume integral', google translation)
+ - "∱": [t: "integral no sentido horário"]      	#  0x2231	(en: 'clockwise integral', google translation)
+ - "∲": [t: "integral de contorno no sentido horário"]	#  0x2232	(en: 'clockwise contour integral', google translation)
+ - "∳": [t: "integral de contorno no sentido anti-horário"]	#  0x2233	(en: 'anticlockwise contour integral', google translation)
+ - "∴": [t: "portanto"]                         	#  0x2234	(en: 'therefore', google translation)
+ - "∵": [t: "porque"]                           	#  0x2235	(en: 'because', google translation)
+ - "∷": [t: "como"]                             	#  0x2237	(en: 'as', google translation)
+ - "∸": [t: "ponto menos"]                      	#  0x2238	(en: 'dot minus', google translation)
+ - "∹": [t: "tem excesso em comparação com"]    	#  0x2239	(en: 'has excess compared to', google translation)
+ - "∺":                                         	#  0x223a
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [t: "é"]                         	# 	(en: 'is', google translation)
+     - t: "geometricamente proporcional a"      	# 	(en: 'geometrically proportional to', google translation)
+ - "∻":                                         	#  0x223b
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [t: "é"]                         	# 	(en: 'is', google translation)
+     - t: "homotético para"                     	# 	(en: 'homothetic to', google translation)
+ - "∼": [t: "varia com"]                        	#  0x223c	(en: 'varies with', google translation)
+ - "∽": [t: "til invertido"]                    	#  0x223d	(en: 'reversed tilde', google translation)
+ - "∿": [t: "onda senoidal"]                    	#  0x223f	(en: 'sine wave', google translation)
+ - "≀": [t: "produto de guirlanda"]             	#  0x2240	(en: 'wreath product', google translation)
+ - "≁": [t: "não til"]                          	#  0x2241	(en: 'not tilde', google translation)
+ - "≂": [t: "menos til"]                        	#  0x2242	(en: 'minus tilde', google translation)
+ - "≃":                                         	#  0x2243
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [t: "é"]                         	# 	(en: 'is', google translation)
+     - t: "assintoticamente igual a"            	# 	(en: 'asymptotically equal to', google translation)
+ - "≄":                                         	#  0x2244
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [t: "é"]                         	# 	(en: 'is', google translation)
+     - t: "não assintoticamente igual a"        	# 	(en: 'not asymptotically equal to', google translation)
+ - "≅":                                         	#  0x2245
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [t: "é"]                         	# 	(en: 'is', google translation)
+     - t: "congruente com"                      	# 	(en: 'congruent to', google translation)
+ - "≆":                                         	#  0x2246
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [t: "é"]                         	# 	(en: 'is', google translation)
+     - t: "aproximadamente, mas não realmente igual a"	# 	(en: 'approximately but not actually equal to', google translation)
+ - "≇":                                         	#  0x2247
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [t: "é"]                         	# 	(en: 'is', google translation)
+     - t: "não congruente com"                  	# 	(en: 'not congruent to', google translation)
+ - "≈":                                         	#  0x2248
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [t: "é"]                         	# 	(en: 'is', google translation)
+     - t: "aproximadamente igual a"             	# 	(en: 'approximately equal to', google translation)
+ - "≉":                                         	#  0x2249
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [t: "é"]                         	# 	(en: 'is', google translation)
+     - t: "não é aproximadamente igual a"       	# 	(en: 'not approximately equal to', google translation)
+ - "≊":                                         	#  0x224a
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [t: "é"]                         	# 	(en: 'is', google translation)
+     - t: "aproximadamente igual ou igual a"    	# 	(en: 'approximately equal or equal to', google translation)
+ - "≋": [t: "til triplo"]                       	#  0x224b	(en: 'triple tilde', google translation)
+ - "≌": [t: "são todos iguais"]                 	#  0x224c	(en: 'are all equal to', google translation)
+ - "≍":                                         	#  0x224d
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [t: "é"]                         	# 	(en: 'is', google translation)
+     - t: "equivalente a"                       	# 	(en: 'equivalent to', google translation)
+ - "≎":                                         	#  0x224e
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [t: "é"]                         	# 	(en: 'is', google translation)
+     - t: "geometricamente equivalente a"       	# 	(en: 'geometrically equivalent to', google translation)
+ - "≏":                                         	#  0x224f
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [ot: "o"]                        	# 	(en: 'the', google translation)
+     - t: "diferença entre"                     	# 	(en: 'difference between', google translation)
+ - "≐": [t: "se aproxima do limite"]            	#  0x2250	(en: 'approaches the limit', google translation)
+ - "≑":                                         	#  0x2251
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [t: "é"]                         	# 	(en: 'is', google translation)
+     - t: "geometricamente igual a"             	# 	(en: 'geometrically equal to', google translation)
+ - "≒":                                         	#  0x2252
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [t: "é"]                         	# 	(en: 'is', google translation)
+     - t: "aproximadamente igual ou a imagem de"	# 	(en: 'approximately equal to or the image of', google translation)
+ - "≓":                                         	#  0x2253
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [t: "é o"]                       	# 	(en: 'is the', google translation)
+     - t: "imagem de ou aproximadamente igual a"	# 	(en: 'image of or approximately equal to', google translation)
+ - "≔": [t: "dois pontos é igual"]              	#  0x2254	(en: 'colon equals', google translation)
+ - "≕": [t: "é igual a dois pontos"]            	#  0x2255	(en: 'equals colon', google translation)
+ - "≖": [t: "anel igual a"]                     	#  0x2256	(en: 'ring in equal to', google translation)
+ - "≗":                                         	#  0x2257
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [t: "é"]                         	# 	(en: 'is', google translation)
+     - t: "aproximadamente igual a"             	# 	(en: 'approximately equal to', google translation)
+ - "≘": [t: "corresponde a"]                    	#  0x2258	(en: 'corresponds to', google translation)
+ - "≙": [t: "estimativas"]                      	#  0x2259	(en: 'estimates', google translation)
+ - "≚":                                         	#  0x225a
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [t: "é"]                         	# 	(en: 'is', google translation)
+     - t: "equiângulo a"                        	# 	(en: 'equiangular to', google translation)
+ - "≛": [t: "estrela é igual"]                  	#  0x225b	(en: 'star equals', google translation)
+ - "≜": [t: "delta é igual"]                    	#  0x225c	(en: 'delta equals', google translation)
+ - "≝": [t: "é definido como sendo"]            	#  0x225d	(en: 'is defined to be', google translation)
+ - "≞":                                         	#  0x225e
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [t: "é"]                         	# 	(en: 'is', google translation)
+     - t: "medido por"                          	# 	(en: 'measured by', google translation)
+ - "≟": [t: "tem um relacionamento desconhecido com"]	#  0x225f	(en: 'has an unknown relationship with', google translation)
+ - "≢":                                         	#  0x2262
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [t: "é"]                         	# 	(en: 'is', google translation)
+     - t: "não é idêntico a"                    	# 	(en: 'not identical to', google translation)
+ - "≣":                                         	#  0x2263
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [t: "é"]                         	# 	(en: 'is', google translation)
+     - t: "estritamente equivalente a"          	# 	(en: 'strictly equivalent to', google translation)
+ - "≦": [t: "menos do que igual a"]             	#  0x2266	(en: 'less than over equal to', google translation)
+ - "≧": [t: "maior que sobre igual a"]          	#  0x2267	(en: 'greater than over equal to', google translation)
+ - "≨":                                         	#  0x2268
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [t: "é"]                         	# 	(en: 'is', google translation)
+     - t: "menor que, mas não igual a"          	# 	(en: 'less than but not equal to', google translation)
+ - "≩":                                         	#  0x2269
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [t: "é"]                         	# 	(en: 'is', google translation)
+     - t: "maior que, mas não igual a"          	# 	(en: 'greater than but not equal to', google translation)
+ - "≪":                                         	#  0x226a
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [t: "é"]                         	# 	(en: 'is', google translation)
+     - t: "muito menos do que"                  	# 	(en: 'much less than', google translation)
+ - "≫":                                         	#  0x226b
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [t: "é"]                         	# 	(en: 'is', google translation)
+     - t: "muito maior que"                     	# 	(en: 'much greater than', google translation)
+ - "≬":                                         	#  0x226c
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [t: "é"]                         	# 	(en: 'is', google translation)
+     - t: "entre"                               	# 	(en: 'between', google translation)
+ - "≭":                                         	#  0x226d
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [t: "é"]                         	# 	(en: 'is', google translation)
+     - t: "não é equivalente a"                 	# 	(en: 'not equivalent to', google translation)
+ - "≮":                                         	#  0x226e
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [t: "é"]                         	# 	(en: 'is', google translation)
+     - t: "não menos que"                       	# 	(en: 'not less than', google translation)
+ - "≯":                                         	#  0x226f
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [t: "é"]                         	# 	(en: 'is', google translation)
+     - t: "não maior que"                       	# 	(en: 'not greater than', google translation)
+ - "≰":                                         	#  0x2270
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [t: "é"]                         	# 	(en: 'is', google translation)
+     - t: "nem menor nem igual a"               	# 	(en: 'neither less than nor equal to', google translation)
+ - "≱":                                         	#  0x2271
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [t: "é"]                         	# 	(en: 'is', google translation)
+     - t: "nem maior nem igual a"               	# 	(en: 'neither greater than nor equal to', google translation)
+ - "≲":                                         	#  0x2272
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [t: "é"]                         	# 	(en: 'is', google translation)
+     - t: "menor ou equivalente a"              	# 	(en: 'less than or equivalent to', google translation)
+ - "≳":                                         	#  0x2273
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [t: "é"]                         	# 	(en: 'is', google translation)
+     - t: "maior ou equivalente a"              	# 	(en: 'greater than or equivalent to', google translation)
+ - "≴":                                         	#  0x2274
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [t: "é"]                         	# 	(en: 'is', google translation)
+     - t: "nem menos que nem equivalente a"     	# 	(en: 'neither less than nor equivalent to', google translation)
+ - "≵":                                         	#  0x2275
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [t: "é"]                         	# 	(en: 'is', google translation)
+     - t: "nem maior nem equivalente a"         	# 	(en: 'neither greater than nor equivalent to', google translation)
+ - "≶":                                         	#  0x2276
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [t: "é"]                         	# 	(en: 'is', google translation)
+     - t: "menor ou maior que"                  	# 	(en: 'less than or greater than', google translation)
+ - "≷":                                         	#  0x2277
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [t: "é"]                         	# 	(en: 'is', google translation)
+     - t: "maior ou menor que"                  	# 	(en: 'greater than or less than', google translation)
+ - "≸":                                         	#  0x2278
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [t: "é"]                         	# 	(en: 'is', google translation)
+     - t: "nem menor que nem maior que"         	# 	(en: 'neither less than nor greater than', google translation)
+ - "≹":                                         	#  0x2279
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [t: "é"]                         	# 	(en: 'is', google translation)
+     - t: "nem maior que nem menor que"         	# 	(en: 'neither greater than nor less than', google translation)
+ - "≺": [t: "precede"]                          	#  0x227a	(en: 'precedes', google translation)
+ - "≻": [t: "consegue"]                         	#  0x227b	(en: 'succeeds', google translation)
+ - "≼": [t: "precede ou é igual a"]             	#  0x227c	(en: 'precedes or is equal to', google translation)
+ - "≽": [t: "é bem sucedido ou é igual a"]      	#  0x227d	(en: 'succeeds or is equal to', google translation)
+ - "≾": [t: "precede ou é equivalente a"]       	#  0x227e	(en: 'precedes or is equivalent to', google translation)
+ - "≿": [t: "tem sucesso ou é equivalente a"]   	#  0x227f	(en: 'succeeds or is equivalent to', google translation)
+ - "⊀": [t: "não precede"]                      	#  0x2280	(en: 'does not precede', google translation)
+ - "⊁": [t: "não tem sucesso"]                  	#  0x2281	(en: 'does not succeed', google translation)
+ - "⊈":                                         	#  0x2288
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [t: "é"]                         	# 	(en: 'is', google translation)
+     - t: "nem um subconjunto nem igual a"      	# 	(en: 'neither a subset of nor equal to', google translation)
+ - "⊉":                                         	#  0x2289
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [t: "é"]                         	# 	(en: 'is', google translation)
+     - t: "nem um superconjunto nem igual a"    	# 	(en: 'neither a superset of nor equal to', google translation)
+ - "⊊": [t: "subconjunto de com diferente de"]  	#  0x228a	(en: 'subset of with not equal to', google translation)
+ - "⊋": [t: "superconjunto de com diferente de"]	#  0x228b	(en: 'superset of with not equal to', google translation)
+ - "⊌": [t: "multiconjunto"]                    	#  0x228c	(en: 'multiset', google translation)
+ - "⊍": [t: "multiplicação multiconjunto"]      	#  0x228d	(en: 'multiset multiplication', google translation)
+ - "⊎": [t: "união multiconjunto"]              	#  0x228e	(en: 'multiset union', google translation)
+ - "⊏": [t: "imagem quadrada de"]               	#  0x228f	(en: 'square image of', google translation)
+ - "⊐": [t: "quadrado original de"]             	#  0x2290	(en: 'square original of', google translation)
+ - "⊑": [t: "imagem quadrada de ou igual a"]    	#  0x2291	(en: 'square image of or equal to', google translation)
+ - "⊒": [t: "quadrado original igual ou igual a"]	#  0x2292	(en: 'square original of or equal to', google translation)
+ - "⊓": [t: "quadrado maiúsculo"]               	#  0x2293	(en: 'square cap', google translation)
+ - "⊔": [t: "xícara quadrada"]                  	#  0x2294	(en: 'square cup', google translation)
+ - "⊕": [t: "circulado mais"]                   	#  0x2295	(en: 'circled plus', google translation)
+ - "⊖": [t: "circulado menos"]                  	#  0x2296	(en: 'circled minus', google translation)
+ - "⊗": [t: "tempos circulados"]                	#  0x2297	(en: 'circled times', google translation)
+ - "⊘": [t: "barra circulada"]                  	#  0x2298	(en: 'circled slash', google translation)
+ - "⊙": [t: "operador de ponto circulado"]      	#  0x2299	(en: 'circled dot operator', google translation)
+ - "⊚": [t: "anel circulado"]                   	#  0x229a	(en: 'circled ring', google translation)
+ - "⊛": [t: "asterisco circulado"]              	#  0x229b	(en: 'circled asterisk', google translation)
+ - "⊜": [t: "circulados iguais"]                	#  0x229c	(en: 'circled equals', google translation)
+ - "⊝": [t: "traço circulado"]                  	#  0x229d	(en: 'circled dash', google translation)
+ - "⊞": [t: "quadrado mais"]                    	#  0x229e	(en: 'squared plus', google translation)
+ - "⊟": [t: "ao quadrado menos"]                	#  0x229f	(en: 'squared minus', google translation)
+ - "⊠": [t: "vezes ao quadrado"]                	#  0x22a0	(en: 'squared times', google translation)
+ - "⊡": [t: "operador de ponto quadrado"]       	#  0x22a1	(en: 'squared dot operator', google translation)
+ - "⊢": [t: "prova"]                            	#  0x22a2	(en: 'proves', google translation)
+ - "⊣": [t: "não rende"]                        	#  0x22a3	(en: 'does not yield', google translation)
+ - "⊤": [t: "principal"]                        	#  0x22a4	(en: 'top', google translation)
+ - "⊦": [t: "reduz a"]                          	#  0x22a6	(en: 'reduces to', google translation)
+ - "⊧": [t: "modelos"]                          	#  0x22a7	(en: 'models', google translation)
+ - "⊨":                                         	#  0x22a8
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [t: "é"]                         	# 	(en: 'is', google translation)
+     - t: "verdadeiro"                          	# 	(en: 'true', google translation)
+ - "⊩": [t: "forças"]                           	#  0x22a9	(en: 'forces', google translation)
+ - "⊪": [t: "catraca direita com barra vertical tripla"]	#  0x22aa	(en: 'triple vertical bar right turnstile', google translation)
+ - "⊫": [t: "catraca dupla direita com barra vertical dupla"]	#  0x22ab	(en: 'double vertical bar double right turnstile', google translation)
+ - "⊬": [t: "não prova"]                        	#  0x22ac	(en: 'does not prove', google translation)
+ - "⊭":                                         	#  0x22ad
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [t: "é"]                         	# 	(en: 'is', google translation)
+     - t: "não é verdade"                       	# 	(en: 'not true', google translation)
+ - "⊮": [t: "não força"]                        	#  0x22ae	(en: 'does not force', google translation)
+ - "⊯": [t: "catraca dupla direita negada com barra vertical dupla"]	#  0x22af	(en: 'negated double vertical bar double right turnstile', google translation)
+ - "⊰": [t: "precede sob relação"]              	#  0x22b0	(en: 'precedes under relation', google translation)
+ - "⊱": [t: "tem sucesso em relação"]           	#  0x22b1	(en: 'succeeds under relation', google translation)
+ - "⊲":                                         	#  0x22b2
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [t: "é"]                         	# 	(en: 'is', google translation)
+     - t: "um subgrupo normal de"               	# 	(en: 'a normal subgroup of', google translation)
+ - "⊳": [t: "contém como um subgrupo normal"]   	#  0x22b3	(en: 'contains as a normal subgroup', google translation)
+ - "⊴":                                         	#  0x22b4
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [t: "é"]                         	# 	(en: 'is', google translation)
+     - t: "um subgrupo normal ou igual a"       	# 	(en: 'a normal subgroup of or equal to', google translation)
+ - "⊵": [t: "contém como um subgrupo normal ou igual a"]	#  0x22b5	(en: 'contains as a normal subgroup or equal to', google translation)
+ - "⊶":                                         	#  0x22b6
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [t: "é"]                         	# 	(en: 'is', google translation)
+     - t: "o original de"                       	# 	(en: 'the original of', google translation)
+ - "⊷":                                         	#  0x22b7
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [t: "é"]                         	# 	(en: 'is', google translation)
+     - t: "uma imagem de"                       	# 	(en: 'an image of', google translation)
+ - "⊸": [t: "multimapa"]                        	#  0x22b8	(en: 'multimap', google translation)
+ - "⊹": [t: "matriz conjugada hermitiana"]      	#  0x22b9	(en: 'hermitian conjugate matrix', google translation)
+ - "⊺": [t: "intercalar"]                       	#  0x22ba	(en: 'intercalate', google translation)
+ - "⊻": [t: "xor"]                              	#  0x22bb	(google translation)
+ - "⊼": [t: "nand"]                             	#  0x22bc	(google translation)
+ - "⊽": [t: "nem"]                              	#  0x22bd	(en: 'nor', google translation)
+ - "⊾": [t: "ângulo reto com arco"]             	#  0x22be	(en: 'right angle with arc', google translation)
+ - "⊿": [t: "triângulo retângulo"]              	#  0x22bf	(en: 'right triangle', google translation)
+ - "⋀": [t: "lógico e"]                         	#  0x22c0	(en: 'logical and', google translation)
+ - "⋁": [t: "lógico ou"]                        	#  0x22c1	(en: 'logical or', google translation)
+ - "⋂": [t: "interseção"]                       	#  0x22c2	(en: 'intersection', google translation)
+ - "⋃": [t: "união"]                            	#  0x22c3	(en: 'union', google translation)
+ - "⋄": [t: "operador de diamante"]             	#  0x22c4	(en: 'diamond operator', google translation)
+ - "⋅":                                         	#  0x22c5
+    - test: 
+        if: "@data-chem-formula-op"
+        then: [t: "ponto"]                      	# 	(en: 'dot', google translation)
+        else: [t: "vezes"]                      	# 	(en: 'times', google translation)
+
+ - "⋆": [t: "vezes"]                            	#  0x22c6	(en: 'times', google translation)
+ - "⋇": [t: "tempos de divisão"]                	#  0x22c7	(en: 'division times', google translation)
+ - "⋈": [t: "gravata borboleta"]                	#  0x22c8	(en: 'bowtie', google translation)
+ - "⋉":                                         	#  0x22c9
+    - test: 
+        if: "$Verbosity!='Terse'"
+        then: [t: "é"]                          	# 	(en: 'is', google translation)
+    - t: "o produto semidireto do fator normal esquerdo de"	# 	(en: 'the left normal factor semidirect product of', google translation)
+ - "⋊":                                         	#  0x22ca
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [t: "é"]                         	# 	(en: 'is', google translation)
+     - t: "o produto semidireto do fator normal direito de"	# 	(en: 'the right normal factor semidirect product of', google translation)
+ - "⋋":                                         	#  0x22cb
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [t: "é"]                         	# 	(en: 'is', google translation)
+     - t: "o produto semidireto esquerdo de"    	# 	(en: 'the left semidirect product of', google translation)
+ - "⋌":                                         	#  0x22cc
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [t: "é"]                         	# 	(en: 'is', google translation)
+     - t: "o produto semidireto correto de"     	# 	(en: 'the right semidirect product of', google translation)
+ - "⋍": [t: "til invertido é igual"]            	#  0x22cd	(en: 'reversed tilde equals', google translation)
+ - "⋎": [t: "encaracolado lógico ou"]           	#  0x22ce	(en: 'curly logical or', google translation)
+ - "⋏": [t: "encaracolado lógico e"]            	#  0x22cf	(en: 'curly logical and', google translation)
+ - "⋐":                                         	#  0x22d0
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [t: "é"]                         	# 	(en: 'is', google translation)
+     - t: "um subconjunto duplo de"             	# 	(en: 'a double subset of', google translation)
+ - "⋑":                                         	#  0x22d1
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [t: "é"]                         	# 	(en: 'is', google translation)
+     - t: "um superconjunto duplo de"           	# 	(en: 'a double superset of', google translation)
+ - "⋒":                                         	#  0x22d2
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [ot: "o"]                        	# 	(en: 'the', google translation)
+     - t: "dupla interseção de"                 	# 	(en: 'double intersection of', google translation)
+ - "⋓":                                         	#  0x22d3
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [ot: "o"]                        	# 	(en: 'the', google translation)
+     - t: "dupla união de"                      	# 	(en: 'double union of', google translation)
+ - "⋔":                                         	#  0x22d4
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [ot: "o"]                        	# 	(en: 'the', google translation)
+     - t: "interseção adequada de"              	# 	(en: 'proper intersection of', google translation)
+ - "⋕":                                         	#  0x22d5
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [t: "é"]                         	# 	(en: 'is', google translation)
+     - t: "igual e paralelo a"                  	# 	(en: 'equal to and parallel to', google translation)
+ - "⋖": [t: "menos do que com ponto"]           	#  0x22d6	(en: 'less than with dot', google translation)
+ - "⋗": [t: "maior do que com ponto"]           	#  0x22d7	(en: 'greater than with dot', google translation)
+ - "⋘":                                         	#  0x22d8
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [t: "é"]                         	# 	(en: 'is', google translation)
+     - t: "muito menos do que"                  	# 	(en: 'very much less than', google translation)
+ - "⋙":                                         	#  0x22d9
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [t: "é"]                         	# 	(en: 'is', google translation)
+     - t: "muito maior que"                     	# 	(en: 'very much greater than', google translation)
+ - "⋚":                                         	#  0x22da
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [t: "é"]                         	# 	(en: 'is', google translation)
+     - t: "menor que igual ou maior que"        	# 	(en: 'less than equal to or greater than', google translation)
+ - "⋛":                                         	#  0x22db
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [t: "é"]                         	# 	(en: 'is', google translation)
+     - t: "maior que igual ou menor que"        	# 	(en: 'greater than equal to or less than', google translation)
+ - "⋜":                                         	#  0x22dc
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [t: "é"]                         	# 	(en: 'is', google translation)
+     - t: "igual ou menor que"                  	# 	(en: 'equal to or less than', google translation)
+ - "⋝":                                         	#  0x22dd
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [t: "é"]                         	# 	(en: 'is', google translation)
+     - t: "igual ou maior que"                  	# 	(en: 'equal to or greater than', google translation)
+ - "⋞":                                         	#  0x22de
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [t: "é"]                         	# 	(en: 'is', google translation)
+     - t: "igual ou precede"                    	# 	(en: 'equal to or precedes', google translation)
+ - "⋟":                                         	#  0x22df
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [t: "é"]                         	# 	(en: 'is', google translation)
+     - t: "igual ou bem sucedido"               	# 	(en: 'equal to or succeeds', google translation)
+ - "⋠": [t: "não precede nem é igual a"]        	#  0x22e0	(en: 'does not precede nor is equal to', google translation)
+ - "⋡": [t: "não tem sucesso nem é igual a"]    	#  0x22e1	(en: 'does not succeed nor is equal to', google translation)
+ - "⋢": [t: "imagem não quadrada ou igual a"]   	#  0x22e2	(en: 'not square image of or equal to', google translation)
+ - "⋣": [t: "não é quadrado original ou igual a"]	#  0x22e3	(en: 'not square original of or equal to', google translation)
+ - "⋤": [t: "imagem quadrada ou diferente de"]  	#  0x22e4	(en: 'square image of or not equal to', google translation)
+ - "⋥": [t: "quadrado original de ou diferente de"]	#  0x22e5	(en: 'square original of or not equal to', google translation)
+ - "⋦":                                         	#  0x22e6
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [t: "é"]                         	# 	(en: 'is', google translation)
+     - t: "menor que, mas não equivalente a"    	# 	(en: 'less than but not equivalent to', google translation)
+ - "⋧":                                         	#  0x22e7
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [t: "é"]                         	# 	(en: 'is', google translation)
+     - t: "maior que, mas não equivalente a"    	# 	(en: 'greater than but not equivalent to', google translation)
+ - "⋨": [t: "precede, mas não é equivalente a"] 	#  0x22e8	(en: 'precedes but is not equivalent to', google translation)
+ - "⋩": [t: "tem sucesso, mas não é equivalente a"]	#  0x22e9	(en: 'succeeds but is not equivalent to', google translation)
+ - "⋪":                                         	#  0x22ea
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [t: "é"]                         	# 	(en: 'is', google translation)
+     - t: "não é um subgrupo normal de"         	# 	(en: 'not a normal subgroup of', google translation)
+ - "⋫": [t: "não contém como um subgrupo normal"]	#  0x22eb	(en: 'does not contain as a normal subgroup', google translation)
+ - "⋬":                                         	#  0x22ec
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [t: "é"]                         	# 	(en: 'is', google translation)
+     - t: "não é um subgrupo normal de nem é igual a"	# 	(en: 'not a normal subgroup of nor is equal to', google translation)
+ - "⋭": [t: "não contém como um subgrupo normal nem é igual a"]	#  0x22ed	(en: 'does not contain as a normal subgroup nor is equal to', google translation)
+ - "⋮": [t: "elipse vertical"]                  	#  0x22ee	(en: 'vertical ellipsis', google translation)
+ - "⋯": [t: "ponto ponto ponto"]                	#  0x22ef	(en: 'dot dot dot', google translation)
+ - "⋰": [t: "elipse diagonal"]                  	#  0x22f0	(en: 'up diagonal ellipsis', google translation)
+ - "⋱": [t: "elipse diagonal"]                  	#  0x22f1	(en: 'diagonal ellipsis', google translation)
+ - "⋲": [t: "elemento de com longo curso horizontal"]	#  0x22f2	(en: 'element of with long horizontal stroke', google translation)
+ - "⋳": [t: "elemento com barra vertical no final do traço horizontal"]	#  0x22f3	(en: 'element of with vertical bar at end of horizontal stroke', google translation)
+ - "⋴": [t: "elemento com barra vertical no final do traço horizontal"]	#  0x22f4	(en: 'element of with vertical bar at end of horizontal stroke', google translation)
+ - "⋵": [t: "elemento de com ponto acima"]      	#  0x22f5	(en: 'element of with dot above', google translation)
+ - "⋶": [t: "elemento de com overbar"]          	#  0x22f6	(en: 'element of with overbar', google translation)
+ - "⋷": [t: "elemento de com overbar"]          	#  0x22f7	(en: 'element of with overbar', google translation)
+ - "⋸": [t: "elemento de com barra inferior"]   	#  0x22f8	(en: 'element of with underbar', google translation)
+ - "⋹": [t: "elemento de com dois traços horizontais"]	#  0x22f9	(en: 'element of with two horizontal strokes', google translation)
+ - "⋺": [t: "contém com longo traço horizontal"]	#  0x22fa	(en: 'contains with long horizontal stroke', google translation)
+ - "⋻": [t: "contém uma barra vertical no final do traço horizontal"]	#  0x22fb	(en: 'contains with vertical bar at end of horizontal stroke', google translation)
+ - "⋼": [t: "contém uma barra vertical no final do traço horizontal"]	#  0x22fc	(en: 'contains with vertical bar at end of horizontal stroke', google translation)
+ - "⋽": [t: "contém com barra superior"]        	#  0x22fd	(en: 'contains with overbar', google translation)
+ - "⋾": [t: "contém com barra superior"]        	#  0x22fe	(en: 'contains with overbar', google translation)
+ - "⋿": [t: "adesão ao saco de notação z"]      	#  0x22ff	(en: 'z notation bag membership', google translation)
+ - "⌀": [t: "diâmetro"]                         	#  0x2300	(en: 'diameter', google translation)
+ - "⌁": [t: "flecha elétrica"]                  	#  0x2301	(en: 'electric arrow', google translation)
+ - "⌂": [t: "casa"]                             	#  0x2302	(en: 'house', google translation)
+ - "⌃": [t: "ponta de seta para cima"]          	#  0x2303	(en: 'up arrowhead', google translation)
+ - "⌄": [t: "seta para baixo"]                  	#  0x2304	(en: 'down arrowhead', google translation)
+ - "⌅": [t: "projetivo"]                        	#  0x2305	(en: 'projective', google translation)
+ - "⌆": [t: "perspectiva"]                      	#  0x2306	(en: 'perspective', google translation)
+ - "⌇": [t: "linha ondulada"]                   	#  0x2307	(en: 'wavy line', google translation)
+ - "⌈": [t: "teto esquerdo"]                    	#  0x2308	(en: 'left ceiling', google translation)
+ - "⌉": [t: "teto direito"]                     	#  0x2309	(en: 'right ceiling', google translation)
+ - "⌊": [t: "andar esquerdo"]                   	#  0x230a	(en: 'left floor', google translation)
+ - "⌋": [t: "andar direito"]                    	#  0x230b	(en: 'right floor', google translation)
+ - "⌌": [t: "corte inferior direito"]           	#  0x230c	(en: 'bottom right crop', google translation)
+ - "⌍": [t: "corte inferior esquerdo"]          	#  0x230d	(en: 'bottom left crop', google translation)
+ - "⌎": [t: "corte superior direito"]           	#  0x230e	(en: 'top right crop', google translation)
+ - "⌏": [t: "corte superior esquerdo"]          	#  0x230f	(en: 'top left crop', google translation)
+ - "⌐": [t: "invertido não assinar"]            	#  0x2310	(en: 'reversed not sign', google translation)
+ - "⌑": [t: "losango quadrado"]                 	#  0x2311	(en: 'square lozenge', google translation)
+ - "⌒": [t: "arco"]                             	#  0x2312	(en: 'arc', google translation)
+ - "⌓": [t: "segmento"]                         	#  0x2313	(en: 'segment', google translation)
+ - "⌔": [t: "setor"]                            	#  0x2314	(en: 'sector', google translation)
+ - "⌕": [t: "gravador telefônico"]              	#  0x2315	(en: 'telephone recorder', google translation)
+ - "⌖": [t: "mira do indicador de posição"]     	#  0x2316	(en: 'position indicator crosshairs', google translation)
+ - "⌗": [t: "visualizar dados quadrados"]       	#  0x2317	(en: 'viewdata square', google translation)
+ - "⌘": [t: "sinal de local de interesse"]      	#  0x2318	(en: 'place of interest sign', google translation)
+ - "⌙": [t: "virou não assinar"]                	#  0x2319	(en: 'turned not sign', google translation)
+ - "⌚": [t: "assistir"]                         	#  0x231a	(en: 'watch', google translation)
+ - "⌛": [t: "ampulheta"]                        	#  0x231b	(en: 'hourglass', google translation)
+ - "⌜": [t: "canto superior esquerdo"]          	#  0x231c	(en: 'top left corner', google translation)
+ - "⌝": [t: "canto superior direito"]           	#  0x231d	(en: 'top right corner', google translation)
+ - "⌞": [t: "canto inferior esquerdo"]          	#  0x231e	(en: 'bottom left corner', google translation)
+ - "⌟": [t: "canto inferior direito"]           	#  0x231f	(en: 'bottom right corner', google translation)
+ - "⌠": [t: "metade superior integral"]         	#  0x2320	(en: 'top half integral', google translation)
+ - "⌡": [t: "metade inferior integral"]         	#  0x2321	(en: 'bottom half integral', google translation)
+ - "⌢": [t: "franzir a testa"]                  	#  0x2322	(en: 'frown', google translation)
+ - "⌣": [t: "sorriso"]                          	#  0x2323	(en: 'smile', google translation)
+ - "⌤": [t: "seta para cima entre duas barras horizontais"]	#  0x2324	(en: 'up arrowhead between two horizontal bars', google translation)
+ - "⌥": [t: "chave de opção"]                   	#  0x2325	(en: 'option key', google translation)
+ - "⌦": [t: "apagar para a direita"]            	#  0x2326	(en: 'erase to the right', google translation)
+ - "⌧": [t: "x em uma caixa retangular"]        	#  0x2327	(en: 'x in a rectangle box', google translation)
+ - "⌨": [t: "teclado"]                          	#  0x2328	(en: 'keyboard', google translation)
+ - "〈": [t: "colchete angular apontado para a esquerda"]	#  0x2329	(en: 'left pointing angle bracket', google translation)
+ - "〉": [t: "colchete angular apontado para a direita"]	#  0x232a	(en: 'right pointing angle bracket', google translation)
+ - "⌫": [t: "apagar para a esquerda"]           	#  0x232b	(en: 'erase to the left', google translation)
+ - "⌬": [t: "anel de benzeno"]                  	#  0x232c	(en: 'benzene ring', google translation)
+ - "⌭": [t: "cilindricidade"]                   	#  0x232d	(en: 'cylindricity', google translation)
+ - "⌮": [t: "todo o perfil"]                    	#  0x232e	(en: 'all around profile', google translation)
+ - "⌯": [t: "simetria"]                         	#  0x232f	(en: 'symmetry', google translation)
+ - "⌰": [t: "esgotamento total"]                	#  0x2330	(en: 'total runout', google translation)
+ - "⌱": [t: "origem da dimensão"]               	#  0x2331	(en: 'dimension origin', google translation)
+ - "⌲": [t: "cone cônico"]                      	#  0x2332	(en: 'conical taper', google translation)
+ - "⌳": [t: "declive"]                          	#  0x2333	(en: 'slope', google translation)
+ - "⌴": [t: "rebaixo"]                          	#  0x2334	(en: 'counterbore', google translation)
+ - "⌵": [t: "escareador"]                       	#  0x2335	(en: 'countersink', google translation)
+ - "⌶": [t: "apl eu feixe"]                     	#  0x2336	(en: 'apl i beam', google translation)
+ - "⌽": [t: "estilo círculo apl"]               	#  0x233d	(en: 'apl circle stile', google translation)
+ - "⌿": [t: "barra de barra apl"]               	#  0x233f	(en: 'apl slash bar', google translation)
+ - "⍰": [t: "caixa desconhecida"]               	#  0x2370	(en: 'unknown box', google translation)
+ - "⍼": [t: "ângulo reto com seta em zigue-zague para baixo"]	#  0x237c	(en: 'right angle with down zigzag arrow', google translation)
+ - "⎔": [t: "hexágono"]                         	#  0x2394	(en: 'hexagon', google translation)
+ - "⎕": [t: "caixa"]                            	#  0x2395	(en: 'box', google translation)
+ - "⎶": [t: "colchete inferior sobre colchete superior"]	#  0x23b6	(en: 'bottom square bracket over top square bracket', google translation)
+ - "⏜": [t: "parêntese superior"]               	#  0x23dc	(en: 'top paren', google translation)
+ - "⏝": [t: "parêntese inferior"]               	#  0x23dd	(en: 'bottom paren', google translation)
+ - "⏞": [t: "suporte superior"]                 	#  0x23de	(en: 'top brace', google translation)
+ - "⏟": [t: "suporte inferior"]                 	#  0x23df	(en: 'bottom brace', google translation)
+ - "⏠": [t: "suporte superior de casco de tartaruga"]	#  0x23e0	(en: 'top tortoise shell bracket', google translation)
+ - "⏡": [t: "suporte de casco de tartaruga inferior"]	#  0x23e1	(en: 'bottom tortoise shell bracket', google translation)
+ - "⏢": [t: "trapézio branco"]                  	#  0x23e2	(en: 'white trapezium', google translation)
+ - "⏣": [t: "anel de benzeno com círculo"]      	#  0x23e3	(en: 'benzene ring with circle', google translation)
+ - "⏤": [t: "retidão"]                          	#  0x23e4	(en: 'straightness', google translation)
+ - "⏥": [t: "planicidade"]                      	#  0x23e5	(en: 'flatness', google translation)
+ - "⏦":                                         	#  0x23e6
+     - spell: "ac"
+     - t: "atual"                               	# 	(en: 'current', google translation)
+ - "⏧": [t: "cruzamento elétrico"]              	#  0x23e7	(en: 'electrical intersection', google translation)
+ - "①-⑨":                                       	#  0x2460 - 0x2469
+    - t: "circulado"                            	# 	(en: 'circled', google translation)
+    - spell: "translate('.', '①②③④⑤⑥⑦⑧⑨', '123456789')"
+ - "⑩": [t: "circulou dez"]                     	#  0x2469	(en: 'circled ten', google translation)
+ - "⑪": [t: "circulou onze"]                    	#  0x246a	(en: 'circled eleven', google translation)
+ - "⑫": [t: "circulou doze"]                    	#  0x246b	(en: 'circled twelve', google translation)
+ - "⑬": [t: "circulou treze"]                   	#  0x246c	(en: 'circled thirteen', google translation)
+ - "⑭": [t: "circulou quatorze"]                	#  0x246d	(en: 'circled fourteen', google translation)
+ - "⑮": [t: "circulou quinze"]                  	#  0x246e	(en: 'circled fifteen', google translation)
+ - "⑯": [t: "circulou dezesseis"]               	#  0x246f	(en: 'circled sixteen', google translation)
+ - "⑰": [t: "circulou dezessete"]               	#  0x2470	(en: 'circled seventeen', google translation)
+ - "⑱": [t: "circulou um adolescente"]          	#  0x2471	(en: 'circled eighteen', google translation)
+ - "⑳": [t: "circulou vinte"]                   	#  0x2473	(en: 'circled twenty', google translation)
+ - "⑴-⑼":                                       	#  0x2474 - 0x247d
+    - t: "entre parênteses"                     	# 	(en: 'parenthesized', google translation)
+    - spell: "translate('.', '⑴⑵⑶⑷⑸⑹⑺⑻⑼', '123456789')"
+ - "⑽": [t: "entre parênteses dez"]             	#  0x247d	(en: 'parenthesized ten', google translation)
+ - "⑾": [t: "parênteses entre onze"]            	#  0x247e	(en: 'parenthesized eleven', google translation)
+ - "⑿": [t: "entre parênteses estão doze"]      	#  0x247f	(en: 'parenthesized twelve', google translation)
+ - "⒀": [t: "entre parênteses está treze"]      	#  0x2480	(en: 'parenthesized thirteen', google translation)
+ - "⒁": [t: "entre parênteses quatorze"]        	#  0x2481	(en: 'parenthesized fourteen', google translation)
+ - "⒂": [t: "entre parênteses, quinze"]         	#  0x2482	(en: 'parenthesized fifteen', google translation)
+ - "⒃": [t: "entre parênteses, dezesseis"]      	#  0x2483	(en: 'parenthesized sixteen', google translation)
+ - "⒄": [t: "parênteses entre dezessete"]       	#  0x2484	(en: 'parenthesized seventeen', google translation)
+ - "⒅": [t: "adolescente entre parênteses"]     	#  0x2485	(en: 'parenthesized eighteen', google translation)
+ - "⒆": [t: "entre parênteses, dezenove"]       	#  0x2486	(en: 'parenthesized nineteen', google translation)
+ - "⒇": [t: "parênteses são vinte"]             	#  0x2487	(en: 'parenthesized twenty', google translation)
+ - "⒈-⒐":                                       	#  0x2488 - 0x2491
+    - spell: "translate('.', '⒈⒉⒊⒋⒌⒍⒎⒏⒐', '123456789')"
+    - t: "com período"                          	# 	(en: 'with period', google translation)
+ - "⒑": [t: "dez com ponto final"]              	#  0x2491	(en: 'ten with period', google translation)
+ - "⒒": [t: "onze com ponto final"]             	#  0x2492	(en: 'eleven with period', google translation)
+ - "⒓": [t: "doze com ponto final"]             	#  0x2493	(en: 'twelve with period', google translation)
+ - "⒔": [t: "treze com ponto final"]            	#  0x2494	(en: 'thirteen with period', google translation)
+ - "⒕": [t: "quatorze com ponto final"]         	#  0x2495	(en: 'fourteen with period', google translation)
+ - "⒖": [t: "quinze com ponto final"]           	#  0x2496	(en: 'fifteen with period', google translation)
+ - "⒗": [t: "dezesseis com ponto final"]        	#  0x2497	(en: 'sixteen with period', google translation)
+ - "⒘": [t: "dezessete com ponto final"]        	#  0x2498	(en: 'seventeen with period', google translation)
+ - "⒙": [t: "adolescente com menstruação"]      	#  0x2499	(en: 'eighteen with period', google translation)
+ - "⒚": [t: "dezenove com ponto final"]         	#  0x249a	(en: 'nineteen with period', google translation)
+ - "⒛": [t: "vinte com ponto final"]            	#  0x249b	(en: 'twenty with period', google translation)
+ - "⒜-⒵":                                       	#  0x249c - 0x24b5
+    - t: "entre parênteses"                     	# 	(en: 'parenthesized', google translation)
+    - spell: "translate('.', '⒜⒝⒞⒟⒠⒡⒢⒣⒤⒥⒦⒧⒨⒩⒪⒫⒬⒭⒮⒯⒰⒱⒲⒳⒴⒵', 'abcdefghijklmnopqrstuvwxyz')"
+
+ - "Ⓐ-Ⓩ":                                       	#  0x24b6 - 0x24cf
+    - t: "circulado"                            	# 	(en: 'circled', google translation)
+    - spell: "translate('.', 'ⒶⒷⒸⒹⒺⒻⒼⒽⒾⒿⓀⓁⓂⓃⓄⓅⓆⓇⓈⓉⓊⓋⓌⓍⓎⓏ', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ')"
+
+ - "🅐-🅩":                                       	#  0x1f150 - 0x1f169
+    - t: "preto circulado"                      	# 	(en: 'black circled', google translation)
+    - spell: "translate('.', '🅐🅑🅒🅓🅔🅕🅖🅗🅘🅙🅚🅛🅜🅝🅞🅟🅠🅡🅢🅣🅤🅥🅦🅧🅨🅩', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ')"
+
+ - "ⓐ-ⓩ":                                       	#  0x24d0 - 0x24e9
+    - t: "circulado"                            	# 	(en: 'circled', google translation)
+    - spell: "translate('.', 'ⓐⓑⓒⓓⓔⓕⓖⓗⓘⓙⓚⓛⓜⓝⓞⓟⓠⓡⓢⓣⓤⓥⓦⓧⓨⓩ', 'abcdefghijklmnopqrstuvwxyz')"
+
+ - "⓪": [t: "circulou zero"]                    	#  0x24ea	(en: 'circled zero', google translation)
+ - "⓫": [t: "preto circulou onze"]              	#  0x24eb	(en: 'black circled eleven', google translation)
+ - "⓬": [t: "preto circulou doze"]              	#  0x24ec	(en: 'black circled twelve', google translation)
+ - "⓭": [t: "preto circulou treze"]             	#  0x24ed	(en: 'black circled thirteen', google translation)
+ - "⓮": [t: "preto circulou quatorze"]          	#  0x24ee	(en: 'black circled fourteen', google translation)
+ - "⓯": [t: "preto circulou quinze"]            	#  0x24ef	(en: 'black circled fifteen', google translation)
+ - "⓰": [t: "preto circulou dezesseis"]         	#  0x24f0	(en: 'black circled sixteen', google translation)
+ - "⓱": [t: "preto circulou dezessete"]         	#  0x24f1	(en: 'black circled seventeen', google translation)
+ - "⓲": [t: "preto circulado adolescente"]      	#  0x24f2	(en: 'black circled eighteen', google translation)
+ - "⓳": [t: "preto circulou dezenove"]          	#  0x24f3	(en: 'black circled nineteen', google translation)
+ - "⓴": [t: "preto circulou vinte"]             	#  0x24f4	(en: 'black circled twenty', google translation)
+ - "⓵-⓽":                                       	#  0x24f5 - 0x24fe
+    - t: "circulado duplo"                      	# 	(en: 'double circled', google translation)
+    - spell: "translate('.', '⓵⓶⓷⓸⓹⓺⓻⓼⓽', '123456789')"
+ - "⓾": [t: "circulou duas vezes dez"]          	#  0x24fe	(en: 'double circled ten', google translation)
+ - "⓿": [t: "preto circulou zero"]              	#  0x24ff	(en: 'black circled zero', google translation)
+ - "■": [t: "quadrado preto"]                   	#  0x25a0	(en: 'black square', google translation)
+ - "□": [t: "quadrado branco"]                  	#  0x25a1	(en: 'white square', google translation)
+ - "▢": [t: "quadrado branco com cantos arredondados"]	#  0x25a2	(en: 'white square with rounded corners', google translation)
+ - "▣": [t: "quadrado branco contendo pequeno quadrado preto"]	#  0x25a3	(en: 'white square containing small black square', google translation)
+ - "▤": [t: "quadrado com preenchimento horizontal"]	#  0x25a4	(en: 'square with horizontal fill', google translation)
+ - "▥": [t: "quadrado com preenchimento vertical"]	#  0x25a5	(en: 'square with vertical fill', google translation)
+ - "▦": [t: "quadrado com preenchimento hachurado ortogonal"]	#  0x25a6	(en: 'square with orthogonal crosshatch fill', google translation)
+ - "▧": [t: "quadrado com preenchimento superior esquerdo para inferior direito"]	#  0x25a7	(en: 'square with upper left to lower right fill', google translation)
+ - "▨": [t: "quadrado com preenchimento superior direito para inferior esquerdo"]	#  0x25a8	(en: 'square with upper right to lower left fill', google translation)
+ - "▩": [t: "quadrado com preenchimento hachurado diagonal"]	#  0x25a9	(en: 'square with diagonal crosshatch fill', google translation)
+ - "▪": [t: "pequeno quadrado preto"]           	#  0x25aa	(en: 'black small square', google translation)
+ - "▫": [t: "pequeno quadrado branco"]          	#  0x25ab	(en: 'white small square', google translation)
+ - "▬": [t: "retângulo preto"]                  	#  0x25ac	(en: 'black rectangle', google translation)
+ - "▭": [t: "retângulo branco"]                 	#  0x25ad	(en: 'white rectangle', google translation)
+ - "▮": [t: "retângulo vertical preto"]         	#  0x25ae	(en: 'black vertical rectangle', google translation)
+ - "▯": [t: "retângulo vertical branco"]        	#  0x25af	(en: 'white vertical rectangle', google translation)
+ - "▰": [t: "paralelogramo preto"]              	#  0x25b0	(en: 'black parallelogram', google translation)
+ - "▱": [t: "paralelogramo branco"]             	#  0x25b1	(en: 'white parallelogram', google translation)
+ - "▲": [t: "preto apontando triângulo"]        	#  0x25b2	(en: 'black up pointing triangle', google translation)
+ - "△": [t: "triângulo"]                        	#  0x25b3	(en: 'triangle', google translation)
+ - "▴": [t: "preto apontando pequeno triângulo"]	#  0x25b4	(en: 'black up pointing small triangle', google translation)
+ - "▵": [t: "branco apontando pequeno triângulo"]	#  0x25b5	(en: 'white up pointing small triangle', google translation)
+ - "▶": [t: "triângulo preto apontando para a direita"]	#  0x25b6	(en: 'black right pointing triangle', google translation)
+ - "▷": [t: "triângulo branco apontando para a direita"]	#  0x25b7	(en: 'white right pointing triangle', google translation)
+ - "▸": [t: "direita preta apontando pequeno triângulo"]	#  0x25b8	(en: 'black right pointing small triangle', google translation)
+ - "▹": [t: "direita branca apontando pequeno triângulo"]	#  0x25b9	(en: 'white right pointing small triangle', google translation)
+ - "►": [t: "ponteiro preto apontando para a direita"]	#  0x25ba	(en: 'black right pointing pointer', google translation)
+ - "▻": [t: "ponteiro branco apontando para a direita"]	#  0x25bb	(en: 'white right pointing pointer', google translation)
+ - "▼": [t: "triângulo preto apontando para baixo"]	#  0x25bc	(en: 'black down pointing triangle', google translation)
+ - "▽": [t: "branco para baixo apontando triângulo"]	#  0x25bd	(en: 'white down pointing triangle', google translation)
+ - "▾": [t: "preto para baixo apontando pequeno triângulo"]	#  0x25be	(en: 'black down pointing small triangle', google translation)
+ - "▿": [t: "branco para baixo apontando pequeno triângulo"]	#  0x25bf	(en: 'white down pointing small triangle', google translation)
+ - "◀": [t: "triângulo preto apontando para a esquerda"]	#  0x25c0	(en: 'black left pointing triangle', google translation)
+ - "◁": [t: "triângulo branco apontando para a esquerda"]	#  0x25c1	(en: 'white left pointing triangle', google translation)
+ - "◂": [t: "preto à esquerda apontando pequeno triângulo"]	#  0x25c2	(en: 'black left pointing small triangle', google translation)
+ - "◃": [t: "branco à esquerda apontando pequeno triângulo"]	#  0x25c3	(en: 'white left pointing small triangle', google translation)
+ - "◄": [t: "ponteiro preto apontando para a esquerda"]	#  0x25c4	(en: 'black left pointing pointer', google translation)
+ - "◅": [t: "ponteiro branco apontando para a esquerda"]	#  0x25c5	(en: 'white left pointing pointer', google translation)
+ - "◆": [t: "diamante negro"]                   	#  0x25c6	(en: 'black diamond', google translation)
+ - "◇": [t: "diamante branco"]                  	#  0x25c7	(en: 'white diamond', google translation)
+ - "◈": [t: "diamante branco contendo pequeno diamante preto"]	#  0x25c8	(en: 'white diamond containing black small diamond', google translation)
+ - "◉": [t: "olho de peixe"]                    	#  0x25c9	(en: 'fisheye', google translation)
+ - "◊": [t: "pastilha"]                         	#  0x25ca	(en: 'lozenge', google translation)
+ - "○": [t: "círculo branco"]                   	#  0x25cb	(en: 'white circle', google translation)
+ - "◌": [t: "círculo pontilhado"]               	#  0x25cc	(en: 'dotted circle', google translation)
+ - "◍": [t: "círculo com preenchimento vertical"]	#  0x25cd	(en: 'circle with vertical fill', google translation)
+ - "◎": [t: "alvo"]                             	#  0x25ce	(en: 'bullseye', google translation)
+ - "●": [t: "círculo preto"]                    	#  0x25cf	(en: 'black circle', google translation)
+ - "◐": [t: "círculo com metade esquerda preta"]	#  0x25d0	(en: 'circle with left half black', google translation)
+ - "◑": [t: "círculo com metade direita preta"] 	#  0x25d1	(en: 'circle with right half black', google translation)
+ - "◒": [t: "círculo com metade inferior preta"]	#  0x25d2	(en: 'circle with lower half black', google translation)
+ - "◓": [t: "círculo com metade superior preta"]	#  0x25d3	(en: 'circle with upper half black', google translation)
+ - "◔": [t: "círculo com quadrante superior direito preto"]	#  0x25d4	(en: 'circle with upper right quadrant black', google translation)
+ - "◕": [t: "círculo com todos, exceto o quadrante superior esquerdo preto"]	#  0x25d5	(en: 'circle with all but upper left quadrant black', google translation)
+ - "◖": [t: "meio círculo preto esquerdo"]      	#  0x25d6	(en: 'left half black circle', google translation)
+ - "◗": [t: "meio círculo preto direito"]       	#  0x25d7	(en: 'right half black circle', google translation)
+ - "◘": [t: "bala inversa"]                     	#  0x25d8	(en: 'inverse bullet', google translation)
+ - "◙": [t: "círculo branco inverso"]           	#  0x25d9	(en: 'inverse white circle', google translation)
+ - "◚": [t: "metade superior do círculo branco inverso"]	#  0x25da	(en: 'upper half inverse white circle', google translation)
+ - "◛": [t: "metade inferior do círculo branco inverso"]	#  0x25db	(en: 'lower half inverse white circle', google translation)
+ - "◜": [t: "arco circular do quadrante superior esquerdo"]	#  0x25dc	(en: 'upper left quadrant circular arc', google translation)
+ - "◝": [t: "arco circular do quadrante superior direito"]	#  0x25dd	(en: 'upper right quadrant circular arc', google translation)
+ - "◞": [t: "arco circular do quadrante inferior direito"]	#  0x25de	(en: 'lower right quadrant circular arc', google translation)
+ - "◟": [t: "arco circular do quadrante inferior esquerdo"]	#  0x25df	(en: 'lower left quadrant circular arc', google translation)
+ - "◠": [t: "meio círculo superior"]            	#  0x25e0	(en: 'upper half circle', google translation)
+ - "◡": [t: "meio círculo inferior"]            	#  0x25e1	(en: 'lower half circle', google translation)
+ - "◢": [t: "triângulo inferior direito preto"] 	#  0x25e2	(en: 'black lower right triangle', google translation)
+ - "◣": [t: "triângulo inferior esquerdo preto"]	#  0x25e3	(en: 'black lower left triangle', google translation)
+ - "◤": [t: "triângulo superior esquerdo preto"]	#  0x25e4	(en: 'black upper left triangle', google translation)
+ - "◥": [t: "triângulo superior direito preto"] 	#  0x25e5	(en: 'black upper right triangle', google translation)
+ - "◦": [t: "composição"]                       	#  0x25e6	(en: 'composition', google translation)
+ - "◧": [t: "quadrado com metade esquerda preta"]	#  0x25e7	(en: 'square with left half black', google translation)
+ - "◨": [t: "quadrado com metade direita preta"]	#  0x25e8	(en: 'square with right half black', google translation)
+ - "◩": [t: "quadrado com a metade superior esquerda preta"]	#  0x25e9	(en: 'square with upper left half black', google translation)
+ - "◪": [t: "quadrado com a metade inferior direita preta"]	#  0x25ea	(en: 'square with lower right half black', google translation)
+ - "◫": [t: "quadrado branco com linha bissetriz"]	#  0x25eb	(en: 'white square with bisecting line', google translation)
+ - "◬": [t: "branco apontando triângulo com ponto"]	#  0x25ec	(en: 'white up pointing triangle with dot', google translation)
+ - "◭": [t: "triângulo apontando para cima com a metade esquerda preta"]	#  0x25ed	(en: 'up pointing triangle with left half black', google translation)
+ - "◮": [t: "apontando para cima triângulo com metade direita preta"]	#  0x25ee	(en: 'up pointing triangle with right half black', google translation)
+ - "◯": [t: "grande círculo"]                   	#  0x25ef	(en: 'large circle', google translation)
+ - "◰": [t: "quadrado branco com quadrante superior esquerdo"]	#  0x25f0	(en: 'white square with upper left quadrant', google translation)
+ - "◱": [t: "quadrado branco com quadrante inferior esquerdo"]	#  0x25f1	(en: 'white square with lower left quadrant', google translation)
+ - "◲": [t: "quadrado branco com quadrante inferior direito"]	#  0x25f2	(en: 'white square with lower right quadrant', google translation)
+ - "◳": [t: "quadrado branco com quadrante superior direito"]	#  0x25f3	(en: 'white square with upper right quadrant', google translation)
+ - "◴": [t: "círculo branco com quadrante superior esquerdo"]	#  0x25f4	(en: 'white circle with upper left quadrant', google translation)
+ - "◵": [t: "círculo branco com quadrante inferior esquerdo"]	#  0x25f5	(en: 'white circle with lower left quadrant', google translation)
+ - "◶": [t: "círculo branco com quadrante inferior direito"]	#  0x25f6	(en: 'white circle with lower right quadrant', google translation)
+ - "◷": [t: "círculo branco com quadrante superior direito"]	#  0x25f7	(en: 'white circle with upper right quadrant', google translation)
+ - "◸": [t: "triângulo superior esquerdo"]      	#  0x25f8	(en: 'upper left triangle', google translation)
+ - "◹": [t: "triângulo superior direito"]       	#  0x25f9	(en: 'upper right triangle', google translation)
+ - "◺": [t: "triângulo inferior esquerdo"]      	#  0x25fa	(en: 'lower left triangle', google translation)
+ - "◻": [t: "quadrado médio branco"]            	#  0x25fb	(en: 'white medium square', google translation)
+ - "◼": [t: "quadrado médio preto"]             	#  0x25fc	(en: 'black medium square', google translation)
+ - "◽": [t: "quadrado pequeno médio branco"]    	#  0x25fd	(en: 'white medium small square', google translation)
+ - "◾": [t: "quadrado preto médio pequeno"]     	#  0x25fe	(en: 'black medium small square', google translation)
+ - "◿": [t: "triângulo inferior direito"]       	#  0x25ff	(en: 'lower right triangle', google translation)
+ - "★": [t: "estrela negra"]                    	#  0x2605	(en: 'black star', google translation)
+ - "☆": [t: "estrela branca"]                   	#  0x2606	(en: 'white star', google translation)
+ - "☉": [t: "sol"]                              	#  0x2609	(en: 'sun', google translation)
+ - "☌": [t: "conjunção"]                        	#  0x260c	(en: 'conjunction', google translation)
+ - "☒": [t: "urna com x"]                       	#  0x2612	(en: 'ballot box with x', google translation)
+ - "☽": [t: "lua crescente"]                    	#  0x263d	(en: 'waxing moon', google translation)
+ - "☾": [t: "lua minguante"]                    	#  0x263e	(en: 'waning moon', google translation)
+ - "☿": [t: "mercúrio"]                         	#  0x263f	(en: 'mercury', google translation)
+ - "♀": [t: "fêmea"]                            	#  0x2640	(en: 'female', google translation)
+ - "♁": [t: "terra"]                            	#  0x2641	(en: 'earth', google translation)
+ - "♂": [t: "macho"]                            	#  0x2642	(en: 'male', google translation)
+ - "♃": [t: "júpiter"]                          	#  0x2643	(en: 'jupiter', google translation)
+ - "♄": [t: "saturno"]                          	#  0x2644	(en: 'saturn', google translation)
+ - "♅": [t: "urano"]                            	#  0x2645	(en: 'uranus', google translation)
+ - "♆": [t: "netuno"]                           	#  0x2646	(en: 'neptune', google translation)
+ - "♇": [t: "plutão"]                           	#  0x2647	(en: 'pluto', google translation)
+ - "♈": [t: "áries"]                            	#  0x2648	(en: 'aries', google translation)
+ - "♉": [t: "touro"]                            	#  0x2649	(en: 'taurus', google translation)
+ - "♩": [t: "semínima"]                         	#  0x2669	(en: 'quarter note', google translation)
+ - "♭": [t: "plano"]                            	#  0x266d	(en: 'flat', google translation)
+ - "♮": [t: "natural"]                          	#  0x266e	(google translation)
+ - "♯": [t: "afiado"]                           	#  0x266f	(en: 'sharp', google translation)
+ - "♠": [t: "terno de espada preto"]            	#  0x2660	(en: 'black spade suit', google translation)
+ - "♡": [t: "terno de coração branco"]          	#  0x2661	(en: 'white heart suit', google translation)
+ - "♢": [t: "terno de diamante branco"]         	#  0x2662	(en: 'white diamond suit', google translation)
+ - "♣": [t: "terno preto do clube"]             	#  0x2663	(en: 'black club suit', google translation)
+ - "♤": [t: "terno de espadas branco"]          	#  0x2664	(en: 'white spade suit', google translation)
+ - "♥": [t: "terno de coração preto"]           	#  0x2665	(en: 'black heart suit', google translation)
+ - "♦": [t: "terno de diamante negro"]          	#  0x2666	(en: 'black diamond suit', google translation)
+ - "♧": [t: "terno de clube branco"]            	#  0x2667	(en: 'white club suit', google translation)
+ - "⚀": [t: "morrer cara 1"]                    	#  0x2680	(en: 'die face 1', google translation)
+ - "⚁": [t: "morrer cara 2"]                    	#  0x2681	(en: 'die face 2', google translation)
+ - "⚂": [t: "morrer cara 3"]                    	#  0x2682	(en: 'die face 3', google translation)
+ - "⚃": [t: "morrer cara 4"]                    	#  0x2683	(en: 'die face 4', google translation)
+ - "⚄": [t: "morrer cara 5"]                    	#  0x2684	(en: 'die face 5', google translation)
+ - "⚅": [t: "morrer cara 6"]                    	#  0x2685	(en: 'die face 6', google translation)
+ - "⚆": [t: "círculo branco com ponto à direita"]	#  0x2686	(en: 'white circle with dot right', google translation)
+ - "⚇": [t: "círculo branco com dois pontos"]   	#  0x2687	(en: 'white circle wiht two dots', google translation)
+ - "⚈": [t: "círculo preto com ponto à direita"]	#  0x2688	(en: 'black circle with dot right', google translation)
+ - "⚉": [t: "círculo preto com dois pontos"]    	#  0x2689	(en: 'black circle with two dots', google translation)
+ - "⚪": [t: "círculo branco médio"]             	#  0x26aa	(en: 'medium white circle', google translation)
+ - "⚫": [t: "círculo preto médio"]              	#  0x26ab	(en: 'medium black circle', google translation)
+ - "⚬": [t: "círculo branco pequeno médio"]     	#  0x26ac	(en: 'medium small white circle', google translation)
+ - "⚲": [t: "neutro"]                           	#  0x26b2	(en: 'neuter', google translation)
+ - "✓": [t: "marca de seleção"]                 	#  0x2713	(en: 'check mark', google translation)
+ - "✠": [t: "cruz de malta"]                    	#  0x2720	(en: 'maltese cross', google translation)
+ - "✪": [t: "estrela branca circulada"]         	#  0x272a	(en: 'circled white star', google translation)
+ - "✶": [t: "estrela negra de seis pontas"]     	#  0x2736	(en: 'six pionted black star', google translation)
+ - "❨": [t: "ornamento de parênteses médio esquerdo"]	#  0x2768	(en: 'medium left parentheses ornament', google translation)
+ - "❩": [t: "ornamento de parênteses médio direito"]	#  0x2769	(en: 'medium right parentheses ornament', google translation)
+ - "❪": [t: "ornamento de parênteses esquerdo meio achatado"]	#  0x276a	(en: 'medium flattened left parentheses ornament', google translation)
+ - "❫": [t: "ornamento de parênteses direito achatado médio"]	#  0x276b	(en: 'medium flattened right parentheses ornament', google translation)
+ - "❬": [t: "ornamento de colchete angular médio apontando para a esquerda"]	#  0x276c	(en: 'medium left-pointing angle bracket ornament', google translation)
+ - "❭": [t: "ornamento de suporte de ângulo médio apontando para a direita"]	#  0x276d	(en: 'medium right-pointing angle bracket ornament', google translation)
+ - "❮": [t: "ornamento pesado de aspas de ângulo apontando para a esquerda"]	#  0x276e	(en: 'heavy left-pointing angle quotation mark ornament', google translation)
+ - "❯": [t: "ornamento pesado de aspas em ângulo reto"]	#  0x276f	(en: 'heavy right-pointing angle quotation mark ornament', google translation)
+ - "❰": [t: "ornamento pesado de colchete angular apontando para a esquerda"]	#  0x2770	(en: 'heavy left-pointing angle bracket ornament', google translation)
+ - "❱": [t: "ornamento pesado de colchete angular apontando para a direita"]	#  0x2771	(en: 'heavy right-pointing angle bracket ornament', google translation)
+ - "❲": [t: "ornamento de suporte de concha de tartaruga esquerda clara"]	#  0x2772	(en: 'light left tortoise shell bracket ornament', google translation)
+ - "❳": [t: "ornamento de suporte de concha de tartaruga direita clara"]	#  0x2773	(en: 'light right tortoise shell bracket ornament', google translation)
+ - "❴": [t: "ornamento de chave esquerda média"]	#  0x2774	(en: 'medium left brace ornament', google translation)
+ - "❵": [t: "ornamento de chave direita média"] 	#  0x2775	(en: 'medium right brace ornament', google translation)
+ - "❶": [t: "preto circulou um"]                	#  0x2776	(en: 'black circled one', google translation)
+ - "❷": [t: "preto circulou dois"]              	#  0x2777	(en: 'black circled two', google translation)
+ - "❸": [t: "preto circulou três"]              	#  0x2778	(en: 'black circled three', google translation)
+ - "❹": [t: "preto circulou quatro"]            	#  0x2779	(en: 'black circled four', google translation)
+ - "❺": [t: "preto circulou cinco"]             	#  0x277a	(en: 'black circled five', google translation)
+ - "❻": [t: "preto circulou seis"]              	#  0x277b	(en: 'black circled six', google translation)
+ - "❼": [t: "preto circulou sete"]              	#  0x277c	(en: 'black circled seven', google translation)
+ - "❽": [t: "preto circulado em"]               	#  0x277d	(en: 'black circled eight', google translation)
+ - "❾": [t: "preto circulou nove"]              	#  0x277e	(en: 'black circled nine', google translation)
+ - "❿": [t: "preto circulou dez"]               	#  0x277f	(en: 'black circled ten', google translation)
+ - "➀": [t: "circulado sem serifa um"]          	#  0x2780	(en: 'circled sans serif one', google translation)
+ - "➁": [t: "circulado sem serifa dois"]        	#  0x2781	(en: 'circled sans serif two', google translation)
+ - "➂": [t: "circulado sem serifa três"]        	#  0x2782	(en: 'circled sans serif three', google translation)
+ - "➃": [t: "circulado sem serifa quatro"]      	#  0x2783	(en: 'circled sans serif four', google translation)
+ - "➄": [t: "circulou sem serifa cinco"]        	#  0x2784	(en: 'circled sans serif five', google translation)
+ - "➅": [t: "circulou sem serifa seis"]         	#  0x2785	(en: 'circled sans serif six', google translation)
+ - "➆": [t: "circulou sem serifa sete"]         	#  0x2786	(en: 'circled sans serif seven', google translation)
+ - "➇": [t: "circulado sem serifa em"]          	#  0x2787	(en: 'circled sans serif eight', google translation)
+ - "➈": [t: "circulou sem serifa nove"]         	#  0x2788	(en: 'circled sans serif nine', google translation)
+ - "➉": [t: "circulado sem serifa dez"]         	#  0x2789	(en: 'circled sans serif ten', google translation)
+ - "➊": [t: "preto circulado sem serifa um"]    	#  0x278a	(en: 'black circled sans serif one', google translation)
+ - "➋": [t: "preto circulado sem serifa dois"]  	#  0x278b	(en: 'black circled sans serif two', google translation)
+ - "➌": [t: "preto circulado sem serifa três"]  	#  0x278c	(en: 'black circled sans serif three', google translation)
+ - "➍": [t: "preto circulado sem serifa quatro"]	#  0x278d	(en: 'black circled sans serif four', google translation)
+ - "➎": [t: "preto circulado sem serifa cinco"] 	#  0x278e	(en: 'black circled sans serif five', google translation)
+ - "➏": [t: "preto circulado sem serifa seis"]  	#  0x278f	(en: 'black circled sans serif six', google translation)
+ - "➐": [t: "preto circulado sem serifa sete"]  	#  0x2790	(en: 'black circled sans serif seven', google translation)
+ - "➑": [t: "preto circulado sem serifa em"]    	#  0x2791	(en: 'black circled sans serif eight', google translation)
+ - "➒": [t: "preto circulado sem serifa nove"]  	#  0x2792	(en: 'black circled sans serif nine', google translation)
+ - "➓": [t: "preto circulado sem serifa dez"]   	#  0x2793	(en: 'black circled sans serif ten', google translation)
+ - "➔": [t: "seta pesada e larga para a direita"]	#  0x2794	(en: 'heavy wide-headed right arrow', google translation)
+ - "➕": [t: "sinal de mais pesado"]             	#  0x2795	(en: 'heavy plus sign', google translation)
+ - "➖": [t: "sinal de menos pesado"]            	#  0x2796	(en: 'heavy minus sign', google translation)
+ - "➗": [t: "sinal de divisão pesada"]          	#  0x2797	(en: 'heavy division sign', google translation)
+ - "➘": [t: "flecha pesada sudeste"]            	#  0x2798	(en: 'heavy south east arrow', google translation)
+ - "➙": [t: "seta pesada para a direita"]       	#  0x2799	(en: 'heavy right arrow', google translation)
+ - "➚": [t: "flecha pesada do nordeste"]        	#  0x279a	(en: 'heavy north east arrow', google translation)
+ - "➛": [t: "ponto de desenho seta para a direita"]	#  0x279b	(en: 'drafting point right arrow', google translation)
+ - "➜": [t: "seta direita pesada com ponta arredondada"]	#  0x279c	(en: 'heavy round-tipped right arrow', google translation)
+ - "➝": [t: "seta para a direita com ponta de triângulo"]	#  0x279d	(en: 'triangle-headed right arrow', google translation)
+ - "➞": [t: "seta para a direita com ponta de triângulo pesado"]	#  0x279e	(en: 'heavy triangle-headed right arrow', google translation)
+ - "➟": [t: "seta para a direita com ponta de triângulo tracejado"]	#  0x279f	(en: 'dashed triangle-headed right arrow', google translation)
+ - "➠": [t: "seta para a direita com ponta de triângulo tracejado pesado"]	#  0x27a0	(en: 'heavy dashed triangle-headed right arrow', google translation)
+ - "➡": [t: "seta preta para a direita"]        	#  0x27a1	(en: 'black right arrow', google translation)
+ - "➢": [t: "três d seta para a direita iluminada no topo"]	#  0x27a2	(en: 'three d top lighted right arrow', google translation)
+ - "➣": [t: "três d seta para a direita iluminada na parte inferior"]	#  0x27a3	(en: 'three d bottom lighted right arrow', google translation)
+ - "➤": [t: "ponta de seta preta para a direita"]	#  0x27a4	(en: 'black right arrowhead', google translation)
+ - "➥": [t: "preto pesado curvado para baixo e seta para a direita"]	#  0x27a5	(en: 'heavy black curved down and right arrow', google translation)
+ - "➦": [t: "preto pesado curvado para cima e seta para a direita"]	#  0x27a6	(en: 'heavy black curved up and right arrow', google translation)
+ - "➧": [t: "agachamento seta preta para a direita"]	#  0x27a7	(en: 'squat black right arrow', google translation)
+ - "➨": [t: "seta preta pesada de ponta côncava para a direita"]	#  0x27a8	(en: 'heavy concave-pointed black right arrow', google translation)
+ - "➩": [t: "seta direita branca sombreada à direita"]	#  0x27a9	(en: 'right-shaded white right arrow', google translation)
+ - "➪": [t: "seta branca para a direita sombreada à esquerda"]	#  0x27aa	(en: 'left-shaded white right arrow', google translation)
+ - "➫": [t: "seta para a direita branca sombreada inclinada para trás"]	#  0x27ab	(en: 'back-tilted shadowed white right arrow', google translation)
+ - "➬": [t: "seta direita branca sombreada inclinada para frente"]	#  0x27ac	(en: 'front-tilted shadowed white right arrow', google translation)
+ - "➭": [t: "seta direita branca sombreada inferior à direita"]	#  0x27ad	(en: 'heavy lower right-shadowed white right arrow', google translation)
+ - "➮": [t: "seta branca direita sombreada no canto superior direito"]	#  0x27ae	(en: 'heavy upper right-shadowed white right arrow', google translation)
+ - "➯": [t: "seta direita branca sombreada inferior direita entalhada"]	#  0x27af	(en: 'notched lower right-shadowed white right arrow', google translation)
+ - "➱": [t: "seta direita branca sombreada superior direita entalhada"]	#  0x27b1	(en: 'notched upper right-shadowed white right arrow', google translation)
+ - "➲": [t: "circulou uma seta branca pesada para a direita"]	#  0x27b2	(en: 'circled heavy white right arrow', google translation)
+ - "➳": [t: "seta para a direita com penas brancas"]	#  0x27b3	(en: 'white-feathered right arrow', google translation)
+ - "➴": [t: "flecha sudeste com penas pretas"]  	#  0x27b4	(en: 'black-feathered south east arrow', google translation)
+ - "➵": [t: "seta para a direita com penas pretas"]	#  0x27b5	(en: 'black-feathered right arrow', google translation)
+ - "➶": [t: "flecha nordeste com penas pretas"] 	#  0x27b6	(en: 'black-feathered north east arrow', google translation)
+ - "➷": [t: "pesada flecha sudeste com penas pretas"]	#  0x27b7	(en: 'heavy black-feathered south east arrow', google translation)
+ - "➸": [t: "seta direita pesada com penas pretas"]	#  0x27b8	(en: 'heavy black-feathered right arrow', google translation)
+ - "➹": [t: "pesada flecha nordeste com penas pretas"]	#  0x27b9	(en: 'heavy black-feathered north east arrow', google translation)
+ - "➺": [t: "seta para a direita com farpas de teradrop"]	#  0x27ba	(en: 'teradrop-barbed right arrow', google translation)
+ - "➻": [t: "pesada seta para a direita em forma de lágrima"]	#  0x27bb	(en: 'heavy teardrop-shanked right arrow', google translation)
+ - "➼": [t: "seta para a direita em forma de cunha"]	#  0x27bc	(en: 'wedge-tailed right arrow', google translation)
+ - "➽": [t: "seta para a direita com cauda em cunha pesada"]	#  0x27bd	(en: 'heavy wedge-tailed right arrow', google translation)
+ - "➾": [t: "seta para a direita com contorno aberto"]	#  0x27be	(en: 'open-outlined right arrow', google translation)
+ - "⟀": [t: "ângulo tridimensional"]            	#  0x27c0	(en: 'three dimensional angle', google translation)
+ - "⟁": [t: "triângulo branco contendo um pequeno triângulo branco"]	#  0x27c1	(en: 'white triangle containing small white triangle', google translation)
+ - "⟂⊥":                                        	#  0x27c2, 22A5 (22A5 wrongly used for perpendicular by most editors)
+     - test:
+        - if: "$SpeechStyle = 'LiteralSpeak' and text()='⊥'"	#  22A5 (up tack/bottom)
+          then: [t: "para cima"]                	# 	(en: 'up tack', google translation)
+        - else:
+          - test:
+              if: "$Verbosity!='Terse'"
+              then: [t: "é"]                    	# 	(en: 'is', google translation)
+          - t: "perpendicularmente a"           	# 	(en: 'perpendicular to', google translation)
+ - "⟃":                                         	#  0x27c3
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [t: "é"]                         	# 	(en: 'is', google translation)
+     - t: "um subconjunto aberto de"            	# 	(en: 'an open subset of', google translation)
+ - "⟄":                                         	#  0x27c4
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [t: "é"]                         	# 	(en: 'is', google translation)
+     - t: "um superconjunto aberto de"          	# 	(en: 'an open superset of', google translation)
+ - "⟅": [t: "delimitador de saco em forma de s esquerdo"]	#  0x27c5	(en: 'left s-shaped bag delimiter', google translation)
+ - "⟆": [t: "delimitador de bolsa em forma de s à direita"]	#  0x27c6	(en: 'right s-shaped bag delimiter', google translation)
+ - "⟇": [t: "ou com ponto dentro"]              	#  0x27c7	(en: 'or with dot inside', google translation)
+ - "⟈": [t: "solidus reverso subconjunto anterior"]	#  0x27c8	(en: 'reverse solidus preceding subset', google translation)
+ - "⟉": [t: "superconjunto anterior ao solidus"]	#  0x27c9	(en: 'superset preceding solidus', google translation)
+ - "⟊": [t: "barra vertical com traço horizontal"]	#  0x27ca	(en: 'vertical bar with horizontal stroke', google translation)
+ - "⟋": [t: "diagonal ascendente matemática"]   	#  0x27cb	(en: 'mathematical rising diagonal', google translation)
+ - "⟌": [t: "longa divisão"]                    	#  0x27cc	(en: 'long division', google translation)
+ - "⟍": [t: "diagonal descendente matemática"]  	#  0x27cd	(en: 'mathematical falling diagonal', google translation)
+ - "⟎": [t: "ao quadrado lógico e"]             	#  0x27ce	(en: 'squared logical and', google translation)
+ - "⟏": [t: "ao quadrado lógico ou"]            	#  0x27cf	(en: 'squared logical or', google translation)
+ - "⟐": [t: "diamante branco com ponto centralizado"]	#  0x27d0	(en: 'white diamond with centered dot', google translation)
+ - "⟑": [t: "e com ponto"]                      	#  0x27d1	(en: 'and with dot', google translation)
+ - "⟒": [t: "elemento de abertura"]             	#  0x27d2	(en: 'element of opening up', google translation)
+ - "⟓": [t: "canto inferior direito com ponto"] 	#  0x27d3	(en: 'lower right corner with dot', google translation)
+ - "⟔": [t: "canto superior esquerdo com ponto"]	#  0x27d4	(en: 'upper left corner with dot', google translation)
+ - "⟕": [t: "junção externa esquerda"]          	#  0x27d5	(en: 'left outer join', google translation)
+ - "⟖": [t: "junção externa direita"]           	#  0x27d6	(en: 'right outer join', google translation)
+ - "⟗": [t: "junção externa completa"]          	#  0x27d7	(en: 'full outer join', google translation)
+ - "⟘": [t: "aderência grande"]                 	#  0x27d8	(en: 'large up tack', google translation)
+ - "⟙": [t: "grande aderência para baixo"]      	#  0x27d9	(en: 'large down tack', google translation)
+ - "⟚": [t: "catraca dupla esquerda e direita"] 	#  0x27da	(en: 'left and right double turnstile', google translation)
+ - "⟛": [t: "direção esquerda e direita"]       	#  0x27db	(en: 'left and right tack', google translation)
+ - "⟜": [t: "multimapa esquerdo"]               	#  0x27dc	(en: 'left multimap', google translation)
+ - "⟝": [t: "longo rumo à direita"]             	#  0x27dd	(en: 'long right tack', google translation)
+ - "⟞": [t: "longo rumo à esquerda"]            	#  0x27de	(en: 'long left tack', google translation)
+ - "⟟": [t: "alinhave com o círculo acima"]     	#  0x27df	(en: 'up tack with circle above', google translation)
+ - "⟠": [t: "losango dividido por régua horizontal"]	#  0x27e0	(en: 'lozenge divided by horizontal rule', google translation)
+ - "⟡": [t: "diamante de face côncava branca"]  	#  0x27e1	(en: 'white concave sided diamond', google translation)
+ - "⟢": [t: "diamante de face côncava branca com marca esquerda"]	#  0x27e2	(en: 'white concave sided diamond with left tick', google translation)
+ - "⟣": [t: "diamante de face côncava branca com marca direita"]	#  0x27e3	(en: 'white concave sided diamond with right tick', google translation)
+ - "⟤": [t: "quadrado branco com marca esquerda"]	#  0x27e4	(en: 'white square with left tick', google translation)
+ - "⟥": [t: "quadrado branco com marca direita"]	#  0x27e5	(en: 'white square with right tick', google translation)
+ - "⟦": [t: "colchete branco esquerdo"]         	#  0x27e6	(en: 'left white square bracket', google translation)
+ - "⟧": [t: "colchete branco direito"]          	#  0x27e7	(en: 'right white square bracket', google translation)
+ - "⟨": [t: "colchete angular esquerdo"]        	#  0x27e8	(en: 'left angle bracket', google translation)
+ - "⟩": [t: "colchete em ângulo reto"]          	#  0x27e9	(en: 'right angle bracket', google translation)
+ - "⟪": [t: "suporte de ângulo duplo esquerdo"] 	#  0x27ea	(en: 'left double angle bracket', google translation)
+ - "⟫": [t: "suporte de ângulo duplo direito"]  	#  0x27eb	(en: 'right double angle bracket', google translation)
+ - "⟬": [t: "suporte de carapaça de tartaruga branca esquerda"]	#  0x27ec	(en: 'left white tortoise shell bracket', google translation)
+ - "⟭": [t: "suporte de carapaça de tartaruga branca direita"]	#  0x27ed	(en: 'right white tortoise shell bracket', google translation)
+ - "⟮": [t: "parêntese achatado à esquerda"]    	#  0x27ee	(en: 'left flattened parenthesis', google translation)
+ - "⟯": [t: "parêntese achatado à direita"]     	#  0x27ef	(en: 'right flattened parenthesis', google translation)
+ - "⟰": [t: "seta quádrupla para cima"]         	#  0x27f0	(en: 'up quadruple arrow', google translation)
+ - "⟱": [t: "seta quádrupla para baixo"]        	#  0x27f1	(en: 'down quadruple arrow', google translation)
+ - "⟲": [t: "seta circular com folga no sentido anti-horário"]	#  0x27f2	(en: 'anticlockwise gapped circle arrow', google translation)
+ - "⟳": [t: "seta circular espaçada no sentido horário"]	#  0x27f3	(en: 'clockwise gapped circle arrow', google translation)
+ - "⟴": [t: "seta para a direita com mais circulado"]	#  0x27f4	(en: 'right arrow with circled plus', google translation)
+ - "⟵": [t: "seta longa para a esquerda"]       	#  0x27f5	(en: 'long left arrow', google translation)
+ - "⟶": [t: "seta longa para a direita"]        	#  0x27f6	(en: 'long right arrow', google translation)
+ - "⟷": [t: "seta longa para a esquerda e para a direita"]	#  0x27f7	(en: 'long left right arrow', google translation)
+ - "⟸": [t: "seta dupla longa para a esquerda"] 	#  0x27f8	(en: 'long left double arrow', google translation)
+ - "⟹": [t: "implica"]                          	#  0x27f9	(en: 'implies', google translation)
+ - "⟺": [t: "se e somente se"]                  	#  0x27fa	(en: 'if and only if', google translation)
+ - "⟻": [t: "seta longa para a esquerda da barra"]	#  0x27fb	(en: 'long left arrow from bar', google translation)
+ - "⟼": [t: "seta longa para a direita da barra"]	#  0x27fc	(en: 'long right arrow from bar', google translation)
+ - "⟽": [t: "seta dupla longa para a esquerda da barra"]	#  0x27fd	(en: 'long left double arrow from bar', google translation)
+ - "⟾": [t: "seta dupla longa para a direita da barra"]	#  0x27fe	(en: 'long right double arrow from bar', google translation)
+ - "⟿": [t: "seta longa para a direita"]        	#  0x27ff	(en: 'long right squiggle arrow', google translation)
+ - "⤀": [t: "seta de duas pontas para a direita com traço vertical"]	#  0x2900	(en: 'right two headed arrow with vertical stroke', google translation)
+ - "⤁": [t: "seta de duas pontas para a direita com traço vertical duplo"]	#  0x2901	(en: 'right two headed arrow with double vertical stroke', google translation)
+ - "⤂": [t: "seta dupla para a esquerda com traço vertical"]	#  0x2902	(en: 'left double arrow with vertical stroke', google translation)
+ - "⤃": [t: "seta dupla para a direita com traço vertical"]	#  0x2903	(en: 'right double arrow with vertical stroke', google translation)
+ - "⤄": [t: "seta dupla esquerda direita com traço vertical"]	#  0x2904	(en: 'left right double arrow with vertical stroke', google translation)
+ - "⤅": [t: "seta de duas pontas para a direita da barra"]	#  0x2905	(en: 'right two headed arrow from bar', google translation)
+ - "⤆": [t: "seta dupla para a esquerda da barra"]	#  0x2906	(en: 'left double arrow from bar', google translation)
+ - "⤇": [t: "seta dupla para a direita da barra"]	#  0x2907	(en: 'right double arrow from bar', google translation)
+ - "⤈": [t: "seta para baixo com traço horizontal"]	#  0x2908	(en: 'down arrow with horizontal stroke', google translation)
+ - "⤉": [t: "seta para cima com traço horizontal"]	#  0x2909	(en: 'up arrow with horizontal stroke', google translation)
+ - "⤊": [t: "seta tripla para cima"]            	#  0x290a	(en: 'up triple arrow', google translation)
+ - "⤋": [t: "seta tripla para baixo"]           	#  0x290b	(en: 'down triple arrow', google translation)
+ - "⤌": [t: "seta de traço duplo para a esquerda"]	#  0x290c	(en: 'left double dash arrow', google translation)
+ - "⤍": [t: "seta dupla para a direita"]        	#  0x290d	(en: 'right double dash arrow', google translation)
+ - "⤎": [t: "seta de traço triplo para a esquerda"]	#  0x290e	(en: 'left triple dash arrow', google translation)
+ - "⤏": [t: "seta tripla para a direita"]       	#  0x290f	(en: 'right triple dash arrow', google translation)
+ - "⤐": [t: "seta de traço triplo de duas pontas para a direita"]	#  0x2910	(en: 'right two headed triple dash arrow', google translation)
+ - "⤑": [t: "seta para a direita com haste pontilhada"]	#  0x2911	(en: 'right arrow with dotted stem', google translation)
+ - "⤒": [t: "seta para cima na barra"]          	#  0x2912	(en: 'up arrow to bar', google translation)
+ - "⤓": [t: "seta para baixo até a barra"]      	#  0x2913	(en: 'down arrow to bar', google translation)
+ - "⤔": [t: "seta para a direita com cauda e traço vertical"]	#  0x2914	(en: 'right arrow with tail and vertical stroke', google translation)
+ - "⤕": [t: "seta para a direita com cauda e traço vertical duplo"]	#  0x2915	(en: 'right arrow with tail and double vertical stroke', google translation)
+ - "⤖": [t: "seta de duas cabeças para a direita com cauda"]	#  0x2916	(en: 'right two headed arrow with tail', google translation)
+ - "⤗": [t: "seta de duas cabeças para a direita com cauda com traço vertical"]	#  0x2917	(en: 'right two headed arrow with tail with vertical stroke', google translation)
+ - "⤘": [t: "seta de duas cabeças para a direita com cauda com traço vertical duplo"]	#  0x2918	(en: 'right two headed arrow with tail with double vertical stroke', google translation)
+ - "⤙": [t: "cauda da seta esquerda"]           	#  0x2919	(en: 'left arrow tail', google translation)
+ - "⤚": [t: "cauda de seta para a direita"]     	#  0x291a	(en: 'right arrow tail', google translation)
+ - "⤛": [t: "cauda de seta dupla esquerda"]     	#  0x291b	(en: 'left double arrow tail', google translation)
+ - "⤜": [t: "cauda de seta dupla direita"]      	#  0x291c	(en: 'right double arrow tail', google translation)
+ - "⤝": [t: "seta para a esquerda para o diamante preenchido"]	#  0x291d	(en: 'left arrow to filled diamond', google translation)
+ - "⤞": [t: "seta para a direita para o diamante preenchido"]	#  0x291e	(en: 'right arrow to filled diamond', google translation)
+ - "⤟": [t: "seta para a esquerda da barra até o diamante preenchido"]	#  0x291f	(en: 'left arrow from bar to filled diamond', google translation)
+ - "⤠": [t: "seta para a direita da barra até o diamante preenchido"]	#  0x2920	(en: 'right arrow from bar to filled diamond', google translation)
+ - "⤡": [t: "seta noroeste e sudeste"]          	#  0x2921	(en: 'north west and south east arrow', google translation)
+ - "⤢": [t: "seta nordeste e sudoeste"]         	#  0x2922	(en: 'north east and south west arrow', google translation)
+ - "⤣": [t: "seta noroeste com gancho"]         	#  0x2923	(en: 'north west arrow with hook', google translation)
+ - "⤤": [t: "seta nordeste com gancho"]         	#  0x2924	(en: 'north east arrow with hook', google translation)
+ - "⤥": [t: "seta sudeste com gancho"]          	#  0x2925	(en: 'south east arrow with hook', google translation)
+ - "⤦": [t: "seta sudoeste com gancho"]         	#  0x2926	(en: 'south west arrow with hook', google translation)
+ - "⤧": [t: "seta noroeste e seta nordeste"]    	#  0x2927	(en: 'north west arrow and north east arrow', google translation)
+ - "⤨": [t: "seta nordeste e seta sudeste"]     	#  0x2928	(en: 'north east arrow and south east arrow', google translation)
+ - "⤩": [t: "seta sudeste e seta sudoeste"]     	#  0x2929	(en: 'south east arrow and south west arrow', google translation)
+ - "⤪": [t: "seta sudoeste e seta noroeste"]    	#  0x292a	(en: 'south west arrow and north west arrow', google translation)
+ - "⤫": [t: "diagonal ascendente cruzando diagonal descendente"]	#  0x292b	(en: 'rising diagonal crossing falling diagonal', google translation)
+ - "⤬": [t: "diagonal descendente cruzando diagonal ascendente"]	#  0x292c	(en: 'falling diagonal crossing rising diagonal', google translation)
+ - "⤭": [t: "seta sudeste cruzando a seta nordeste"]	#  0x292d	(en: 'south east arrow crossing north east arrow', google translation)
+ - "⤮": [t: "seta nordeste cruzando a seta sudeste"]	#  0x292e	(en: 'north east arrow crossing south east arrow', google translation)
+ - "⤯": [t: "caindo diagonal cruzando a seta nordeste"]	#  0x292f	(en: 'falling diagonal crossing north east arrow', google translation)
+ - "⤰": [t: "diagonal ascendente cruzando a seta sudeste"]	#  0x2930	(en: 'rising diagonal crossing south east arrow', google translation)
+ - "⤱": [t: "seta nordeste cruzando a seta noroeste"]	#  0x2931	(en: 'north east arrow crossing north west arrow', google translation)
+ - "⤲": [t: "seta noroeste cruzando a seta nordeste"]	#  0x2932	(en: 'north west arrow crossing north east arrow', google translation)
+ - "⤳": [t: "seta de onda apontando diretamente para a direita"]	#  0x2933	(en: 'wave arrow pointing directly right', google translation)
+ - "⤴": [t: "seta apontando para a direita e depois curvando-se para cima"]	#  0x2934	(en: 'arrow pointing right then curving up', google translation)
+ - "⤵": [t: "seta apontando para a direita e depois curvando-se para baixo"]	#  0x2935	(en: 'arrow pointing right then curving down', google translation)
+ - "⤶": [t: "seta apontando para baixo e depois curvando para a esquerda"]	#  0x2936	(en: 'arrow pointing down then curving left', google translation)
+ - "⤷": [t: "seta apontando para baixo e depois curvando para a direita"]	#  0x2937	(en: 'arrow pointing down then curving right', google translation)
+ - "⤸": [t: "seta do arco do lado direito no sentido horário"]	#  0x2938	(en: 'right side arc clockwise arrow', google translation)
+ - "⤹": [t: "arco do lado esquerdo seta no sentido anti-horário"]	#  0x2939	(en: 'left side arc anticlockwise arrow', google translation)
+ - "⤺": [t: "arco superior seta no sentido anti-horário"]	#  0x293a	(en: 'top arc anticlockwise arrow', google translation)
+ - "⤻": [t: "arco inferior seta no sentido anti-horário"]	#  0x293b	(en: 'bottom arc anticlockwise arrow', google translation)
+ - "⤼": [t: "seta superior do arco no sentido horário com menos"]	#  0x293c	(en: 'top arc clockwise arrow with minus', google translation)
+ - "⤽": [t: "seta superior do arco no sentido anti-horário com mais"]	#  0x293d	(en: 'top arc anticlockwise arrow with plus', google translation)
+ - "⤾": [t: "seta semicircular inferior direita no sentido horário"]	#  0x293e	(en: 'lower right semicircular clockwise arrow', google translation)
+ - "⤿": [t: "seta semicircular inferior esquerda no sentido anti-horário"]	#  0x293f	(en: 'lower left semicircular anticlockwise arrow', google translation)
+ - "⥀": [t: "seta de círculo fechado no sentido anti-horário"]	#  0x2940	(en: 'anticlockwise closed circle arrow', google translation)
+ - "⥁": [t: "seta de círculo fechado no sentido horário"]	#  0x2941	(en: 'clockwise closed circle arrow', google translation)
+ - "⥂": [t: "seta para a direita acima da seta curta para a esquerda"]	#  0x2942	(en: 'right arrow above short left arrow', google translation)
+ - "⥃": [t: "seta para a esquerda acima da seta curta para a direita"]	#  0x2943	(en: 'left arrow above short right arrow', google translation)
+ - "⥄": [t: "seta curta para a direita acima da seta para a esquerda"]	#  0x2944	(en: 'short right arrow above left arrow', google translation)
+ - "⥅": [t: "seta para a direita com mais abaixo"]	#  0x2945	(en: 'right arrow with plus below', google translation)
+ - "⥆": [t: "seta para a esquerda com mais abaixo"]	#  0x2946	(en: 'left arrow with plus below', google translation)
+ - "⥇": [t: "seta para a direita passando por x"]	#  0x2947	(en: 'right arrow through x', google translation)
+ - "⥈": [t: "seta para a esquerda e para a direita através do círculo"]	#  0x2948	(en: 'left right arrow through circle', google translation)
+ - "⥉": [t: "seta de duas pontas do círculo"]   	#  0x2949	(en: 'up two headed arrow from circle', google translation)
+ - "⥊": [t: "farpa esquerda para cima farpa direita para baixo arpão"]	#  0x294a	(en: 'left barb up right barb down harpoon', google translation)
+ - "⥋": [t: "farpa esquerda para baixo farpa direita para cima arpão"]	#  0x294b	(en: 'left barb down right barb up harpoon', google translation)
+ - "⥌": [t: "farpa para cima, para baixo, farpa para a esquerda, arpão"]	#  0x294c	(en: 'up barb right down barb left harpoon', google translation)
+ - "⥍": [t: "para cima farpa esquerda para baixo farpa direita arpão"]	#  0x294d	(en: 'up barb left down barb right harpoon', google translation)
+ - "⥎": [t: "farpa esquerda para cima farpa direita para cima arpão"]	#  0x294e	(en: 'left barb up right barb up harpoon', google translation)
+ - "⥏": [t: "farpa para cima, para baixo, farpa, arpão direito"]	#  0x294f	(en: 'up barb right down barb right harpoon', google translation)
+ - "⥐": [t: "farpa esquerda para baixo farpa direita para baixo arpão"]	#  0x2950	(en: 'left barb down right barb down harpoon', google translation)
+ - "⥑": [t: "para cima farpa esquerda para baixo farpa esquerda arpão"]	#  0x2951	(en: 'up barb left down barb left harpoon', google translation)
+ - "⥒": [t: "arpão esquerdo com farpa até barra"]	#  0x2952	(en: 'left harpoon with barb up to bar', google translation)
+ - "⥓": [t: "arpão direito com farpa até a barra"]	#  0x2953	(en: 'right harpoon with barb up to bar', google translation)
+ - "⥔": [t: "arpão com farpa direto na barra"]  	#  0x2954	(en: 'up harpoon with barb right to bar', google translation)
+ - "⥕": [t: "arpão com farpa direto para a barra"]	#  0x2955	(en: 'down harpoon with barb right to bar', google translation)
+ - "⥖": [t: "arpão esquerdo com farpa até a barra"]	#  0x2956	(en: 'left harpoon with barb down to bar', google translation)
+ - "⥗": [t: "arpão direito com farpa até a barra"]	#  0x2957	(en: 'right harpoon with barb down to bar', google translation)
+ - "⥘": [t: "arpão com farpa da esquerda para a barra"]	#  0x2958	(en: 'up harpoon with barb left to bar', google translation)
+ - "⥙": [t: "arpão para baixo com a farpa da esquerda para a barra"]	#  0x2959	(en: 'down harpoon with barb left to bar', google translation)
+ - "⥚": [t: "arpão esquerdo com farpa para cima da barra"]	#  0x295a	(en: 'left harpoon with barb up from bar', google translation)
+ - "⥛": [t: "arpão direito com a farpa para cima da barra"]	#  0x295b	(en: 'right harpoon with barb up from bar', google translation)
+ - "⥜": [t: "arpão com farpa direto da barra"]  	#  0x295c	(en: 'up harpoon with barb right from bar', google translation)
+ - "⥝": [t: "arpão com farpa direto da barra"]  	#  0x295d	(en: 'down harpoon with barb right from bar', google translation)
+ - "⥞": [t: "arpão esquerdo com farpa para baixo da barra"]	#  0x295e	(en: 'left harpoon with barb down from bar', google translation)
+ - "⥟": [t: "arpão direito com a farpa voltada para baixo da barra"]	#  0x295f	(en: 'right harpoon with barb down from bar', google translation)
+ - "⥠": [t: "arpão com farpa à esquerda da barra"]	#  0x2960	(en: 'up harpoon with barb left from bar', google translation)
+ - "⥡": [t: "arpão com farpa à esquerda da barra"]	#  0x2961	(en: 'down harpoon with barb left from bar', google translation)
+ - "⥢": [t: "arpão esquerdo com a farpa para cima acima do arpão esquerdo com a farpa para baixo"]	#  0x2962	(en: 'left harpoon with barb up above left harpoon with barb down', google translation)
+ - "⥣": [t: "arpão para cima com a farpa à esquerda ao lado do arpão para cima com a farpa à direita"]	#  0x2963	(en: 'up harpoon with barb left beside up harpoon with barb right', google translation)
+ - "⥤": [t: "arpão direito com a farpa para cima acima do arpão direito com a farpa para baixo"]	#  0x2964	(en: 'right harpoon with barb up above right harpoon with barb down', google translation)
+ - "⥥": [t: "arpão para baixo com a farpa à esquerda ao lado arpão para baixo com a farpa à direita"]	#  0x2965	(en: 'down harpoon with barb left beside down harpoon with barb right', google translation)
+ - "⥦": [t: "arpão esquerdo com a farpa para cima acima do arpão direito com a farpa para cima"]	#  0x2966	(en: 'left harpoon with barb up above right harpoon with barb up', google translation)
+ - "⥧": [t: "arpão esquerdo com a farpa para baixo acima do arpão direito com a farpa para baixo"]	#  0x2967	(en: 'left harpoon with barb down above right harpoon with barb down', google translation)
+ - "⥨": [t: "arpão direito com a farpa para cima acima do arpão esquerdo com a farpa para cima"]	#  0x2968	(en: 'right harpoon with barb up above left harpoon with barb up', google translation)
+ - "⥩": [t: "arpão direito com a farpa para baixo acima do arpão esquerdo com a farpa para baixo"]	#  0x2969	(en: 'right harpoon with barb down above left harpoon with barb down', google translation)
+ - "⥪": [t: "arpão esquerdo com farpa acima do longo traço"]	#  0x296a	(en: 'left harpoon with barb up above long dash', google translation)
+ - "⥫": [t: "arpão esquerdo com farpa abaixo do traço longo"]	#  0x296b	(en: 'left harpoon with barb down below long dash', google translation)
+ - "⥬": [t: "arpão direito com farpa acima do traço longo"]	#  0x296c	(en: 'right harpoon with barb up above long dash', google translation)
+ - "⥭": [t: "arpão direito com farpa abaixo do traço longo"]	#  0x296d	(en: 'right harpoon with barb down below long dash', google translation)
+ - "⥮": [t: "arpão para cima com a farpa à esquerda ao lado do arpão para baixo com a farpa à direita"]	#  0x296e	(en: 'up harpoon with barb left beside down harpoon with barb right', google translation)
+ - "⥯": [t: "arpão para baixo com a farpa à esquerda ao lado do arpão para cima com a farpa à direita"]	#  0x296f	(en: 'down harpoon with barb left beside up harpoon with barb right', google translation)
+ - "⥰": [t: "seta dupla para a direita com ponta arredondada"]	#  0x2970	(en: 'right double arrow with rounded head', google translation)
+ - "⥱": [t: "é igual acima da seta para a direita"]	#  0x2971	(en: 'equals above right arrow', google translation)
+ - "⥲": [t: "operador til acima da seta para a direita"]	#  0x2972	(en: 'tilde operator above right arrow', google translation)
+ - "⥳": [t: "seta para a esquerda acima do operador til"]	#  0x2973	(en: 'left arrow above tilde operator', google translation)
+ - "⥴": [t: "seta para a direita acima do operador til"]	#  0x2974	(en: 'right arrow above tilde operator', google translation)
+ - "⥵": [t: "seta para a direita acima quase igual a"]	#  0x2975	(en: 'right arrow above almost equal to', google translation)
+ - "⥶": [t: "menos do que acima da seta esquerda"]	#  0x2976	(en: 'less than above left arrow', google translation)
+ - "⥷": [t: "seta para a esquerda passando por menos de"]	#  0x2977	(en: 'left arrow through less than', google translation)
+ - "⥸": [t: "maior que a seta acima para a direita"]	#  0x2978	(en: 'greater than above right arrow', google translation)
+ - "⥹": [t: "subconjunto acima da seta para a direita"]	#  0x2979	(en: 'subset above right arrow', google translation)
+ - "⥺": [t: "seta para a esquerda através do subconjunto"]	#  0x297a	(en: 'left arrow through subset', google translation)
+ - "⥻": [t: "superconjunto acima da seta para a esquerda"]	#  0x297b	(en: 'superset above left arrow', google translation)
+ - "⥼": [t: "rabo de peixe esquerdo"]           	#  0x297c	(en: 'left fish tail', google translation)
+ - "⥽": [t: "cauda de peixe direita"]           	#  0x297d	(en: 'right fish tail', google translation)
+ - "⥾": [t: "rabo de peixe"]                    	#  0x297e	(en: 'up fish tail', google translation)
+ - "⥿": [t: "rabo de peixe para baixo"]         	#  0x297f	(en: 'down fish tail', google translation)
+ - "⦀": [t: "delimitador de barra vertical tripla"]	#  0x2980	(en: 'triple vertical bar delimiter', google translation)
+ - "⦁": [t: "ponto de notação z"]               	#  0x2981	(en: 'z notation spot', google translation)
+ - "⦂": [t: "notação z tipo dois pontos"]       	#  0x2982	(en: 'z notation type colon', google translation)
+ - "⦃": [t: "chave branca esquerda"]            	#  0x2983	(en: 'left white brace', google translation)
+ - "⦄": [t: "chave branca direita"]             	#  0x2984	(en: 'right white brace', google translation)
+ - "⦅": [t: "parêntese branco esquerdo"]        	#  0x2985	(en: 'left white parenthesis', google translation)
+ - "⦆": [t: "parênteses branco direito"]        	#  0x2986	(en: 'right white parenthesis', google translation)
+ - "⦇": [t: "notação z colchete esquerdo da imagem"]	#  0x2987	(en: 'z notation left image bracket', google translation)
+ - "⦈": [t: "notação z colchete direito da imagem"]	#  0x2988	(en: 'z notation right image bracket', google translation)
+ - "⦉": [t: "notação z colchete de ligação esquerdo"]	#  0x2989	(en: 'z notation left binding bracket', google translation)
+ - "⦊": [t: "notação z colchete de ligação direito"]	#  0x298a	(en: 'z notation right binding bracket', google translation)
+ - "⦋": [t: "colchete esquerdo com barra inferior"]	#  0x298b	(en: 'left square bracket with underbar', google translation)
+ - "⦌": [t: "colchete direito com barra inferior"]	#  0x298c	(en: 'right square bracket with underbar', google translation)
+ - "⦍": [t: "colchete esquerdo com marca de seleção no canto superior"]	#  0x298d	(en: 'left square bracket with tick in top corner', google translation)
+ - "⦎": [t: "colchete direito com marca de seleção no canto inferior"]	#  0x298e	(en: 'right square bracket with tick in bottom corner', google translation)
+ - "⦏": [t: "colchete esquerdo com marca de seleção no canto inferior"]	#  0x298f	(en: 'left square bracket with tick in bottom corner', google translation)
+ - "⦐": [t: "colchete direito com marca de seleção no canto superior"]	#  0x2990	(en: 'right square bracket with tick in top corner', google translation)
+ - "⦑": [t: "colchete angular esquerdo com ponto"]	#  0x2991	(en: 'left angle bracket with dot', google translation)
+ - "⦒": [t: "colchete de ângulo reto com ponto"]	#  0x2992	(en: 'right angle bracket with dot', google translation)
+ - "⦓": [t: "arco esquerdo menor que o colchete"]	#  0x2993	(en: 'left arc less than bracket', google translation)
+ - "⦔": [t: "arco direito maior que o colchete"]	#  0x2994	(en: 'right arc greater than bracket', google translation)
+ - "⦕": [t: "arco duplo esquerdo maior que o colchete"]	#  0x2995	(en: 'double left arc greater than bracket', google translation)
+ - "⦖": [t: "arco duplo à direita menor que o colchete"]	#  0x2996	(en: 'double right arc less than bracket', google translation)
+ - "⦗": [t: "suporte esquerdo de carapaça de tartaruga preta"]	#  0x2997	(en: 'left black tortoise shell bracket', google translation)
+ - "⦘": [t: "suporte direito de carapaça de tartaruga preta"]	#  0x2998	(en: 'right black tortoise shell bracket', google translation)
+ - "⦙": [t: "cerca pontilhada"]                 	#  0x2999	(en: 'dotted fence', google translation)
+ - "⦚": [t: "linha vertical em zigue-zague"]    	#  0x299a	(en: 'vertical zigzag line', google translation)
+ - "⦛": [t: "ângulo medido de abertura para a esquerda"]	#  0x299b	(en: 'measured angle opening left', google translation)
+ - "⦜": [t: "variante de ângulo reto com quadrado"]	#  0x299c	(en: 'right angle variant with square', google translation)
+ - "⦝": [t: "ângulo reto medido com ponto"]     	#  0x299d	(en: 'measured right angle with dot', google translation)
+ - "⦞": [t: "ângulo com s dentro"]              	#  0x299e	(en: 'angle with s inside', google translation)
+ - "⦟": [t: "ângulo agudo"]                     	#  0x299f	(en: 'acute angle', google translation)
+ - "⦠": [t: "abertura angular esférica à esquerda"]	#  0x29a0	(en: 'spherical angle opening left', google translation)
+ - "⦡": [t: "abertura do ângulo esférico"]      	#  0x29a1	(en: 'spherical angle opening up', google translation)
+ - "⦢": [t: "ângulo virado"]                    	#  0x29a2	(en: 'turned angle', google translation)
+ - "⦣": [t: "ângulo invertido"]                 	#  0x29a3	(en: 'reversed angle', google translation)
+ - "⦤": [t: "ângulo com a barra inferior"]      	#  0x29a4	(en: 'angle with underbar', google translation)
+ - "⦥": [t: "ângulo invertido com barra inferior"]	#  0x29a5	(en: 'reversed angle with underbar', google translation)
+ - "⦦": [t: "ângulo oblíquo abrindo"]           	#  0x29a6	(en: 'oblique angle opening up', google translation)
+ - "⦧": [t: "ângulo oblíquo abrindo para baixo"]	#  0x29a7	(en: 'oblique angle opening down', google translation)
+ - "⦨": [t: "ângulo medido com braço aberto terminando em seta apontando para cima e para a direita"]	#  0x29a8	(en: 'measured angle with open arm ending in arrow pointing up and to the right', google translation)
+ - "⦩": [t: "ângulo medido com o braço aberto terminando em seta apontando para cima e para a esquerda"]	#  0x29a9	(en: 'measured angle with open arm ending in arrow pointing up and to the left', google translation)
+ - "⦪": [t: "ângulo medido com o braço aberto terminando em seta apontando para baixo e para a direita"]	#  0x29aa	(en: 'measured angle with open arm ending in arrow pointing down and to the right', google translation)
+ - "⦫": [t: "ângulo medido com braço aberto terminando em seta apontando para baixo e para a esquerda"]	#  0x29ab	(en: 'measured angle with open arm ending in arrow pointing down and to the left', google translation)
+ - "⦬": [t: "ângulo medido com o braço aberto terminando em seta apontando para a direita e para cima"]	#  0x29ac	(en: 'measured angle with open arm ending in arrow pointing right and up', google translation)
+ - "⦭": [t: "ângulo medido com o braço aberto terminando em seta apontando para a esquerda e para cima"]	#  0x29ad	(en: 'measured angle with open arm ending in arrow pointing left and up', google translation)
+ - "⦮": [t: "ângulo medido com braço aberto terminando em seta apontando para direita e para baixo"]	#  0x29ae	(en: 'measured angle with open arm ending in arrow pointing right and down', google translation)
+ - "⦯": [t: "ângulo medido com braço aberto terminando em seta apontando para esquerda e para baixo"]	#  0x29af	(en: 'measured angle with open arm ending in arrow pointing left and down', google translation)
+ - "⦰": [t: "conjunto vazio invertido"]         	#  0x29b0	(en: 'reversed empty set', google translation)
+ - "⦱": [t: "conjunto vazio com barra superior"]	#  0x29b1	(en: 'empty set with overbar', google translation)
+ - "⦲": [t: "conjunto vazio com pequeno círculo acima"]	#  0x29b2	(en: 'empty set with small circle above', google translation)
+ - "⦳": [t: "conjunto vazio com seta para a direita acima"]	#  0x29b3	(en: 'empty set with right arrow above', google translation)
+ - "⦴": [t: "conjunto vazio com seta para a esquerda acima"]	#  0x29b4	(en: 'empty set with left arrow above', google translation)
+ - "⦵": [t: "círculo com barra horizontal"]     	#  0x29b5	(en: 'circle with horizontal bar', google translation)
+ - "⦶": [t: "barra vertical circulada"]         	#  0x29b6	(en: 'circled vertical bar', google translation)
+ - "⦷": [t: "circulado paralelamente"]          	#  0x29b7	(en: 'circled parallel', google translation)
+ - "⦸": [t: "solidus reverso circulado"]        	#  0x29b8	(en: 'circled reverse solidus', google translation)
+ - "⦹": [t: "circulado perpendicularmente"]     	#  0x29b9	(en: 'circled perpendicular', google translation)
+ - "⦺": [t: "circulado dividido por barra horizontal e metade superior dividida por barra vertical"]	#  0x29ba	(en: 'circled divided by horizontal bar and top half divided by vertical bar', google translation)
+ - "⦻": [t: "círculo com x sobreposto"]         	#  0x29bb	(en: 'circle with superimposed x', google translation)
+ - "⦼": [t: "sinal de divisão girado no sentido anti-horário circulado"]	#  0x29bc	(en: 'circled anticlockwise rotated division sign', google translation)
+ - "⦽": [t: "seta para cima através do círculo"]	#  0x29bd	(en: 'up arrow through circle', google translation)
+ - "⦾": [t: "bala branca circulada"]            	#  0x29be	(en: 'circled white bullet', google translation)
+ - "⦿": [t: "bala circulada"]                   	#  0x29bf	(en: 'circled bullet', google translation)
+ - "⧀": [t: "circulou menos que"]               	#  0x29c0	(en: 'circled less than', google translation)
+ - "⧁": [t: "circulado maior que"]              	#  0x29c1	(en: 'circled greater than', google translation)
+ - "⧂": [t: "círculo com pequeno círculo para a direita"]	#  0x29c2	(en: 'circle with small circle to the right', google translation)
+ - "⧃": [t: "círculo com dois traços horizontais para a direita"]	#  0x29c3	(en: 'circle with two horizontal strokes to the right', google translation)
+ - "⧄": [t: "barra diagonal ascendente quadrada"]	#  0x29c4	(en: 'squared rising diagonal slash', google translation)
+ - "⧅": [t: "barra diagonal descendente quadrada"]	#  0x29c5	(en: 'squared falling diagonal slash', google translation)
+ - "⧆": [t: "asterisco quadrado"]               	#  0x29c6	(en: 'squared asterisk', google translation)
+ - "⧇": [t: "pequeno círculo quadrado"]         	#  0x29c7	(en: 'squared small circle', google translation)
+ - "⧈": [t: "quadrado quadrado"]                	#  0x29c8	(en: 'squared square', google translation)
+ - "⧉": [t: "dois quadrados unidos"]            	#  0x29c9	(en: 'two joined squares', google translation)
+ - "⧊": [t: "triângulo com ponto acima"]        	#  0x29ca	(en: 'triangle with dot above', google translation)
+ - "⧋": [t: "triângulo com barra inferior"]     	#  0x29cb	(en: 'triangle with underbar', google translation)
+ - "⧌": [t: "s em triângulo"]                   	#  0x29cc	(en: 's in triangle', google translation)
+ - "⧍": [t: "triângulo com serifas na parte inferior"]	#  0x29cd	(en: 'triangle with serifs at bottom', google translation)
+ - "⧎": [t: "triângulo retângulo acima do triângulo esquerdo"]	#  0x29ce	(en: 'right triangle above left triangle', google translation)
+ - "⧏": [t: "triângulo esquerdo ao lado da barra vertical"]	#  0x29cf	(en: 'left triangle beside vertical bar', google translation)
+ - "⧐": [t: "barra vertical ao lado do triângulo retângulo"]	#  0x29d0	(en: 'vertical bar beside right triangle', google translation)
+ - "⧑": [t: "gravata borboleta com metade esquerda preta"]	#  0x29d1	(en: 'bowtie with left half black', google translation)
+ - "⧒": [t: "gravata borboleta com metade direita preta"]	#  0x29d2	(en: 'bowtie with right half black', google translation)
+ - "⧓": [t: "gravata borboleta preta"]          	#  0x29d3	(en: 'black bowtie', google translation)
+ - "⧔": [t: "vezes com a metade esquerda preta"]	#  0x29d4	(en: 'times with left half black', google translation)
+ - "⧕": [t: "vezes com metade direita preta"]   	#  0x29d5	(en: 'times with right half black', google translation)
+ - "⧖": [t: "ampulheta branca"]                 	#  0x29d6	(en: 'white hourglass', google translation)
+ - "⧗": [t: "ampulheta preta"]                  	#  0x29d7	(en: 'black hourglass', google translation)
+ - "⧘": [t: "cerca esquerda ondulada"]          	#  0x29d8	(en: 'left wiggly fence', google translation)
+ - "⧙": [t: "cerca ondulada direita"]           	#  0x29d9	(en: 'right wiggly fence', google translation)
+ - "⧚": [t: "esquerda cerca dupla ondulada"]    	#  0x29da	(en: 'left double wiggly fence', google translation)
+ - "⧛": [t: "cerca dupla direita e ondulada"]   	#  0x29db	(en: 'right double wiggly fence', google translation)
+ - "⧜": [t: "infinito incompleto"]              	#  0x29dc	(en: 'incomplete infinity', google translation)
+ - "⧝": [t: "amarrar no infinito"]              	#  0x29dd	(en: 'tie over infinity', google translation)
+ - "⧞": [t: "infinito negado com barra vertical"]	#  0x29de	(en: 'infinity negated with vertical bar', google translation)
+ - "⧟": [t: "multimapa duplo"]                  	#  0x29df	(en: 'double-ended multimap', google translation)
+ - "⧠": [t: "quadrado com contorno contornado"] 	#  0x29e0	(en: 'square with contoured outline', google translation)
+ - "⧡": [t: "aumenta à medida que"]             	#  0x29e1	(en: 'increases as', google translation)
+ - "⧢": [t: "embaralhar o produto"]             	#  0x29e2	(en: 'shuffle product', google translation)
+ - "⧣": [t: "sinal de igual e paralelo inclinado"]	#  0x29e3	(en: 'equals sign and slanted parallel', google translation)
+ - "⧤": [t: "sinal de igual e paralelo inclinado com o til acima"]	#  0x29e4	(en: 'equals sign and slanted parallel with tilde above', google translation)
+ - "⧥": [t: "idêntico e paralelo inclinado"]    	#  0x29e5	(en: 'identical to and slanted parallel', google translation)
+ - "⧦": [t: "gleich austero"]                   	#  0x29e6	(en: 'gleich stark', google translation)
+ - "⧧": [t: "termodinâmico"]                    	#  0x29e7	(en: 'thermodynamic', google translation)
+ - "⧨": [t: "triângulo apontando para baixo com a metade esquerda preta"]	#  0x29e8	(en: 'down pointing triangle with left half black', google translation)
+ - "⧩": [t: "triângulo apontando para baixo com metade direita preta"]	#  0x29e9	(en: 'down pointing triangle with right half black', google translation)
+ - "⧪": [t: "diamante negro com seta para baixo"]	#  0x29ea	(en: 'black diamond with down arrow', google translation)
+ - "⧫": [t: "pastilha preta"]                   	#  0x29eb	(en: 'black lozenge', google translation)
+ - "⧬": [t: "círculo branco com seta para baixo"]	#  0x29ec	(en: 'white circle with down arrow', google translation)
+ - "⧭": [t: "círculo preto com seta para baixo"]	#  0x29ed	(en: 'black circle with down arrow', google translation)
+ - "⧮": [t: "quadrado branco com barras de erro"]	#  0x29ee	(en: 'error-barred white square', google translation)
+ - "⧯": [t: "quadrado preto com barras de erro"]	#  0x29ef	(en: 'error-barred black square', google translation)
+ - "⧰": [t: "diamante branco com barras de erro"]	#  0x29f0	(en: 'error-barred white diamond', google translation)
+ - "⧱": [t: "diamante negro com barras de erro"]	#  0x29f1	(en: 'error-barred black diamond', google translation)
+ - "⧲": [t: "círculo branco com barras de erro"]	#  0x29f2	(en: 'error-barred white circle', google translation)
+ - "⧳": [t: "círculo preto com barras de erro"] 	#  0x29f3	(en: 'error-barred black circle', google translation)
+ - "⧴": [t: "atrasado por regra"]               	#  0x29f4	(en: 'rule-delayed', google translation)
+ - "⧵": [t: "operador solidus reverso"]         	#  0x29f5	(en: 'reverse solidus operator', google translation)
+ - "⧶": [t: "solidus com barra superior"]       	#  0x29f6	(en: 'solidus with overbar', google translation)
+ - "⧷": [t: "solidus reverso com curso horizontal"]	#  0x29f7	(en: 'reverse solidus with horizontal stroke', google translation)
+ - "⧸": [t: "grande sólido"]                    	#  0x29f8	(en: 'big solidus', google translation)
+ - "⧹": [t: "grande solidus reverso"]           	#  0x29f9	(en: 'big reverse solidus', google translation)
+ - "⧺": [t: "duplo mais"]                       	#  0x29fa	(en: 'double plus', google translation)
+ - "⧻": [t: "triplo mais"]                      	#  0x29fb	(en: 'triple plus', google translation)
+ - "⧼": [t: "esquerda apontando colchete angular curvo"]	#  0x29fc	(en: 'left pointing curved angle bracket', google translation)
+ - "⧽": [t: "suporte de ângulo curvo apontando para a direita"]	#  0x29fd	(en: 'right pointing curved angle bracket', google translation)
+ - "⧾": [t: "pequeno"]                          	#  0x29fe	(en: 'tiny', google translation)
+ - "⧿": [t: "meu"]                              	#  0x29ff	(en: 'miny', google translation)
+ - "⨀": [t: "operador de ponto circulado"]      	#  0x2a00	(en: 'circled dot operator', google translation)
+ - "⨁": [t: "operador circulado mais"]          	#  0x2a01	(en: 'circled plus operator', google translation)
+ - "⨂": [t: "operador de tempos circulados"]    	#  0x2a02	(en: 'circled times operator', google translation)
+ - "⨃": [t: "operador de união com ponto"]      	#  0x2a03	(en: 'union operator with dot', google translation)
+ - "⨄": [t: "operador de união com mais"]       	#  0x2a04	(en: 'union operator with plus', google translation)
+ - "⨅": [t: "operador de interseção quadrada"]  	#  0x2a05	(en: 'square intersection operator', google translation)
+ - "⨆": [t: "operador de união quadrada"]       	#  0x2a06	(en: 'square union operator', google translation)
+ - "⨇": [t: "dois lógicos e operadores"]        	#  0x2a07	(en: 'two logical and operator', google translation)
+ - "⨈": [t: "dois lógicos ou operadores"]       	#  0x2a08	(en: 'two logical or operator', google translation)
+ - "⨉": [t: "operador vezes"]                   	#  0x2a09	(en: 'times operator', google translation)
+ - "⨊": [t: "módulo dois soma"]                 	#  0x2a0a	(en: 'modulo two sum', google translation)
+ - "⨋": [t: "soma com integral"]                	#  0x2a0b	(en: 'summation with integral', google translation)
+ - "⨌": [t: "operador integral quádruplo"]      	#  0x2a0c	(en: 'quadruple integral operator', google translation)
+ - "⨍": [t: "integral de parte finita"]         	#  0x2a0d	(en: 'finite part integral', google translation)
+ - "⨎": [t: "integral com curso duplo"]         	#  0x2a0e	(en: 'integral with double stroke', google translation)
+ - "⨏": [t: "média integral com barra"]         	#  0x2a0f	(en: 'integral average with slash', google translation)
+ - "⨐": [t: "função de circulação"]             	#  0x2a10	(en: 'circulation function', google translation)
+ - "⨑": [t: "integração no sentido anti-horário"]	#  0x2a11	(en: 'anticlockwise integration', google translation)
+ - "⨒": [t: "integração de linha com caminho retangular ao redor do poste"]	#  0x2a12	(en: 'line integration with rectangular path around pole', google translation)
+ - "⨓": [t: "integração de linha com caminho semicircular em torno do pólo"]	#  0x2a13	(en: 'line integration with semicircular path around pole', google translation)
+ - "⨔": [t: "integração de linha não incluindo o pólo"]	#  0x2a14	(en: 'line integration not including the pole', google translation)
+ - "⨕": [t: "integral em torno de um operador de ponto"]	#  0x2a15	(en: 'integral around a point operator', google translation)
+ - "⨖": [t: "operador integral de quatérnio"]   	#  0x2a16	(en: 'quaternion integral operator', google translation)
+ - "⨗": [t: "integral com seta para a esquerda com gancho"]	#  0x2a17	(en: 'integral with left arrow with hook', google translation)
+ - "⨘": [t: "integral com sinal de tempo"]      	#  0x2a18	(en: 'integral with times sign', google translation)
+ - "⨙": [t: "integral com intersecção"]         	#  0x2a19	(en: 'integral with intersection', google translation)
+ - "⨚": [t: "integral com a união"]             	#  0x2a1a	(en: 'integral with union', google translation)
+ - "⨛": [t: "integral com a barra superior"]    	#  0x2a1b	(en: 'integral with overbar', google translation)
+ - "⨜": [t: "integral com a barra inferior"]    	#  0x2a1c	(en: 'integral with underbar', google translation)
+ - "⨝": [t: "juntar"]                           	#  0x2a1d	(en: 'join', google translation)
+ - "⨞": [t: "operador de triângulo esquerdo grande"]	#  0x2a1e	(en: 'large left triangle operator', google translation)
+ - "⨟": [t: "composição do esquema de notação z"]	#  0x2a1f	(en: 'z notation schema composition', google translation)
+ - "⨠": [t: "tubulação de esquema de notação z"]	#  0x2a20	(en: 'z notation schema piping', google translation)
+ - "⨡": [t: "projeção do esquema de notação z"] 	#  0x2a21	(en: 'z notation schema projection', google translation)
+ - "⨢": [t: "sinal de mais com círculo acima"]  	#  0x2a22	(en: 'plus sign with circle above', google translation)
+ - "⨣": [t: "sinal de mais com acento circunflexo acima"]	#  0x2a23	(en: 'plus sign with circumflex accent above', google translation)
+ - "⨤": [t: "sinal de mais com til acima"]      	#  0x2a24	(en: 'plus sign with tilde above', google translation)
+ - "⨥": [t: "sinal de mais com ponto abaixo"]   	#  0x2a25	(en: 'plus sign with dot below', google translation)
+ - "⨦": [t: "sinal de mais com til abaixo"]     	#  0x2a26	(en: 'plus sign with tilde below', google translation)
+ - "⨧": [t: "sinal de mais com subscrito dois"] 	#  0x2a27	(en: 'plus sign with subscript two', google translation)
+ - "⨨": [t: "sinal de mais com triângulo preto"]	#  0x2a28	(en: 'plus sign with black triangle', google translation)
+ - "⨩": [t: "sinal de menos com vírgula acima"] 	#  0x2a29	(en: 'minus sign with comma above', google translation)
+ - "⨪": [t: "sinal de menos com ponto abaixo"]  	#  0x2a2a	(en: 'minus sign with dot below', google translation)
+ - "⨫": [t: "sinal de menos com pontos caindo"] 	#  0x2a2b	(en: 'minus sign with falling dots', google translation)
+ - "⨬": [t: "sinal de menos com pontos ascendentes"]	#  0x2a2c	(en: 'minus sign with rising dots', google translation)
+ - "⨭": [t: "sinal de mais no semicírculo esquerdo"]	#  0x2a2d	(en: 'plus sign in left half circle', google translation)
+ - "⨮": [t: "sinal de mais no semicírculo direito"]	#  0x2a2e	(en: 'plus sign in right half circle', google translation)
+ - "⨯":                                         	#  0x2a2f
+      - test: 
+         if: "$Verbosity='Terse'"
+         then: [t: "cruzar"]                    	# 	(en: 'cross', google translation)
+         else: [t: "produto vetorial"]          	# 	(en: 'cross product', google translation)
+ - "⨰": [t: "sinal de multiplicação com ponto acima"]	#  0x2a30	(en: 'multiplication sign with dot above', google translation)
+ - "⨱": [t: "sinal de multiplicação com barra inferior"]	#  0x2a31	(en: 'multiplication sign with underbar', google translation)
+ - "⨲": [t: "produto semidireto com fundo fechado"]	#  0x2a32	(en: 'semidirect product with bottom closed', google translation)
+ - "⨳": [t: "esmagar produto"]                  	#  0x2a33	(en: 'smash product', google translation)
+ - "⨴": [t: "sinal de multiplicação no semicírculo esquerdo"]	#  0x2a34	(en: 'multiplication sign in left half circle', google translation)
+ - "⨵": [t: "sinal de multiplicação no semicírculo direito"]	#  0x2a35	(en: 'multiplication sign in right half circle', google translation)
+ - "⨶": [t: "sinal de multiplicação circulado com acento circunflexo"]	#  0x2a36	(en: 'circled multiplication sign with circumflex accent', google translation)
+ - "⨷": [t: "sinal de multiplicação em círculo duplo"]	#  0x2a37	(en: 'multiplication sign in double circle', google translation)
+ - "⨸": [t: "sinal de divisão circulado"]       	#  0x2a38	(en: 'circled division sign', google translation)
+ - "⨹": [t: "sinal de mais no triângulo"]       	#  0x2a39	(en: 'plus sign in triangle', google translation)
+ - "⨺": [t: "sinal de menos no triângulo"]      	#  0x2a3a	(en: 'minus sign in triangle', google translation)
+ - "⨻": [t: "sinal de multiplicação no triângulo"]	#  0x2a3b	(en: 'multiplication sign in triangle', google translation)
+ - "⨼": [t: "produto interno"]                  	#  0x2a3c	(en: 'interior product', google translation)
+ - "⨽": [t: "produto interior à direita"]       	#  0x2a3d	(en: 'righthand interior product', google translation)
+ - "⨾": [t: "composição relacional da notação z"]	#  0x2a3e	(en: 'z notation relational composition', google translation)
+ - "⨿": [t: "amálgama ou coproduto"]            	#  0x2a3f	(en: 'amalgamation or coproduct', google translation)
+ - "⩀": [t: "interseção com ponto"]             	#  0x2a40	(en: 'intersection with dot', google translation)
+ - "⩁": [t: "união com sinal de menos"]         	#  0x2a41	(en: 'union with minus sign', google translation)
+ - "⩂": [t: "união com overbar"]                	#  0x2a42	(en: 'union with overbar', google translation)
+ - "⩃": [t: "interseção com a barra superior"]  	#  0x2a43	(en: 'intersection with overbar', google translation)
+ - "⩄": [t: "interseção com lógico e"]          	#  0x2a44	(en: 'intersection with logical and', google translation)
+ - "⩅": [t: "união com ou lógico"]              	#  0x2a45	(en: 'union with logical or', google translation)
+ - "⩆": [t: "união acima da interseção"]        	#  0x2a46	(en: 'union above intersection', google translation)
+ - "⩇": [t: "interseção acima da união"]        	#  0x2a47	(en: 'intersection above union', google translation)
+ - "⩈": [t: "união acima da barra acima da interseção"]	#  0x2a48	(en: 'union above bar above intersection', google translation)
+ - "⩉": [t: "interseção acima da barra acima da união"]	#  0x2a49	(en: 'intersection above bar above union', google translation)
+ - "⩊": [t: "união ao lado e unida com união"]  	#  0x2a4a	(en: 'union beside and joined with union', google translation)
+ - "⩋": [t: "interseção ao lado e unida à interseção"]	#  0x2a4b	(en: 'intersection beside and joined with intersection', google translation)
+ - "⩌": [t: "união fechada com serifas"]        	#  0x2a4c	(en: 'closed union with serifs', google translation)
+ - "⩍": [t: "intersecção fechada com serifas"]  	#  0x2a4d	(en: 'closed intersection with serifs', google translation)
+ - "⩎": [t: "interseção quadrada dupla"]        	#  0x2a4e	(en: 'double square intersection', google translation)
+ - "⩏": [t: "união quadrada dupla"]             	#  0x2a4f	(en: 'double square union', google translation)
+ - "⩐": [t: "união fechada com serifas e produto smash"]	#  0x2a50	(en: 'closed union with serifs and smash product', google translation)
+ - "⩑": [t: "lógico e com ponto acima"]         	#  0x2a51	(en: 'logical and with dot above', google translation)
+ - "⩒": [t: "lógico ou com ponto acima"]        	#  0x2a52	(en: 'logical or with dot above', google translation)
+ - "⩓": [t: "duplo lógico e"]                   	#  0x2a53	(en: 'double logical and', google translation)
+ - "⩔": [t: "duplo lógico ou"]                  	#  0x2a54	(en: 'double logical or', google translation)
+ - "⩕": [t: "dois que se cruzam lógicos e"]     	#  0x2a55	(en: 'two intersecting logical and', google translation)
+ - "⩖": [t: "dois que se cruzam lógicos ou"]    	#  0x2a56	(en: 'two intersecting logical or', google translation)
+ - "⩗": [t: "inclinado grande ou"]              	#  0x2a57	(en: 'sloping large or', google translation)
+ - "⩘": [t: "inclinado grande e"]               	#  0x2a58	(en: 'sloping large and', google translation)
+ - "⩙": [t: "lógico ou lógico sobreposto e"]    	#  0x2a59	(en: 'logical or overlapping logical and', google translation)
+ - "⩚": [t: "lógico e com haste intermediária"] 	#  0x2a5a	(en: 'logical and with middle stem', google translation)
+ - "⩛": [t: "lógico ou com radical intermediário"]	#  0x2a5b	(en: 'logical or with middle stem', google translation)
+ - "⩜": [t: "lógico e com traço horizontal"]    	#  0x2a5c	(en: 'logical and with horizontal dash', google translation)
+ - "⩝": [t: "lógico ou com traço horizontal"]   	#  0x2a5d	(en: 'logical or with horizontal dash', google translation)
+ - "⩞": [t: "lógico e com overbar duplo"]       	#  0x2a5e	(en: 'logical and with double overbar', google translation)
+ - "⩟": [t: "lógico e com underbar"]            	#  0x2a5f	(en: 'logical and with underbar', google translation)
+ - "⩠": [t: "lógico e com barra inferior dupla"]	#  0x2a60	(en: 'logical and with double underbar', google translation)
+ - "⩡": [t: "pequeno v com barra inferior"]     	#  0x2a61	(en: 'small vee with underbar', google translation)
+ - "⩢": [t: "lógico ou com overbar duplo"]      	#  0x2a62	(en: 'logical or with double overbar', google translation)
+ - "⩣": [t: "lógico ou com barra inferior dupla"]	#  0x2a63	(en: 'logical or with double underbar', google translation)
+ - "⩤": [t: "antirrestrição de domínio de notação z"]	#  0x2a64	(en: 'z notation domain antirestriction', google translation)
+ - "⩥": [t: "anti-restrição do intervalo de notação z"]	#  0x2a65	(en: 'z notation range antirestriction', google translation)
+ - "⩦": [t: "sinal de igual com ponto abaixo"]  	#  0x2a66	(en: 'equals sign with dot below', google translation)
+ - "⩧": [t: "idêntico ao ponto acima"]          	#  0x2a67	(en: 'identical with dot above', google translation)
+ - "⩨": [t: "barra horizontal tripla com curso vertical duplo"]	#  0x2a68	(en: 'triple horizontal bar with double vertical stroke', google translation)
+ - "⩩": [t: "barra horizontal tripla com curso vertical triplo"]	#  0x2a69	(en: 'triple horizontal bar with triple vertical stroke', google translation)
+ - "⩪": [t: "operador til com ponto acima"]     	#  0x2a6a	(en: 'tilde operator with dot above', google translation)
+ - "⩫": [t: "operador til com pontos ascendentes"]	#  0x2a6b	(en: 'tilde operator with rising dots', google translation)
+ - "⩬": [t: "semelhante menos semelhante"]      	#  0x2a6c	(en: 'similar minus similar', google translation)
+ - "⩭": [t: "congruente com o ponto acima"]     	#  0x2a6d	(en: 'congruent with dot above', google translation)
+ - "⩮": [t: "é igual a asterisco"]              	#  0x2a6e	(en: 'equals with asterisk', google translation)
+ - "⩯": [t: "quase igual ao acento circunflexo"]	#  0x2a6f	(en: 'almost equal to with circumflex accent', google translation)
+ - "⩰": [t: "aproximadamente igual ou igual a"] 	#  0x2a70	(en: 'approximately equal to or equal to', google translation)
+ - "⩱": [t: "sinal de igual acima do sinal de mais"]	#  0x2a71	(en: 'equals sign above plus sign', google translation)
+ - "⩲": [t: "sinal de mais acima do sinal de igual"]	#  0x2a72	(en: 'plus sign above equals sign', google translation)
+ - "⩳": [t: "sinal de igual acima do operador til"]	#  0x2a73	(en: 'equals sign above tilde operator', google translation)
+ - "⩴": [t: "dois pontos duplos iguais"]        	#  0x2a74	(en: 'double colon equal', google translation)
+ - "⩵": [t: "dois sinais de igual consecutivos"]	#  0x2a75	(en: 'two consecutive equals signs', google translation)
+ - "⩶": [t: "três sinais de igual consecutivos"]	#  0x2a76	(en: 'three consecutive equals signs', google translation)
+ - "⩷": [t: "sinal de igual com dois pontos acima e dois pontos abaixo"]	#  0x2a77	(en: 'equals sign with two dots above and two dots below', google translation)
+ - "⩸": [t: "equivalente com quatro pontos acima"]	#  0x2a78	(en: 'equivalent with four dots above', google translation)
+ - "⩹": [t: "menos do que com círculo dentro"]  	#  0x2a79	(en: 'less than with circle inside', google translation)
+ - "⩺": [t: "maior do que com círculo dentro"]  	#  0x2a7a	(en: 'greater than with circle inside', google translation)
+ - "⩻": [t: "menos do que com ponto de interrogação acima"]	#  0x2a7b	(en: 'less than with question mark above', google translation)
+ - "⩼": [t: "maior do que com o ponto de interrogação acima"]	#  0x2a7c	(en: 'greater than with question mark above', google translation)
+ - "⩽": [t: "menor ou inclinado igual a"]       	#  0x2a7d	(en: 'less than or slanted equal to', google translation)
+ - "⩾": [t: "maior ou inclinado igual a"]       	#  0x2a7e	(en: 'greater than or slanted equal to', google translation)
+ - "⩿": [t: "menor ou inclinado igual ao ponto dentro"]	#  0x2a7f	(en: 'less than or slanted equal to with dot inside', google translation)
+ - "⪀": [t: "maior ou inclinado igual ao ponto dentro"]	#  0x2a80	(en: 'greater than or slanted equal to with dot inside', google translation)
+ - "⪁": [t: "menor ou inclinado igual ao ponto acima"]	#  0x2a81	(en: 'less than or slanted equal to with dot above', google translation)
+ - "⪂": [t: "maior ou inclinado igual ao ponto acima"]	#  0x2a82	(en: 'greater than or slanted equal to with dot above', google translation)
+ - "⪃": [t: "menor ou inclinado igual ao ponto acima à direita"]	#  0x2a83	(en: 'less than or slanted equal to with dot above right', google translation)
+ - "⪄": [t: "maior ou inclinado igual ao ponto acima à esquerda"]	#  0x2a84	(en: 'greater than or slanted equal to with dot above left', google translation)
+ - "⪅": [t: "menor ou aproximado"]              	#  0x2a85	(en: 'less than or approximate', google translation)
+ - "⪆": [t: "maior ou aproximado"]              	#  0x2a86	(en: 'greater than or approximate', google translation)
+ - "⪇": [t: "menor que e linha única diferente de"]	#  0x2a87	(en: 'less than and single line not equal to', google translation)
+ - "⪈": [t: "maior que e linha única diferente de"]	#  0x2a88	(en: 'greater than and single line not equal to', google translation)
+ - "⪉": [t: "menor que e não aproximado"]       	#  0x2a89	(en: 'less than and not approximate', google translation)
+ - "⪊": [t: "maior que e não aproximado"]       	#  0x2a8a	(en: 'greater than and not approximate', google translation)
+ - "⪋": [t: "menor que acima da linha dupla igual acima de maior que"]	#  0x2a8b	(en: 'less than above double line equal above greater than', google translation)
+ - "⪌": [t: "maior que acima da linha dupla igual acima de menor que"]	#  0x2a8c	(en: 'greater than above double line equal above less than', google translation)
+ - "⪍": [t: "menor que acima semelhante ou igual"]	#  0x2a8d	(en: 'less than above similar or equal', google translation)
+ - "⪎": [t: "maior que acima de semelhante ou igual"]	#  0x2a8e	(en: 'greater than above similar or equal', google translation)
+ - "⪏": [t: "menor que acima semelhante acima maior que"]	#  0x2a8f	(en: 'less than above similar above greater than', google translation)
+ - "⪐": [t: "maior que acima semelhante acima menor que"]	#  0x2a90	(en: 'greater than above similar above less than', google translation)
+ - "⪑": [t: "menor que acima maior que acima da linha dupla igual"]	#  0x2a91	(en: 'less than above greater than above double line equal', google translation)
+ - "⪒": [t: "maior que acima menor que acima da linha dupla igual"]	#  0x2a92	(en: 'greater than above less than above double line equal', google translation)
+ - "⪓": [t: "menor que acima inclinado igual acima maior que acima inclinado igual"]	#  0x2a93	(en: 'less than above slanted equal above greater than above slanted equal', google translation)
+ - "⪔": [t: "maior que acima inclinado igual acima menor que acima inclinado igual"]	#  0x2a94	(en: 'greater than above slanted equal above less than above slanted equal', google translation)
+ - "⪕": [t: "inclinado igual ou menor que"]     	#  0x2a95	(en: 'slanted equal to or less than', google translation)
+ - "⪖": [t: "inclinado igual ou maior que"]     	#  0x2a96	(en: 'slanted equal to or greater than', google translation)
+ - "⪗": [t: "inclinado igual ou menor que o ponto dentro"]	#  0x2a97	(en: 'slanted equal to or less than with dot inside', google translation)
+ - "⪘": [t: "inclinado igual ou maior que o ponto dentro"]	#  0x2a98	(en: 'slanted equal to or greater than with dot inside', google translation)
+ - "⪙": [t: "linha dupla igual ou menor que"]   	#  0x2a99	(en: 'double line equal to or less than', google translation)
+ - "⪚": [t: "linha dupla igual ou maior que"]   	#  0x2a9a	(en: 'double line equal to or greater than', google translation)
+ - "⪛": [t: "linha dupla inclinada igual ou menor que"]	#  0x2a9b	(en: 'double line slanted equal to or less than', google translation)
+ - "⪜": [t: "linha dupla inclinada igual ou maior que"]	#  0x2a9c	(en: 'double line slanted equal to or greater than', google translation)
+ - "⪝": [t: "semelhante ou menor que"]          	#  0x2a9d	(en: 'similar or less than', google translation)
+ - "⪞": [t: "semelhante ou maior que"]          	#  0x2a9e	(en: 'similar or greater than', google translation)
+ - "⪟": [t: "semelhante acima menor que acima sinal de igual"]	#  0x2a9f	(en: 'similar above less than above equals sign', google translation)
+ - "⪠": [t: "semelhante acima maior que acima sinal de igual"]	#  0x2aa0	(en: 'similar above greater than above equals sign', google translation)
+ - "⪡": [t: "duplo aninhado menor que"]         	#  0x2aa1	(en: 'double nested less than', google translation)
+ - "⪢": [t: "duplo aninhado maior que"]         	#  0x2aa2	(en: 'double nested greater than', google translation)
+ - "⪣": [t: "duplo aninhado menos do que com barra inferior"]	#  0x2aa3	(en: 'double nested less than with underbar', google translation)
+ - "⪤": [t: "maior que sobreposto menor que"]   	#  0x2aa4	(en: 'greater than overlapping less than', google translation)
+ - "⪥": [t: "maior que ao lado de menor que"]   	#  0x2aa5	(en: 'greater than beside less than', google translation)
+ - "⪦": [t: "menos que fechado pela curva"]     	#  0x2aa6	(en: 'less than closed by curve', google translation)
+ - "⪧": [t: "maior que fechado pela curva"]     	#  0x2aa7	(en: 'greater than closed by curve', google translation)
+ - "⪨": [t: "menos que fechado por curva acima inclinada igual"]	#  0x2aa8	(en: 'less than closed by curve above slanted equal', google translation)
+ - "⪩": [t: "maior que fechado por curva acima inclinada igual"]	#  0x2aa9	(en: 'greater than closed by curve above slanted equal', google translation)
+ - "⪪": [t: "menor que"]                        	#  0x2aaa	(en: 'smaller than', google translation)
+ - "⪫": [t: "maior que"]                        	#  0x2aab	(en: 'larger than', google translation)
+ - "⪬": [t: "menor ou igual a"]                 	#  0x2aac	(en: 'smaller than or equal to', google translation)
+ - "⪭": [t: "maior ou igual a"]                 	#  0x2aad	(en: 'larger than or equal to', google translation)
+ - "⪮": [t: "sinal de igual com irregularidade acima"]	#  0x2aae	(en: 'equals sign with bumpy above', google translation)
+ - "⪯": [t: "precede acima da linha única sinal de igual"]	#  0x2aaf	(en: 'precedes above single line equals sign', google translation)
+ - "⪰": [t: "tem sucesso acima da linha única do sinal de igual"]	#  0x2ab0	(en: 'succeeds above single line equals sign', google translation)
+ - "⪱": [t: "precede a linha única acima diferente de"]	#  0x2ab1	(en: 'precedes above single line not equal to', google translation)
+ - "⪲": [t: "tem sucesso acima de uma única linha diferente de"]	#  0x2ab2	(en: 'succeeds above single line not equal to', google translation)
+ - "⪳": [t: "precede o sinal de igual acima"]   	#  0x2ab3	(en: 'precedes above equals sign', google translation)
+ - "⪴": [t: "tem sucesso acima do sinal de igual"]	#  0x2ab4	(en: 'succeeds above equals sign', google translation)
+ - "⪵": [t: "precede acima não é igual a"]      	#  0x2ab5	(en: 'precedes above not equal to', google translation)
+ - "⪶": [t: "tem sucesso acima não igual a"]    	#  0x2ab6	(en: 'succeeds above not equal to', google translation)
+ - "⪷": [t: "precede acima quase igual a"]      	#  0x2ab7	(en: 'precedes above almost equal to', google translation)
+ - "⪸": [t: "tem sucesso acima de quase igual a"]	#  0x2ab8	(en: 'succeeds above almost equal to', google translation)
+ - "⪹": [t: "precede acima não é quase igual a"]	#  0x2ab9	(en: 'precedes above not almost equal to', google translation)
+ - "⪺": [t: "consegue acima não quase igual a"] 	#  0x2aba	(en: 'succeeds above not almost equal to', google translation)
+ - "⪻": [t: "duplo precede"]                    	#  0x2abb	(en: 'double precedes', google translation)
+ - "⪼": [t: "duplo é bem-sucedido"]             	#  0x2abc	(en: 'double succeeds', google translation)
+ - "⪽": [t: "subconjunto com ponto"]            	#  0x2abd	(en: 'subset with dot', google translation)
+ - "⪾": [t: "superconjunto com ponto"]          	#  0x2abe	(en: 'superset with dot', google translation)
+ - "⪿": [t: "subconjunto com sinal de mais abaixo"]	#  0x2abf	(en: 'subset with plus sign below', google translation)
+ - "⫀": [t: "superconjunto com sinal de mais abaixo"]	#  0x2ac0	(en: 'superset with plus sign below', google translation)
+ - "⫁": [t: "subconjunto com sinal de multiplicação abaixo"]	#  0x2ac1	(en: 'subset with multiplication sign below', google translation)
+ - "⫂": [t: "superconjunto com sinal de multiplicação abaixo"]	#  0x2ac2	(en: 'superset with multiplication sign below', google translation)
+ - "⫃": [t: "subconjunto ou igual ao ponto acima"]	#  0x2ac3	(en: 'subset of or equal to with dot above', google translation)
+ - "⫄": [t: "superconjunto ou igual ao ponto acima"]	#  0x2ac4	(en: 'superset of or equal to with dot above', google translation)
+ - "⫅": [t: "subconjunto do sinal de igual acima"]	#  0x2ac5	(en: 'subset of above equals sign', google translation)
+ - "⫆": [t: "superconjunto do sinal de igual acima"]	#  0x2ac6	(en: 'superset of above equals sign', google translation)
+ - "⫇": [t: "subconjunto do operador til acima"]	#  0x2ac7	(en: 'subset of above tilde operator', google translation)
+ - "⫈": [t: "superconjunto do operador til acima"]	#  0x2ac8	(en: 'superset of above tilde operator', google translation)
+ - "⫉": [t: "subconjunto acima quase igual a"]  	#  0x2ac9	(en: 'subset of above almost equal to', google translation)
+ - "⫊": [t: "superconjunto acima quase igual a"]	#  0x2aca	(en: 'superset of above almost equal to', google translation)
+ - "⫋": [t: "subconjunto acima não é igual a"]  	#  0x2acb	(en: 'subset above not equal to', google translation)
+ - "⫌": [t: "superconjunto acima não é igual a"]	#  0x2acc	(en: 'superset of above not equal to', google translation)
+ - "⫍": [t: "operador de caixa aberta quadrada esquerda"]	#  0x2acd	(en: 'square left open box operator', google translation)
+ - "⫎": [t: "operador de caixa aberta quadrada à direita"]	#  0x2ace	(en: 'square right open box operator', google translation)
+ - "⫏": [t: "subconjunto fechado"]              	#  0x2acf	(en: 'closed subset', google translation)
+ - "⫐": [t: "superconjunto fechado"]            	#  0x2ad0	(en: 'closed superset', google translation)
+ - "⫑": [t: "subconjunto fechado ou igual a"]   	#  0x2ad1	(en: 'closed subset or equal to', google translation)
+ - "⫒": [t: "superconjunto fechado ou igual a"] 	#  0x2ad2	(en: 'closed superset or equal to', google translation)
+ - "⫓": [t: "subconjunto acima do superconjunto"]	#  0x2ad3	(en: 'subset above superset', google translation)
+ - "⫔": [t: "superconjunto acima do subconjunto"]	#  0x2ad4	(en: 'superset above subset', google translation)
+ - "⫕": [t: "subconjunto acima do subconjunto"] 	#  0x2ad5	(en: 'subset above subset', google translation)
+ - "⫖": [t: "superconjunto acima do superconjunto"]	#  0x2ad6	(en: 'superset above superset', google translation)
+ - "⫗": [t: "superconjunto ao lado do subconjunto"]	#  0x2ad7	(en: 'superset beside subset', google translation)
+ - "⫘": [t: "superconjunto ao lado e unido por traço com subconjunto"]	#  0x2ad8	(en: 'superset beside and joined by dash with subset', google translation)
+ - "⫙": [t: "elemento de abertura"]             	#  0x2ad9	(en: 'element of opening down', google translation)
+ - "⫚": [t: "forcado com camiseta"]             	#  0x2ada	(en: 'pitchfork with tee top', google translation)
+ - "⫛": [t: "interseção transversal"]           	#  0x2adb	(en: 'transversal intersection', google translation)
+ - "⫝̸": [t: "bifurcação"]                       	#  0x2adc	(en: 'forking', google translation)
+ - "⫝": [t: "sem bifurcação"]                   	#  0x2add	(en: 'nonforking', google translation)
+ - "⫞": [t: "rumo curto à esquerda"]            	#  0x2ade	(en: 'short left tack', google translation)
+ - "⫟": [t: "aderência curta"]                  	#  0x2adf	(en: 'short down tack', google translation)
+ - "⫠": [t: "curta aderência"]                  	#  0x2ae0	(en: 'short up tack', google translation)
+ - "⫡": [t: "perpendicular a s"]                	#  0x2ae1	(en: 'perpendicular with s', google translation)
+ - "⫢": [t: "catraca tripla direita com barra vertical"]	#  0x2ae2	(en: 'vertical bar triple right turnstile', google translation)
+ - "⫣": [t: "catraca esquerda de barra vertical dupla"]	#  0x2ae3	(en: 'double vertical bar left turnstile', google translation)
+ - "⫤": [t: "barra vertical dupla catraca esquerda"]	#  0x2ae4	(en: 'vertical bar double left turnstile', google translation)
+ - "⫥": [t: "catraca dupla esquerda com barra vertical dupla"]	#  0x2ae5	(en: 'double vertical bar double left turnstile', google translation)
+ - "⫦": [t: "traço longo do membro esquerdo da vertical dupla"]	#  0x2ae6	(en: 'long dash from left member of double vertical', google translation)
+ - "⫧": [t: "aderência curta com barra superior"]	#  0x2ae7	(en: 'short down tack with overbar', google translation)
+ - "⫨": [t: "aderência curta com barra inferior"]	#  0x2ae8	(en: 'short up tack with underbar', google translation)
+ - "⫩": [t: "amura curta acima acima da amura curta"]	#  0x2ae9	(en: 'short up tack above short down tack', google translation)
+ - "⫪": [t: "aderência dupla"]                  	#  0x2aea	(en: 'double down tack', google translation)
+ - "⫫": [t: "dobrar a aderência"]               	#  0x2aeb	(en: 'double up tack', google translation)
+ - "⫬": [t: "traço duplo não assina"]           	#  0x2aec	(en: 'double stroke not sign', google translation)
+ - "⫭": [t: "curso duplo invertido não assina"] 	#  0x2aed	(en: 'reversed double stroke not sign', google translation)
+ - "⫮": [t: "não divide com barra de negação invertida"]	#  0x2aee	(en: 'does not divide with reversed negation slash', google translation)
+ - "⫯": [t: "linha vertical com círculo acima"] 	#  0x2aef	(en: 'vertical line with circle above', google translation)
+ - "⫰": [t: "linha vertical com círculo abaixo"]	#  0x2af0	(en: 'vertical line with circle below', google translation)
+ - "⫱": [t: "para baixo com o círculo abaixo"]  	#  0x2af1	(en: 'down tack with circle below', google translation)
+ - "⫲": [t: "paralelo ao curso horizontal"]     	#  0x2af2	(en: 'parallel with horizontal stroke', google translation)
+ - "⫳": [t: "paralelo com o operador til"]      	#  0x2af3	(en: 'parallel with tilde operator', google translation)
+ - "⫴": [t: "relação binária de barra vertical tripla"]	#  0x2af4	(en: 'triple vertical bar binary relation', google translation)
+ - "⫵": [t: "barra vertical tripla com traço horizontal"]	#  0x2af5	(en: 'triple vertical bar with horizontal stroke', google translation)
+ - "⫶": [t: "operador de dois pontos triplos"]  	#  0x2af6	(en: 'triple colon operator', google translation)
+ - "⫷": [t: "triplo aninhado menor que"]        	#  0x2af7	(en: 'triple nested less than', google translation)
+ - "⫸": [t: "triplo aninhado maior que"]        	#  0x2af8	(en: 'triple nested greater than', google translation)
+ - "⫹": [t: "linha dupla inclinada menor ou igual a"]	#  0x2af9	(en: 'double line slanted less than or equal to', google translation)
+ - "⫺": [t: "linha dupla inclinada maior ou igual a"]	#  0x2afa	(en: 'double line slanted greater than or equal to', google translation)
+ - "⫻": [t: "relação binária solidus tripla"]   	#  0x2afb	(en: 'triple solidus binary relation', google translation)
+ - "⫼": [t: "grande operador de barra vertical tripla"]	#  0x2afc	(en: 'large triple vertical bar operator', google translation)
+ - "⫽": [t: "operador solidus duplo"]           	#  0x2afd	(en: 'double solidus operator', google translation)
+ - "⫾": [t: "barra vertical branca"]            	#  0x2afe	(en: 'white vertical bar', google translation)
+ - "⫿": [t: "barra vertical branca"]            	#  0x2aff	(en: 'white vertical bar', google translation)
+ - "⬀": [t: "seta branca nordeste"]             	#  0x2b00	(en: 'north east white arrow', google translation)
+ - "⬁": [t: "seta branca noroeste"]             	#  0x2b01	(en: 'north west white arrow', google translation)
+ - "⬂": [t: "seta branca sudeste"]              	#  0x2b02	(en: 'south east white arrow', google translation)
+ - "⬃": [t: "seta branca sudoeste"]             	#  0x2b03	(en: 'south west white arrow', google translation)
+ - "⬄": [t: "seta branca esquerda direita"]     	#  0x2b04	(en: 'left right white arrow', google translation)
+ - "⬅": [t: "seta preta esquerda"]              	#  0x2b05	(en: 'left black arrow', google translation)
+ - "⬆": [t: "seta preta para cima"]             	#  0x2b06	(en: 'up black arrow', google translation)
+ - "⬇": [t: "seta preta para baixo"]            	#  0x2b07	(en: 'down black arrow', google translation)
+ - "⬈": [t: "seta preta nordeste"]              	#  0x2b08	(en: 'north east black arrow', google translation)
+ - "⬉": [t: "seta preta noroeste"]              	#  0x2b09	(en: 'north west black arrow', google translation)
+ - "⬊": [t: "seta preta sudeste"]               	#  0x2b0a	(en: 'south east black arrow', google translation)
+ - "⬋": [t: "seta preta sudoeste"]              	#  0x2b0b	(en: 'south west black arrow', google translation)
+ - "⬌": [t: "seta preta esquerda direita"]      	#  0x2b0c	(en: 'left right black arrow', google translation)
+ - "⬍": [t: "seta preta para cima e para baixo"]	#  0x2b0d	(en: 'up down black arrow', google translation)
+ - "⬎": [t: "seta para a direita com ponta para baixo"]	#  0x2b0e	(en: 'right arrow with tip down', google translation)
+ - "⬏": [t: "seta para a direita com ponta para cima"]	#  0x2b0f	(en: 'right arrow with tip up', google translation)
+ - "⬐": [t: "seta para a esquerda com ponta para baixo"]	#  0x2b10	(en: 'left arrow with tip down', google translation)
+ - "⬑": [t: "seta para a esquerda com ponta para cima"]	#  0x2b11	(en: 'left arrow with tip up', google translation)
+ - "⬒": [t: "quadrado com metade superior preta"]	#  0x2b12	(en: 'square with top half black', google translation)
+ - "⬓": [t: "quadrado com metade inferior preta"]	#  0x2b13	(en: 'square with bottom half black', google translation)
+ - "⬔": [t: "quadrado com metade diagonal superior direita preta"]	#  0x2b14	(en: 'square with upper right diagonal half black', google translation)
+ - "⬕": [t: "quadrado com metade diagonal inferior esquerda preta"]	#  0x2b15	(en: 'square with lower left diagonal half black', google translation)
+ - "⬖": [t: "diamante com metade esquerda preta"]	#  0x2b16	(en: 'diamond with left half black', google translation)
+ - "⬗": [t: "diamante com metade direita preta"]	#  0x2b17	(en: 'diamond with right half black', google translation)
+ - "⬘": [t: "diamante com metade superior preta"]	#  0x2b18	(en: 'diamond with top half black', google translation)
+ - "⬙": [t: "diamante com metade inferior preta"]	#  0x2b19	(en: 'diamond with bottom half black', google translation)
+ - "⬚": [t: "caixa"]                            	#  0x2b1a	(en: 'box', google translation)
+ - "⬛": [t: "grande quadrado preto"]            	#  0x2b1b	(en: 'black large square', google translation)
+ - "⬜": [t: "grande quadrado branco"]           	#  0x2b1c	(en: 'white large square', google translation)
+ - "⬝": [t: "quadrado preto muito pequeno"]     	#  0x2b1d	(en: 'black very small square', google translation)
+ - "⬞": [t: "quadrado branco muito pequeno"]    	#  0x2b1e	(en: 'white very small square', google translation)
+ - "⬟": [t: "pentágono negro"]                  	#  0x2b1f	(en: 'black pentagon', google translation)
+ - "⬠": [t: "pentágono branco"]                 	#  0x2b20	(en: 'white pentagon', google translation)
+ - "⬡": [t: "hexágono branco"]                  	#  0x2b21	(en: 'white hexagon', google translation)
+ - "⬢": [t: "hexágono preto"]                   	#  0x2b22	(en: 'black hexagon', google translation)
+ - "⬣": [t: "hexágono preto horizontal"]        	#  0x2b23	(en: 'horizontal black hexagon', google translation)
+ - "⬤": [t: "grande círculo preto"]             	#  0x2b24	(en: 'black large circle', google translation)
+ - "⬥": [t: "diamante médio preto"]             	#  0x2b25	(en: 'black medium diamond', google translation)
+ - "⬦": [t: "diamante médio branco"]            	#  0x2b26	(en: 'white medium diamond', google translation)
+ - "⬧": [t: "pastilha média preta"]             	#  0x2b27	(en: 'black medium lozenge', google translation)
+ - "⬨": [t: "pastilha média branca"]            	#  0x2b28	(en: 'white medium lozenge', google translation)
+ - "⬩": [t: "pequeno diamante preto"]           	#  0x2b29	(en: 'black small diamond', google translation)
+ - "⬪": [t: "losango pequeno preto"]            	#  0x2b2a	(en: 'black small lozenge', google translation)
+ - "⬫": [t: "losango pequeno branco"]           	#  0x2b2b	(en: 'white small lozenge', google translation)
+ - "⬬": [t: "elipse horizontal preta"]          	#  0x2b2c	(en: 'black horizontal ellipse', google translation)
+ - "⬭": [t: "elipse horizontal branca"]         	#  0x2b2d	(en: 'white horizontal ellipse', google translation)
+ - "⬮": [t: "elipse vertical preta"]            	#  0x2b2e	(en: 'black vertical ellipse', google translation)
+ - "⬯": [t: "elipse vertical branca"]           	#  0x2b2f	(en: 'white vertical ellipse', google translation)
+ - "⬰": [t: "seta para a esquerda com um pequeno círculo"]	#  0x2b30	(en: 'left arrow with small circle', google translation)
+ - "⬱": [t: "três setas para a esquerda"]       	#  0x2b31	(en: 'three left arrows', google translation)
+ - "⬲": [t: "seta para a esquerda com mais circulado"]	#  0x2b32	(en: 'left arrow with circled plus', google translation)
+ - "⬳": [t: "seta longa para a esquerda"]       	#  0x2b33	(en: 'long left squiggle arrow', google translation)
+ - "⬴": [t: "seta de duas pontas para a esquerda com traço vertical"]	#  0x2b34	(en: 'left two headed arrow with vertical stroke', google translation)
+ - "⬵": [t: "seta de duas pontas para a esquerda com traço vertical duplo"]	#  0x2b35	(en: 'left two headed arrow with double vertical stroke', google translation)
+ - "⬶": [t: "seta de duas pontas para a esquerda da barra"]	#  0x2b36	(en: 'left two headed arrow from bar', google translation)
+ - "⬷": [t: "seta de traço triplo de duas pontas para a esquerda"]	#  0x2b37	(en: 'left two headed triple dash arrow', google translation)
+ - "⬸": [t: "seta para a esquerda com haste pontilhada"]	#  0x2b38	(en: 'left arrow with dotted stem', google translation)
+ - "⬹": [t: "seta para a esquerda com cauda com traço vertical"]	#  0x2b39	(en: 'left arrow with tail with vertical stroke', google translation)
+ - "⬺": [t: "seta para a esquerda com cauda com traço vertical duplo"]	#  0x2b3a	(en: 'left arrow with tail with double vertical stroke', google translation)
+ - "⬻": [t: "deixou uma seta de duas cabeças com cauda"]	#  0x2b3b	(en: 'left two headed arrow with tail', google translation)
+ - "⬼": [t: "seta esquerda de duas pontas com cauda com traço vertical"]	#  0x2b3c	(en: 'left two headed arrow with tail with vertical stroke', google translation)
+ - "⬽": [t: "seta esquerda de duas pontas com cauda com traço vertical duplo"]	#  0x2b3d	(en: 'left two headed arrow with tail with double vertical stroke', google translation)
+ - "⬾": [t: "seta para a esquerda passando por x"]	#  0x2b3e	(en: 'left arrow through x', google translation)
+ - "⬿": [t: "seta de onda apontando diretamente para a esquerda"]	#  0x2b3f	(en: 'wave arrow pointing directly left', google translation)
+ - "⭀": [t: "sinal de igual acima da seta esquerda"]	#  0x2b40	(en: 'equals sign above left arrow', google translation)
+ - "⭁": [t: "operador de til reverso acima da seta para a esquerda"]	#  0x2b41	(en: 'reverse tilde operator above left arrow', google translation)
+ - "⭂": [t: "seta para a esquerda acima do reverso quase igual a"]	#  0x2b42	(en: 'left arrow above reverse almost equal to', google translation)
+ - "⭃": [t: "seta para a direita passando por maior que"]	#  0x2b43	(en: 'right arrow through greater than', google translation)
+ - "⭄": [t: "seta para a direita através do superconjunto"]	#  0x2b44	(en: 'right arrow through superset', google translation)
+ - "⭅": [t: "seta quádrupla para a esquerda"]   	#  0x2b45	(en: 'left quadruple arrow', google translation)
+ - "⭆": [t: "seta quádrupla para a direita"]    	#  0x2b46	(en: 'right quadruple arrow', google translation)
+ - "⭇": [t: "operador de til reverso acima da seta para a direita"]	#  0x2b47	(en: 'reverse tilde operator above right arrow', google translation)
+ - "⭈": [t: "seta para a direita acima do reverso quase igual a"]	#  0x2b48	(en: 'right arrow above reverse almost equal to', google translation)
+ - "⭉": [t: "operador til acima da seta para a esquerda"]	#  0x2b49	(en: 'tilde operator above left arrow', google translation)
+ - "⭊": [t: "seta para a esquerda acima quase igual a"]	#  0x2b4a	(en: 'left arrow above almost equal to', google translation)
+ - "⭋": [t: "seta para a esquerda acima do operador de til reverso"]	#  0x2b4b	(en: 'left arrow above reverse tilde operator', google translation)
+ - "⭌": [t: "seta para a direita acima do operador de til reverso"]	#  0x2b4c	(en: 'right arrow above reverse tilde operator', google translation)
+ - "⭐": [t: "estrela média branca"]             	#  0x2b50	(en: 'white medium star', google translation)
+ - "⭑": [t: "pequena estrela negra"]            	#  0x2b51	(en: 'black small star', google translation)
+ - "⭒": [t: "pequena estrela branca"]           	#  0x2b52	(en: 'white small star', google translation)
+ - "⭓": [t: "pentágono preto apontando para a direita"]	#  0x2b53	(en: 'black right pointing pentagon', google translation)
+ - "⭔": [t: "pentágono branco apontando para a direita"]	#  0x2b54	(en: 'white right pointing pentagon', google translation)
+ - "⭕": [t: "círculo grande e pesado"]          	#  0x2b55	(en: 'heavy large circle', google translation)
+ - "⭖": [t: "oval pesado com oval por dentro"]  	#  0x2b56	(en: 'heavy oval with oval inside', google translation)
+ - "⭗": [t: "círculo pesado com círculo dentro"]	#  0x2b57	(en: 'heavy circle with circle inside', google translation)
+ - "⭘": [t: "círculo pesado"]                   	#  0x2b58	(en: 'heavy circle', google translation)
+ - "⭙": [t: "saltire circulado pesado"]         	#  0x2b59	(en: 'heavy circled saltire', google translation)
+ - "⸀": [t: "marcador de substituição em ângulo reto"]	#  0x2e00	(en: 'right angle substitution marker', google translation)
+ - "⸁": [t: "marcador de substituição pontilhado em ângulo reto"]	#  0x2e01	(en: 'right angle dotted substitution marker', google translation)
+ - "⸂": [t: "colchete de substituição esquerdo"]	#  0x2e02	(en: 'left substitution bracket', google translation)
+ - "⸃": [t: "colchete de substituição direito"] 	#  0x2e03	(en: 'right substitution bracket', google translation)
+ - "⸄": [t: "colchete de substituição pontilhado à esquerda"]	#  0x2e04	(en: 'left dotted substitution bracket', google translation)
+ - "⸅": [t: "colchete de substituição pontilhado à direita"]	#  0x2e05	(en: 'right dotted substitution bracket', google translation)
+ - "⸆": [t: "marcador de interpolação elevado"] 	#  0x2e06	(en: 'raised interpolation marker', google translation)
+ - "⸇": [t: "marcador de interpolação pontilhado em relevo"]	#  0x2e07	(en: 'raised dotted interpolation marker', google translation)
+ - "⸈": [t: "marcador de transposição pontilhado"]	#  0x2e08	(en: 'dotted transposition marker marker', google translation)
+ - "⸉": [t: "colchete de transposição esquerdo"]	#  0x2e09	(en: 'left transposition bracket', google translation)
+ - "⸊": [t: "colchete de transposição direito"] 	#  0x2e0a	(en: 'right transposition bracket', google translation)
+ - "⸋": [t: "quadrado elevado"]                 	#  0x2e0b	(en: 'raised square', google translation)
+ - "⸌": [t: "colchete de omissão levantado à esquerda"]	#  0x2e0c	(en: 'left raised omission bracket', google translation)
+ - "⸍": [t: "colchete de omissão elevado à direita"]	#  0x2e0d	(en: 'right raised omission bracket', google translation)
+ - "⸎": [t: "editorial coronis"]                	#  0x2e0e	(google translation)
+ - "⸏": [t: "parágrafos"]                       	#  0x2e0f	(en: 'paragraphos', google translation)
+ - "⸐": [t: "parágrafos bifurcados"]            	#  0x2e10	(en: 'forked paragraphos', google translation)
+ - "⸑": [t: "parágrafos bifurcados invertidos"] 	#  0x2e11	(en: 'reversed forked paragraphos', google translation)
+ - "⸒": [t: "hipodiástole"]                     	#  0x2e12	(en: 'hypodiastole', google translation)
+ - "⸓": [t: "obelos pontilhados"]               	#  0x2e13	(en: 'dotted obelos', google translation)
+ - "⸔": [t: "para baixo âncora"]                	#  0x2e14	(en: 'down ancora', google translation)
+ - "⸕": [t: "para cima âncora"]                 	#  0x2e15	(en: 'up ancora', google translation)
+ - "⸖": [t: "ângulo pontilhado apontando para a direita"]	#  0x2e16	(en: 'dotted right pointing angle', google translation)
+ - "⸗": [t: "hífen duplo oblíquo"]              	#  0x2e17	(en: 'double oblique hyphen', google translation)
+ - "⸘": [t: "interrobang invertido"]            	#  0x2e18	(en: 'inverted interrobang', google translation)
+ - "⸙": [t: "ramo de palmeira"]                 	#  0x2e19	(en: 'palm branch', google translation)
+ - "⸚": [t: "hífen com diérese"]                	#  0x2e1a	(en: 'hyphen with diaeresis', google translation)
+ - "⸛": [t: "til com anel acima"]               	#  0x2e1b	(en: 'tilde with ring above', google translation)
+ - "⸜": [t: "colchete de paráfrase inferior esquerdo"]	#  0x2e1c	(en: 'left low paraphrase bracket', google translation)
+ - "⸝": [t: "colchete de paráfrase inferior direito"]	#  0x2e1d	(en: 'right low paraphrase bracket', google translation)
+ - "⸞": [t: "til com ponto acima"]              	#  0x2e1e	(en: 'tilde with dot above', google translation)
+ - "⸟": [t: "til com ponto abaixo"]             	#  0x2e1f	(en: 'tilde with dot below', google translation)
+ - "⸠": [t: "barra vertical esquerda com pena"] 	#  0x2e20	(en: 'left vertical bar with quill', google translation)
+ - "⸡": [t: "barra vertical direita com pena"]  	#  0x2e21	(en: 'right vertical bar with quill', google translation)
+ - "⸢": [t: "meio colchete superior esquerdo"]  	#  0x2e22	(en: 'top left half bracket', google translation)
+ - "⸣": [t: "meio colchete superior direito"]   	#  0x2e23	(en: 'top right half bracket', google translation)
+ - "⸤": [t: "meio colchete inferior esquerdo"]  	#  0x2e24	(en: 'bottom left half bracket', google translation)
+ - "⸥": [t: "meio colchete inferior direito"]   	#  0x2e25	(en: 'bottom right half bracket', google translation)
+ - "⸦": [t: "lado esquerdo você colchete"]      	#  0x2e26	(en: 'left sideways u bracket', google translation)
+ - "⸧": [t: "lado direito você colchete"]       	#  0x2e27	(en: 'right sideways u bracket', google translation)
+ - "⸨": [t: "parênteses duplos esquerdos"]      	#  0x2e28	(en: 'left double parentheses', google translation)
+ - "⸩": [t: "parênteses duplos à direita"]      	#  0x2e29	(en: 'right double parentheses', google translation)
+ - "⸪": [t: "dois pontos sobre pontuação de um ponto"]	#  0x2e2a	(en: 'two dots over one dot punctuation', google translation)
+ - "⸫": [t: "pontuação de um ponto sobre dois pontos"]	#  0x2e2b	(en: 'one dot over two dots punctuation', google translation)
+ - "⸬": [t: "pontuação quadrada de quatro pontos"]	#  0x2e2c	(en: 'squared four dot punctuation', google translation)
+ - "⸭": [t: "marca de cinco pontos"]            	#  0x2e2d	(en: 'five dot mark', google translation)
+ - "⸮": [t: "ponto de interrogação invertido"]  	#  0x2e2e	(en: 'reversed question mark', google translation)
+ - "ⸯ": [t: "til vertical"]                     	#  0x2e2f	(en: 'vertical tilde', google translation)
+ - "⸰": [t: "ponto de anel"]                    	#  0x2e30	(en: 'ring point', google translation)
+ - "⸱": [t: "ponto central do separador de palavras"]	#  0x2e31	(en: 'word separator middle dot', google translation)
+ - "⸲": [t: "virou vírgula"]                    	#  0x2e32	(en: 'turned comma', google translation)
+ - "⸳": [t: "ponto elevado"]                    	#  0x2e33	(en: 'raised dot', google translation)
+ - "⸴": [t: "vírgula elevada"]                  	#  0x2e34	(en: 'raised comma', google translation)
+ - "⸵": [t: "virou ponto e vírgula"]            	#  0x2e35	(en: 'turned semicolon', google translation)
+ - "⸶": [t: "adaga com guarda esquerda"]        	#  0x2e36	(en: 'dagger with left guard', google translation)
+ - "⸷": [t: "adaga com guarda direita"]         	#  0x2e37	(en: 'dagger with right guard', google translation)
+ - "⸸": [t: "virou punhal"]                     	#  0x2e38	(en: 'turned dagger', google translation)
+ - "⸹": [t: "sinal da metade superior da seção"]	#  0x2e39	(en: 'top half section sign', google translation)
+ - "⸺": [t: "dois travessões"]                  	#  0x2e3a	(en: 'two em dash', google translation)
+ - "⸻": [t: "três travessões"]                  	#  0x2e3b	(en: 'three em dash', google translation)
+ - "〃": [t: "idem marca"]                       	#  0x3003	(en: 'ditto mark', google translation)
+ - "〈": [t: "colchete angular esquerdo"]        	#  0x3008	(en: 'left angle bracket', google translation)
+ - "〉": [t: "colchete em ângulo reto"]          	#  0x3009	(en: 'right angle bracket', google translation)
+ - "《": [t: "suporte de ângulo duplo esquerdo"] 	#  0x300a	(en: 'left double angle bracket', google translation)
+ - "》": [t: "suporte de ângulo duplo direito"]  	#  0x300b	(en: 'right double angle bracket', google translation)
+ - "「": [t: "colchete do canto esquerdo"]       	#  0x300c	(en: 'left corner bracket', google translation)
+ - "」": [t: "colchete do canto direito"]        	#  0x300d	(en: 'right corner bracket', google translation)
+ - "『": [t: "colchete de canto branco esquerdo"]	#  0x300e	(en: 'left white corner bracket', google translation)
+ - "』": [t: "colchete de canto branco direito"] 	#  0x300f	(en: 'right white corner bracket', google translation)
+ - "【": [t: "suporte lenticular preto esquerdo"]	#  0x3010	(en: 'left black lenticular bracket', google translation)
+ - "】": [t: "suporte lenticular preto direito"] 	#  0x3011	(en: 'right black lenticular bracket', google translation)
+ - "〔": [t: "suporte de casco de tartaruga esquerdo"]	#  0x3014	(en: 'left tortoise shell bracket', google translation)
+ - "〕": [t: "suporte de casco de tartaruga direito"]	#  0x3015	(en: 'right tortoise shell bracket', google translation)
+ - "〖": [t: "colchete lenticular branco esquerdo"]	#  0x3016	(en: 'left white lenticular bracket', google translation)
+ - "〗": [t: "suporte lenticular branco direito"]	#  0x3017	(en: 'right white lenticular bracket', google translation)
+ - "〘": [t: "suporte de carapaça de tartaruga branca esquerda"]	#  0x3018	(en: 'left white tortoise shell bracket', google translation)
+ - "〙": [t: "suporte de carapaça de tartaruga branca direita"]	#  0x3019	(en: 'right white tortoise shell bracket', google translation)
+ - "〚": [t: "colchete branco esquerdo"]         	#  0x301a	(en: 'left white square bracket', google translation)
+ - "〛": [t: "colchete branco direito"]          	#  0x301b	(en: 'right white square bracket', google translation)
+ - "〜": [t: "traço de onda"]                    	#  0x301c	(en: 'wave dash', google translation)
+ - "〰": [t: "traço ondulado"]                   	#  0x3030	(en: 'wavy dash', google translation)
+ - "㉈": [t: "circulou o número dez no quadrado preto"]	#  0x3248	(en: 'circled number ten on black square', google translation)
+ - "㉉": [t: "circulou o número vinte no quadrado preto"]	#  0x3249	(en: 'circled number twenty on black square', google translation)
+ - "㉊": [t: "circulou o número trinta no quadrado preto"]	#  0x324a	(en: 'circled number thirty on black square', google translation)
+ - "㉋": [t: "circulou o número quarenta no quadrado dos negros"]	#  0x324b	(en: 'circled number forty on blacks square', google translation)
+ - "㉌": [t: "circulou o número cinquenta no quadrado preto"]	#  0x324c	(en: 'circled number fifty on black square', google translation)
+ - "㉍": [t: "circulou o número sessenta no quadrado preto"]	#  0x324d	(en: 'circled number sixty on black square', google translation)
+ - "㉎": [t: "circulou o número setenta no quadrado preto"]	#  0x324e	(en: 'circled number seventy on black square', google translation)
+ - "㉏": [t: "número circulado aty no quadrado preto"]	#  0x324f	(en: 'circled number eighty on black square', google translation)
+ - "㉑": [t: "circulou o número vinte e um"]     	#  0x3251	(en: 'circled number twenty one', google translation)
+ - "㉒": [t: "circulou o número vinte e dois"]   	#  0x3252	(en: 'circled number twenty two', google translation)
+ - "㉓": [t: "circulou o número vinte e três"]   	#  0x3253	(en: 'circled number twenty three', google translation)
+ - "㉔": [t: "circulou o número vinte e quatro"] 	#  0x3254	(en: 'circled number twenty four', google translation)
+ - "㉕": [t: "circulou o número vinte e cinco"]  	#  0x3255	(en: 'circled number twenty five', google translation)
+ - "㉖": [t: "circulou o número vinte e seis"]   	#  0x3256	(en: 'circled number twenty six', google translation)
+ - "㉗": [t: "circulou o número vinte e sete"]   	#  0x3257	(en: 'circled number twenty seven', google translation)
+ - "㉘": [t: "circulou o número vinte em"]       	#  0x3258	(en: 'circled number twenty eight', google translation)
+ - "㉙": [t: "circulou o número vinte e nove"]   	#  0x3259	(en: 'circled number twenty nine', google translation)
+ - "㉚": [t: "circulou o número trinta"]         	#  0x325a	(en: 'circled number thirty', google translation)
+ - "㉛": [t: "circulou o número trinta e um"]    	#  0x325b	(en: 'circled number thirty one', google translation)
+ - "㉜": [t: "circulou o número trinta e dois"]  	#  0x325c	(en: 'circled number thirty two', google translation)
+ - "㉝": [t: "circulou o número trinta e três"]  	#  0x325d	(en: 'circled number thirty three', google translation)
+ - "㉞": [t: "circulou o número trinta e quatro"]	#  0x325e	(en: 'circled number thirty four', google translation)
+ - "㉟": [t: "circulou o número trinta e cinco"] 	#  0x325f	(en: 'circled number thirty five', google translation)
+ - "㊱": [t: "circulou o número trinta e seis"]  	#  0x32b1	(en: 'circled number thirty six', google translation)
+ - "㊲": [t: "circulou o número trinta e sete"]  	#  0x32b2  (GPT-5.4 translation)	(en: 'circled number thirty seven', google translation)
+ - "㊳": [t: "circulou o número trinta em"]      	#  0x32b3  (GPT-5.4 translation)	(en: 'circled number thirty eight', google translation)
+ - "㊴": [t: "circulou o número trinta e nove"]  	#  0x32b4  (GPT-5.4 translation)	(en: 'circled number thirty nine', google translation)
+ - "㊵": [t: "circulou o número quarenta"]       	#  0x32b5  (GPT-5.4 translation)	(en: 'circled number forty', google translation)
+ - "㊶": [t: "circulou o número quarenta e um"]  	#  0x32b6  (GPT-5.4 translation)	(en: 'circled number forty one', google translation)
+ - "㊷": [t: "circulou o número quarenta e dois"]	#  0x32b7  (GPT-5.4 translation)	(en: 'circled number forty two', google translation)
+ - "㊸": [t: "circulou o número quarenta e três"]	#  0x32b8  (GPT-5.4 translation)	(en: 'circled number forty three', google translation)
+ - "㊹": [t: "circulou o número quarenta e quatro"]	#  0x32b9  (GPT-5.4 translation)	(en: 'circled number forty four', google translation)
+ - "㊺": [t: "circulou o número quarenta e cinco"]	#  0x32ba  (GPT-5.4 translation)	(en: 'circled number forty five', google translation)
+ - "㊻": [t: "circulou o número quarenta e seis"]	#  0x32bb  (GPT-5.4 translation)	(en: 'circled number forty six', google translation)
+ - "㊼": [t: "circulou o número quarenta e sete"]	#  0x32bc  (GPT-5.4 translation)	(en: 'circled number forty seven', google translation)
+ - "㊽": [t: "circulou o número quarenta em"]    	#  0x32bd  (GPT-5.4 translation)	(en: 'circled number forty eight', google translation)
+ - "㊾": [t: "circulou o número quarenta e nove"]	#  0x32be  (GPT-5.4 translation)	(en: 'circled number forty nine', google translation)
+ - "㊿": [t: "circulou o número cinquenta"]      	#  0x32bf  (GPT-5.4 translation)	(en: 'circled number fifty', google translation)
+ - "㋌": [t: "mercúrio"]                         	#  0x32cc	(en: 'mercury', google translation)
+ - "㋍": [t: "erg"]                              	#  0x32cd	(en: 'ergs', google translation)
+ - "㋎": [t: "elétron-volts"]                    	#  0x32ce	(en: 'electron volts', google translation)
+ - "㋏": [t: "sinal de responsabilidade limitada"]	#  0x32cf	(en: 'limited liability sign', google translation)
+ - "㍱": [t: "hectopascais"]                     	#  0x3371	(en: 'hectopascals', google translation)
+ - "㍲": [t: "daltons"]                          	#  0x3372	(google translation)
+ - "㍳": [t: "unidades astronômicas"]            	#  0x3373	(en: 'astronomical units', google translation)
+ - "㍴": [t: "bares"]                            	#  0x3374	(en: 'bars', google translation)
+ - "㍵": [t: "mv"]                              	#  0x3375	(google translation)
+ - "㍶": [t: "parsecs"]                          	#  0x3376	(google translation)
+ - "㍷": [t: "decímetros"]                       	#  0x3377	(en: 'decimeters', google translation)
+ - "㍸": [t: "decímetros quadrados"]             	#  0x3378	(en: 'decimeters squared', google translation)
+ - "㍹": [t: "decímetros cúbicos"]               	#  0x3379	(en: 'decimeters cubed', google translation)
+ - "㍺": [t: "unidades instrumentais"]           	#  0x337a	(en: 'instrumental units', google translation)
+ - "㎀": [t: "picoamperes"]                      	#  0x3380	(en: 'picoamps', google translation)
+ - "㎁": [t: "nanoampères"]                      	#  0x3381	(en: 'nanoamps', google translation)
+ - "㎂": [t: "microampères"]                     	#  0x3382	(en: 'microamps', google translation)
+ - "㎃": [t: "miliamperes"]                      	#  0x3383	(en: 'milliamps', google translation)
+ - "㎄": [t: "quiloampères"]                     	#  0x3384	(en: 'kiloamps', google translation)
+ - "㎅": [t: "quilobytes"]                       	#  0x3385	(en: 'kilobytes', google translation)
+ - "㎆": [t: "megabytes"]                        	#  0x3386	(google translation)
+ - "㎇": [t: "gigabytes"]                        	#  0x3387	(google translation)
+ - "㎈": [t: "calorias"]                         	#  0x3388	(en: 'calories', google translation)
+ - "㎉": [t: "quilocalorias"]                    	#  0x3389	(en: 'kilocalories', google translation)
+ - "㎊": [t: "picofarads"]                       	#  0x338a	(google translation)
+ - "㎋": [t: "nanofarads"]                       	#  0x338b	(google translation)
+ - "㎌": [t: "microfarads"]                      	#  0x338c	(google translation)
+ - "㎍": [t: "microgramas"]                      	#  0x338d	(en: 'micrograms', google translation)
+ - "㎎": [t: "miligramas"]                       	#  0x338e	(en: 'milligrams', google translation)
+ - "㎏": [t: "quilogramas"]                      	#  0x338f	(en: 'kilograms', google translation)
+ - "㎐": [t: "hertz"]                            	#  0x3390	(google translation)
+ - "㎑": [t: "quilohertz"]                       	#  0x3391	(en: 'kilohertz', google translation)
+ - "㎒": [t: "megahertz"]                        	#  0x3392	(google translation)
+ - "㎓": [t: "gigahertz"]                        	#  0x3393	(google translation)
+ - "㎔": [t: "terahertz"]                        	#  0x3394	(google translation)
+ - "㎕": [t: "microlitros"]                      	#  0x3395	(en: 'microliters', google translation)
+ - "㎖": [t: "mililitros"]                       	#  0x3396	(en: 'milliliters', google translation)
+ - "㎗": [t: "decilitros"]                       	#  0x3397	(en: 'deciliters', google translation)
+ - "㎘": [t: "quilolitros"]                      	#  0x3398	(en: 'kiloliters', google translation)
+ - "㎙": [t: "femtômetros"]                      	#  0x3399	(en: 'femtometers', google translation)
+ - "㎚": [t: "nanômetros"]                       	#  0x339a	(en: 'nanometers', google translation)
+ - "㎛": [t: "micrômetros"]                      	#  0x339b	(en: 'micrometers', google translation)
+ - "㎜": [t: "milímetros"]                       	#  0x339c	(en: 'millimeters', google translation)
+ - "㎝": [t: "centímetros"]                      	#  0x339d	(en: 'centimeters', google translation)
+ - "㎞": [t: "quilômetros"]                      	#  0x339e	(en: 'kilometers', google translation)
+ - "㎟": [t: "milímetros quadrados"]             	#  0x339f	(en: 'millimeters squared', google translation)
+ - "㎠": [t: "centímetros quadrados"]            	#  0x33a0	(en: 'centimeters squared', google translation)
+ - "㎡": [t: "metros quadrados"]                 	#  0x33a1	(en: 'meters squared', google translation)
+ - "㎢": [t: "quilômetros quadrados"]            	#  0x33a2	(en: 'kilometers squared', google translation)
+ - "㎣": [t: "milímetros cúbicos"]               	#  0x33a3	(en: 'millimeters cubed', google translation)
+ - "㎤": [t: "centímetros cúbicos"]              	#  0x33a4	(en: 'centimeters cubed', google translation)
+ - "㎥": [t: "metros cúbicos"]                   	#  0x33a5	(en: 'meters cubed', google translation)
+ - "㎦": [t: "quilômetros cúbicos"]              	#  0x33a6	(en: 'kilometers cubed', google translation)
+ - "㎧": [t: "metros por segundo"]               	#  0x33a7	(en: 'meters per second', google translation)
+ - "㎨": [t: "metros por segundo ao quadrado"]   	#  0x33a8	(en: 'meters per second squared', google translation)
+ - "㎩": [t: "pascais"]                          	#  0x33a9	(en: 'pascals', google translation)
+ - "㎪": [t: "quilopascais"]                     	#  0x33aa	(en: 'kilopascals', google translation)
+ - "㎫": [t: "megapascais"]                      	#  0x33ab	(en: 'megapascals', google translation)
+ - "㎬": [t: "gigapascais"]                      	#  0x33ac	(en: 'gigapascals', google translation)
+ - "㎭": [t: "radicais"]                         	#  0x33ad	(en: 'rads', google translation)
+ - "㎮": [t: "radianos por segundo"]             	#  0x33ae	(en: 'rads per second', google translation)
+ - "㎯": [t: "rads por segundo ao quadrado"]     	#  0x33af	(en: 'rads per second squared', google translation)
+ - "㎰": [t: "picossegundos"]                    	#  0x33b0	(en: 'picoseconds', google translation)
+ - "㎱": [t: "nanossegundos"]                    	#  0x33b1	(en: 'nanoseconds', google translation)
+ - "㎲": [t: "microssegundos"]                   	#  0x33b2	(en: 'microseconds', google translation)
+ - "㎳": [t: "milissegundos"]                    	#  0x33b3	(en: 'milliseconds', google translation)
+ - "㎴": [t: "picovolts"]                        	#  0x33b4	(google translation)
+ - "㎵": [t: "nanovolts"]                        	#  0x33b5	(google translation)
+ - "㎶": [t: "microvolts"]                       	#  0x33b6	(google translation)
+ - "㎷": [t: "milivolts"]                        	#  0x33b7	(en: 'millivolts', google translation)
+ - "㎸": [t: "quilovolts"]                       	#  0x33b8	(en: 'kilovolts', google translation)
+ - "㎹": [t: "megavolts"]                        	#  0x33b9	(google translation)
+ - "㎺": [t: "picowatts"]                        	#  0x33ba	(google translation)
+ - "㎻": [t: "nanowatts"]                        	#  0x33bb	(google translation)
+ - "㎼": [t: "microwatts"]                       	#  0x33bc	(google translation)
+ - "㎽": [t: "miliwatts"]                        	#  0x33bd	(en: 'milliwatts', google translation)
+ - "㎾": [t: "quilowatts"]                       	#  0x33be	(en: 'kilowatts', google translation)
+ - "㎿": [t: "megawatts"]                        	#  0x33bf	(google translation)
+ - "㏀": [t: "quilo-ohms"]                       	#  0x33c0	(en: 'kilo-ohms', google translation)
+ - "㏁": [t: "megaohms"]                         	#  0x33c1	(google translation)
+ - "㏂": [t: "atômetros"]                        	#  0x33c2	(en: 'attometers', google translation)
+ - "㏃": [t: "bequerels"]                        	#  0x33c3	(en: 'becquerels', google translation)
+ - "㏄": [t: "centímetros cúbicos"]              	#  0x33c4	(en: 'cubic centimeters', google translation)
+ - "㏅": [t: "candelas"]                         	#  0x33c5	(google translation)
+ - "㏆": [t: "coulombs por quilograma"]          	#  0x33c6	(en: 'coulombs per kilogram', google translation)
+ - "㏇": [t: "c maiúsculo, o, ponto final"]      	#  0x33c7 (I have no idea what this is)	(en: 'cap C, o, period', google translation)
+ - "㏈": [t: "decibéis"]                         	#  0x33c8	(en: 'decibels', google translation)
+ - "㏉": [t: "cinzas"]                           	#  0x33c9	(en: 'grays', google translation)
+ - "㏊": [t: "hectares"]                         	#  0x33ca	(google translation)
+ - "㏋": [t: "cavalos de potência"]              	#  0x33cb	(en: 'horsepower', google translation)
+ - "㏌": [t: "polegadas"]                        	#  0x33cc	(en: 'inches', google translation)
+ - "㏍": [t: "quilokelvins"]                     	#  0x33cd	(en: 'kilokelvins', google translation)
+ - "㏎": [t: "quilômetros"]                      	#  0x33ce	(en: 'kilometers', google translation)
+ - "㏏": [t: "nós"]                              	#  0x33cf	(en: 'knots', google translation)
+ - "㏐": [t: "lúmens"]                           	#  0x33d0	(en: 'lumens', google translation)
+ - "㏑": [t: "tronco natural"]                   	#  0x33d1	(en: 'natural log', google translation)
+ - "㏒": [t: "logaritmo"]                        	#  0x33d2	(en: 'logarithm', google translation)
+ - "㏓": [t: "luxo"]                             	#  0x33d3	(en: 'lux', google translation)
+ - "㏔": [t: "milibares"]                        	#  0x33d4	(en: 'millibarns', google translation)
+ - "㏕": [t: "moinhos"]                          	#  0x33d5	(en: 'mills', google translation)
+ - "㏖": [t: "toupeiras"]                        	#  0x33d6	(en: 'moles', google translation)
+ - "㏗": [t: "ph"]                               	#  0x33d7	(en: 'p h', google translation)
+ - "㏘": [t: "picômetros"]                       	#  0x33d8	(en: 'picometers', google translation)
+ - "㏙": [t: "partes por milhão"]                	#  0x33d9	(en: 'parts per million', google translation)
+ - "㏚": [t: "petaroentgens"]                    	#  0x33da	(google translation)
+ - "㏛": [t: "esterradianos"]                    	#  0x33db	(en: 'steradians', google translation)
+ - "㏜": [t: "peneiras"]                         	#  0x33dc	(en: 'sieverts', google translation)
+ - "㏝": [t: "webers"]                           	#  0x33dd	(google translation)
+ - "㏞": [t: "volts por metro"]                  	#  0x33de	(en: 'volts per meter', google translation)
+ - "㏟": [t: "amperes por metro"]                	#  0x33df	(en: 'amps per meter', google translation)
+ - "㏿": [t: "galões"]                           	#  0x33ff	(en: 'gallons', google translation)
+ - "": [t: "é igual ao chapéu abaixo"]         	#  0xe900	(en: 'equals with hat below', google translation)
+ - "": [t: "é igual a mais acima"]             	#  0xe901	(en: 'equals with plus above', google translation)
+ - "": [t: "é igual a mais abaixo"]            	#  0xe902	(en: 'equals with plus below', google translation)
+ - "": [t: "til com mais acima"]               	#  0xe903	(en: 'tilde with plus above', google translation)
+ - "": [t: "til com mais abaixo"]              	#  0xe904	(en: 'tilde with plus below', google translation)
+ - "": [t: "igual duplo sobre maior que"]      	#  0xe908	(en: 'equal double over greater than', google translation)
+ - "": [t: "igual duplo sobre menos que"]      	#  0xe909	(en: 'equal double over less than', google translation)
+ - "": [t: "contém ou igual a"]                	#  0xe90a	(en: 'contains or equal to', google translation)
+ - "": [t: "superconjunto de ou igual a"]      	#  0xe90b	(en: 'superset of or equal to', google translation)
+ - "": [t: "subconjunto de ou igual a"]        	#  0xe90c	(en: 'subset of or equal to', google translation)
+ - "": [t: "igual sobre menos que"]            	#  0xe90d	(en: 'equal over less than', google translation)
+ - "": [t: "elemento de ou igual a"]           	#  0xe912	(en: 'element of or equal to', google translation)
+ - "": [t: "igual ou maior que"]               	#  0xe913	(en: 'equal to or greater than', google translation)
+ - "": [t: "superconjunto aproximado de"]      	#  0xe914	(en: 'approximate superset of', google translation)
+ - "": [t: "subconjunto aproximado de"]        	#  0xe915	(en: 'approximate subset of', google translation)
+ - "": [t: "superconjunto de com ponto inclui como sub-relação"]	#  0xe916	(en: 'superset of with dot includes as sub relation', google translation)
+ - "": [t: "subconjunto de com ponto é incluído como sub-relação"]	#  0xe917	(en: 'subset of with dot is included in as sub relation', google translation)
+ - "": [t: "igual ao ponto abaixo"]            	#  0xe918	(en: 'equal with dot below', google translation)
+ - "": [t: "ponto esquerdo sobre menos sobre o ponto direito"]	#  0xe919	(en: 'left dot over minus over right dot', google translation)
+ - "": [t: "ponto direito sobre menos sobre o ponto esquerdo"]	#  0xe91a	(en: 'right dot over minus over left dot', google translation)
+ - "": [t: "quase igual a menos"]              	#  0xe91f	(en: 'almost equal to minus', google translation)
+ - "": [t: "xícara quadrada dupla"]            	#  0xe920	(en: 'double square cup', google translation)
+ - "": [t: "duplo quadrado maiúsculo"]         	#  0xe921	(en: 'double square cap', google translation)
+ - "": [t: "menor que igual ou maior que"]     	#  0xe922	(en: 'less than equal to or greater than', google translation)
+ - "": [t: "til com ponto"]                    	#  0xe924	(en: 'tilde with dot', google translation)
+ - "": [t: "til com dois pontos"]              	#  0xe925	(en: 'tilde with two dots', google translation)
+ - "": [t: "menor que maior ou igual a"]       	#  0xe926	(en: 'less than greater than or equal to', google translation)
+ - "": [t: "maior que menor ou igual a"]       	#  0xe927	(en: 'greater than less than or equal to', google translation)
+ - "": [t: "equivalente ou menor que"]         	#  0xe928	(en: 'equivalent to or less than', google translation)
+ - "": [t: "equivalente ou maior que"]         	#  0xe929	(en: 'equivalent to or greater than', google translation)
+ - "": [t: "deixou o operador de caixa aberta"]	#  0xe92a	(en: 'left open box operator', google translation)
+ - "": [t: "operador de caixa aberta à direita"]	#  0xe92b	(en: 'right open box operator', google translation)
+ - "": [t: "idêntico ao ponto"]                	#  0xe92c	(en: 'identical to with dot', google translation)
+ - "": [t: "maior que igual ou menor que"]     	#  0xe92d	(en: 'greater than equal to or less than', google translation)
+ - "": [t: "operador de bar"]                  	#  0xe92e	(en: 'bar operator', google translation)
+ - "": [t: "operador de barra dupla"]          	#  0xe92f	(en: 'double bar operator', google translation)
+ - "": [t: "operador de barra tripla"]         	#  0xe930	(en: 'triple bar operator', google translation)
+ - "": [t: "menor ou aproximadamente igual a"] 	#  0xe932	(en: 'less than or approximately equal to', google translation)
+ - "": [t: "maior ou aproximadamente igual a"] 	#  0xe933	(en: 'greater than or approximately equal to', google translation)
+ - "": [t: "aninhado menos que"]               	#  0xe936	(en: 'nested less than', google translation)
+ - "": [t: "aninhado maior que"]               	#  0xe937	(en: 'nested greater than', google translation)
+ - "": [t: "precede ou equivalente a"]         	#  0xe93a	(en: 'precedes or equivalent to', google translation)
+ - "": [t: "sucede ou equivalente a"]          	#  0xe93b	(en: 'succeeds or equivalent to', google translation)
+ - "": [t: "precede sobre igual"]              	#  0xe940	(en: 'precedes over equal', google translation)
+ - "": [t: "tem sucesso acima da igualdade"]   	#  0xe941	(en: 'succeeds over equal', google translation)
+ - "": [t: "menos igual inclinado maior"]      	#  0xe942	(en: 'less equal slanted greater', google translation)
+ - "": [t: "maior igual inclinado menos"]      	#  0xe943	(en: 'greater equal slanted less', google translation)
+ - "": [t: "satisfeito por"]                   	#  0xe948	(en: 'satisfied by', google translation)
+ - "": [t: "preguiçoso s"]                     	#  0xe949	(en: 'lazy s', google translation)
+ - "": [t: "não afirmação"]                    	#  0xe94a	(en: 'not assertion', google translation)
+ - "": [t: "duplo igual"]                      	#  0xe94b	(en: 'double equal', google translation)
+ - "": [t: "triplo igual"]                     	#  0xe94c	(en: 'triple equal', google translation)
+ - "": [t: "regra atrasada"]                   	#  0xe94d	(en: 'rule delayed', google translation)
+ - "": [t: "delimitador de alias"]             	#  0xe94e	(en: 'alias delimiter', google translation)
+ - "": [t: "subgrupo normal de com barra"]     	#  0xe950	(en: 'normal subgroup of with bar', google translation)
+ - "": [t: "contém como subgrupo normal com barra"]	#  0xe951	(en: 'contains as normal subgroup with bar', google translation)
+ - "": [t: "rodada implica"]                   	#  0xe954	(en: 'round implies', google translation)
+ - "": [t: "sorria embaixo do bar"]            	#  0xe955	(en: 'smile under bar', google translation)
+ - "": [t: "franzir a testa sobre a barra"]    	#  0xe956	(en: 'frown over bar', google translation)
+ - "": [t: "superconjunto de ou quase igual a"]	#  0xe957	(en: 'superset of or almost equal to', google translation)
+ - "": [t: "subconjunto de ou quase igual a"]  	#  0xe958	(en: 'subset of or almost equal to', google translation)
+ - "": [t: "maior que quase igual ou menor que"]	#  0xe959	(en: 'greater than almost equal to or less than', google translation)
+ - "": [t: "menor que quase igual ou maior que"]	#  0xe95a	(en: 'less than almost equal or greater than', google translation)
+ - "": [t: "duplo lógico ou"]                  	#  0xe95c	(en: 'double logical or', google translation)
+ - "": [t: "duplo lógico e"]                   	#  0xe95d	(en: 'double logical and', google translation)
+ - "": [t: "lógico ou com barra dupla abaixo"] 	#  0xe95e	(en: 'logical or with double bar below', google translation)
+ - "": [t: "lógico ou com barra abaixo"]       	#  0xe95f	(en: 'logical or with bar below', google translation)
+ - "": [t: "quase igual sobre igual"]          	#  0xe962	(en: 'almost equal over equal', google translation)
+ - "": [t: "triângulo apontando para a esquerda com barra bissetriz"]	#  0xe964	(en: 'left pointing triangle with bisecting bar', google translation)
+ - "": [t: "triângulo apontando para a direita com barra bissetriz"]	#  0xe965	(en: 'right pointing triangle with bisecting bar', google translation)
+ - "": [t: "é igual à linha superior pontilhada"]	#  0xe966	(en: 'equals with dotted top line', google translation)
+ - "": [t: "precede com dois pontos"]          	#  0xe967	(en: 'precedes with colon', google translation)
+ - "": [t: "tem sucesso com dois pontos"]      	#  0xe968	(en: 'succeeds with colon', google translation)
+ - "": [t: "menor ou igual inclinado"]         	#  0xe969	(en: 'smaller than or equal slanted', google translation)
+ - "": [t: "maior ou igual inclinado"]         	#  0xe96a	(en: 'larger than or equal slanted', google translation)
+ - "": [t: "aninhado muito menos do que"]      	#  0xe96b	(en: 'nested very much less than', google translation)
+ - "": [t: "aninhado muito maior que"]         	#  0xe96c	(en: 'nested very much greater than', google translation)
+ - "": [t: "diferença entre variante"]         	#  0xe96d	(en: 'difference between variant', google translation)
+ - "": [t: "menor que maior que sobreposição"] 	#  0xe96e	(en: 'less than greater than overlay', google translation)
+ - "": [t: "lógico ou lógico e sobreposição"]  	#  0xe96f	(en: 'logical or logical and overlay', google translation)
+ - "": [t: "superconjunto sobre superconjunto"]	#  0xe970	(en: 'superset over superset', google translation)
+ - "": [t: "subconjunto sobre subconjunto"]    	#  0xe971	(en: 'subset over subset', google translation)
+ - "": [t: "superconjunto sobre subconjunto"]  	#  0xe972	(en: 'superset over subset', google translation)
+ - "": [t: "subconjunto sobre superconjunto"]  	#  0xe973	(en: 'subset over superset', google translation)
+ - "": [t: "barra vertical tripla"]            	#  0xe979	(en: 'triple vertical bar', google translation)
+ - "": [t: "pontos verticais quádruplos emparelhados"]	#  0xe97a	(en: 'paired quadruple vertical dots', google translation)
+ - "": [t: "perpendicular à barra"]            	#  0xe97b	(en: 'perpendicular over bar', google translation)
+ - "": [t: "barra vertical dupla catraca esquerda"]	#  0xe97c	(en: 'left turnstile double vertical bar', google translation)
+ - "": [t: "catraca dupla esquerda barra vertical dupla"]	#  0xe97d	(en: 'double left turnstile double vertical bar', google translation)
+ - "": [t: "perpendicular sobre perpendicular invertida"]	#  0xe97e	(en: 'perpendicular over inverted perpendicular', google translation)
+ - "": [t: "barra vertical de catraca dupla esquerda"]	#  0xe97f	(en: 'double left turnstile vertical bar', google translation)
+ - "": [t: "abertura do ângulo esférico"]      	#  0xe980	(en: 'spherical angle opening up', google translation)
+ - "": [t: "barra dupla"]                      	#  0xe981	(en: 'double slash', google translation)
+ - "": [t: "ângulo reto com canto"]            	#  0xe982	(en: 'right angle with corner', google translation)
+ - "": [t: "barra vertical circulada"]         	#  0xe984	(en: 'circled vertical bar', google translation)
+ - "": [t: "sinal de divisão circulado"]       	#  0xe985	(en: 'circled division sign', google translation)
+ - "": [t: "sólido tracejado"]                 	#  0xe986	(en: 'dashed solidus', google translation)
+ - "": [t: "barra invertida tracejada"]        	#  0xe987	(en: 'dashed backslash', google translation)
+ - "": [t: "linha média tracejada"]            	#  0xe988	(en: 'dashed mid line', google translation)
+ - "": [t: "barra vertical tracejada"]         	#  0xe989	(en: 'dashed vertical bar', google translation)
+ - "": [t: "perpendicular a s"]                	#  0xe98a	(en: 'perpendicular with s', google translation)
+ - "": [t: "ângulo com s"]                     	#  0xe98b	(en: 'angle with s', google translation)
+ - "": [t: "abertura angular esférica à esquerda"]	#  0xe98c	(en: 'spherical angle opening left', google translation)
+ - "": [t: "ângulo de abertura para a esquerda"]	#  0xe98d	(en: 'angle opening left', google translation)
+ - "": [t: "barra vertical com gancho duplo"]  	#  0xe98e	(en: 'vertical bar with double hook', google translation)
+ - "": [t: "operador de ponto médio radical livre"]	#  0xe98f	(en: 'medium dot operator free radical', google translation)
+ - "": [t: "branco apontando triângulo acima da barra"]	#  0xe990	(en: 'white up pointing triangle above bar', google translation)
+ - "": [t: "idêntico e paralelo a"]            	#  0xe991	(en: 'identical and parallel to', google translation)
+ - "": [t: "esmagar produto"]                  	#  0xe992	(en: 'smash product', google translation)
+ - "": [t: "operador de barra tripla com barra horizontal"]	#  0xe993	(en: 'triple bar operator with horizontal bar', google translation)
+ - "": [t: "idêntico a barra dupla"]           	#  0xe994	(en: 'identical to with double slash', google translation)
+ - "": [t: "barras cruzadas triplas"]          	#  0xe995	(en: 'triple crossed bars', google translation)
+ - "": [t: "barra vertical sobre o círculo"]   	#  0xe996	(en: 'vertical bar over circle', google translation)
+ - "": [t: "vertical proporcional a"]          	#  0xe997	(en: 'vertical proportional to', google translation)
+ - "": [t: "lua negra do último quarto"]       	#  0xe998	(en: 'black last quarter moon', google translation)
+ - "": [t: "lua negra do primeiro quarto"]     	#  0xe999	(en: 'black first quarter moon', google translation)
+ - "": [t: "onda senoidal negativa"]           	#  0xe9a0	(en: 'negative sine wave', google translation)
+ - "": [t: "ponto entre parênteses"]           	#  0xe9a1	(en: 'parenthesized dot', google translation)
+ - "": [t: "parênteses"]                       	#  0xe9a2	(en: 'parens', google translation)
+ - "": [t: "sorriso branco"]                   	#  0xe9a3	(en: 'white smile', google translation)
+ - "": [t: "carranca branca"]                  	#  0xe9a4	(en: 'white frown', google translation)
+ - "": [t: "hexágono"]                         	#  0xe9a5	(en: 'hexagon', google translation)
+ - "": [t: "equivalente a mais de mais"]       	#  0xe9a6	(en: 'equivalent to over plus', google translation)
+ - "": [t: "mais sobre equivalente a"]         	#  0xe9a7	(en: 'plus over equivalent to', google translation)
+ - "": [t: "serifas de intersecção"]           	#  0xe9b0	(en: 'intersection serifs', google translation)
+ - "": [t: "serifas de união"]                 	#  0xe9b1	(en: 'union serifs', google translation)
+ - "": [t: "serifas de interseção quadrada"]   	#  0xe9b2	(en: 'square intersection serifs', google translation)
+ - "": [t: "serifas de união quadrada"]        	#  0xe9b3	(en: 'square union serifs', google translation)
+ - "": [t: "precede equivalente ou sucede"]    	#  0xe9e0	(en: 'precedes equivalent to or succeeds', google translation)
+ - "": [t: "sucede equivalente a ou precede"]  	#  0xe9e1	(en: 'succeeds equivalent to or precedes', google translation)
+ - "": [t: "precede quase igual ou é bem-sucedido"]	#  0xe9e2	(en: 'precedes almost equal to or succeeds', google translation)
+ - "": [t: "tem sucesso quase igual ou precede"]	#  0xe9e3	(en: 'succeeds almost equal to or precedes', google translation)
+ - "": [t: "menor que equivalente ou maior que"]	#  0xe9f0	(en: 'less than equivalent to or greater than', google translation)
+ - "": [t: "maior que equivalente ou menor que"]	#  0xe9f1	(en: 'greater than equivalent to or less than', google translation)
+ - "": [t: "não vert muito menos do que"]      	#  0xea00	(en: 'not vert much less than', google translation)
+ - "": [t: "não vert muito maior que"]         	#  0xea01	(en: 'not vert much greater than', google translation)
+ - "": [t: "não muito menos que variante"]     	#  0xea02	(en: 'not much less than variant', google translation)
+ - "": [t: "não muito maior que a variante"]   	#  0xea03	(en: 'not much greater than variant', google translation)
+ - "": [t: "menos vert e não duplo igual"]     	#  0xea04	(en: 'less vert not double equals', google translation)
+ - "": [t: "gt vert não é igual a duplo"]      	#  0xea05	(en: 'gt vert not double equals', google translation)
+ - "": [t: "não inferior ou igual a"]          	#  0xea06	(en: 'not less than or equal to', google translation)
+ - "": [t: "não maior ou igual a"]             	#  0xea07	(en: 'not greater than or equal to', google translation)
+ - "": [t: "nem igual nem menor que"]          	#  0xea09	(en: 'neither equal to nor less than', google translation)
+ - "": [t: "não contém ou é igual a"]          	#  0xea0a	(en: 'does not contain or equal to', google translation)
+ - "": [t: "nem superconjunto nem igual a"]    	#  0xea0b	(en: 'neither superset of nor equal to', google translation)
+ - "": [t: "nem subconjunto nem igual a"]      	#  0xea0c	(en: 'neither subset of nor equal to', google translation)
+ - "": [t: "subconjunto solidus reverso"]      	#  0xea0d	(en: 'reverse solidus subset', google translation)
+ - "": [t: "nem igual nem maior que"]          	#  0xea0e	(en: 'neither equal to nor greater than', google translation)
+ - "": [t: "não menos operador til"]           	#  0xea0f	(en: 'not minus tilde operator', google translation)
+ - "": [t: "nem igual nem menor que"]          	#  0xea10	(en: 'neither equal to nor less than', google translation)
+ - "": [t: "não operador til"]                 	#  0xea11	(en: 'not tilde operator', google translation)
+ - "": [t: "não é elemento ou igual a"]        	#  0xea12	(en: 'not element of or equal to', google translation)
+ - "": [t: "nem igual nem maior que"]          	#  0xea13	(en: 'neither equal to nor greater than', google translation)
+ - "": [t: "não é quase igual"]                	#  0xea14	(en: 'not almost equal', google translation)
+ - "": [t: "não consegue semelhante"]          	#  0xea15	(en: 'not succeeds similar', google translation)
+ - "": [t: "menor ou inclinado igual a com barra"]	#  0xea16	(en: 'less than or slanted equal to with slash', google translation)
+ - "": [t: "maior ou inclinado igual a com barra"]	#  0xea17	(en: 'greater than or slanted equal to with slash', google translation)
+ - "": [t: "superconjunto solidus"]            	#  0xea1a	(en: 'superset solidus', google translation)
+ - "": [t: "não contém"]                       	#  0xea1b	(en: 'does not contain', google translation)
+ - "": [t: "não inferior ou igual a"]          	#  0xea1d	(en: 'not less than or equal to', google translation)
+ - "": [t: "não maior ou igual a"]             	#  0xea1e	(en: 'not greater than or equal to', google translation)
+ - "": [t: "não é quase igual a menos"]        	#  0xea1f	(en: 'not almost equal to minus', google translation)
+ - "": [t: "ponto de associação do conjunto negado acima"]	#  0xea22	(en: 'negated set membership dot above', google translation)
+ - "": [t: "não ângulo vertical"]              	#  0xea2c	(en: 'not vert angle', google translation)
+ - "": [t: "não inclinado paralelamente"]      	#  0xea2d	(en: 'not parallel slanted', google translation)
+ - "": [t: "não é operador de bar"]            	#  0xea2e	(en: 'not bar operator', google translation)
+ - "": [t: "não é operador de barra dupla"]    	#  0xea2f	(en: 'not double bar operator', google translation)
+ - "": [t: "não é operador de barra tripla"]   	#  0xea30	(en: 'not triple bar operator', google translation)
+ - "": [t: "menor que, mas não aproximadamente igual a"]	#  0xea32	(en: 'less than but not approximately equal to', google translation)
+ - "": [t: "maior que, mas não aproximadamente igual a"]	#  0xea33	(en: 'greater than but not approximately equal to', google translation)
+ - "": [t: "menor ou diferente de"]            	#  0xea34	(en: 'less than or not equal to', google translation)
+ - "": [t: "maior ou diferente de"]            	#  0xea35	(en: 'greater than or not equal to', google translation)
+ - "": [t: "não aninhado menos que"]           	#  0xea36	(en: 'not nested less than', google translation)
+ - "": [t: "não aninhado maior que"]           	#  0xea37	(en: 'not nested greater than', google translation)
+ - "": [t: "não muito menos do que"]           	#  0xea38	(en: 'not much less than', google translation)
+ - "": [t: "não muito maior que"]              	#  0xea39	(en: 'not much greater than', google translation)
+ - "": [t: "precede, mas não é equivalente a"] 	#  0xea3a	(en: 'precedes but not equivalent to', google translation)
+ - "": [t: "tem sucesso, mas não é equivalente a"]	#  0xea3b	(en: 'succeeds but not equivalent to', google translation)
+ - "": [t: "precede, mas não é igual a"]       	#  0xea3c	(en: 'precedes but not equal to', google translation)
+ - "": [t: "tem sucesso, mas não é igual a"]   	#  0xea3d	(en: 'succeeds but not equal to', google translation)
+ - "": [t: "não é igual nem precede"]          	#  0xea3e	(en: 'does not equal or precede', google translation)
+ - "": [t: "não é igual ou bem sucedido"]      	#  0xea3f	(en: 'does not equal or succeed', google translation)
+ - "": [t: "precede, mas não é igual a"]       	#  0xea40	(en: 'precedes but not equal to', google translation)
+ - "": [t: "tem sucesso, mas não é igual a"]   	#  0xea41	(en: 'succeeds but not equal to', google translation)
+ - "": [t: "não é um subconjunto nem é igual a"]	#  0xea42	(en: 'not subset of nor equal to', google translation)
+ - "": [t: "não é superconjunto nem é igual a"]	#  0xea43	(en: 'not superset of nor equal to', google translation)
+ - "": [t: "subconjunto de ou diferente de"]   	#  0xea44	(en: 'subset of or not equal to', google translation)
+ - "": [t: "superconjunto de ou diferente de"] 	#  0xea45	(en: 'superset of or not equal to', google translation)
+ - "": [t: "não é um subconjunto nem é igual a"]	#  0xea46	(en: 'not subset of nor equal to', google translation)
+ - "": [t: "não é superconjunto nem é igual a"]	#  0xea47	(en: 'not superset of nor equal to', google translation)
+ - "": [t: "não triplicar menos que"]          	#  0xea48	(en: 'not triple less than', google translation)
+ - "": [t: "não triplicar maior que"]          	#  0xea49	(en: 'not triple greater than', google translation)
+ - "": [t: "não precede iguais"]               	#  0xea4c	(en: 'not precedes equals', google translation)
+ - "": [t: "não tem sucesso igual"]            	#  0xea4d	(en: 'not succeeds equals', google translation)
+ - "": [t: "subgrupo não normal de com barra"] 	#  0xea50	(en: 'not normal subgroup of with bar', google translation)
+ - "": [t: "não contém um subgrupo normal com barra"]	#  0xea51	(en: 'does not contain as normal subgroup with bar', google translation)
+ - "": [t: "não diferença entre"]              	#  0xea52	(en: 'not difference between', google translation)
+ - "": [t: "não é geometricamente equivalente a"]	#  0xea53	(en: 'not geometrically equivalent to', google translation)
+ - "": [t: "não muito semelhante"]             	#  0xea54	(en: 'not vert similar', google translation)
+ - "": [t: "não é igual ou semelhante"]        	#  0xea55	(en: 'not equal or similar', google translation)
+ - "": [t: "não é aproximado"]                 	#  0xea56	(en: 'not vert approximate', google translation)
+ - "": [t: "não é aproximadamente idêntico a"] 	#  0xea57	(en: 'not approximately identical to', google translation)
+ - "": [t: "não iguais acidentados"]           	#  0xea58	(en: 'not bumpy equals', google translation)
+ - "": [t: "não é igual a acidentado"]         	#  0xea59	(en: 'not bumpy single equals', google translation)
+ - "": [t: "não é igual a ponto"]              	#  0xea5a	(en: 'not equal dot', google translation)
+ - "": [t: "reverso não é equivalente"]        	#  0xea5b	(en: 'reverse not equivalent', google translation)
+ - "": [t: "não subconjunto quadrado"]         	#  0xea60	(en: 'not square subset', google translation)
+ - "": [t: "não superconjunto quadrado"]       	#  0xea61	(en: 'not square superset', google translation)
+ - "": [t: "não quase igual sobre igual"]      	#  0xea62	(en: 'not almost equal over equal', google translation)
+ - "": [t: "não é estritamente equivalente a"] 	#  0xea63	(en: 'not strictly equivalent to', google translation)
+ - "": [t: "ponto não congruente"]             	#  0xea64	(en: 'not congruent dot', google translation)
+ - "": [t: "reverso não é igual"]              	#  0xea65	(en: 'reverse not equal', google translation)
+ - "": [t: "não vert triângulo esquerdo é igual"]	#  0xea70	(en: 'not vert left triangle equals', google translation)
+ - "": [t: "não vert triângulo retângulo é igual"]	#  0xea71	(en: 'not vert right triangle equals', google translation)
+ - "": [t: "não parcial"]                      	#  0xea80	(en: 'not partial', google translation)
+ - "": [t: "extensor de embelezamento de seta"]	#  0xeb00	(en: 'arrow embellishment extender', google translation)
+ - "": [t: "seta para a direita sobre a seta para a esquerda"]	#  0xeb01	(en: 'arrow right over arrow left', google translation)
+ - "": [t: "seta para a direita sobre a seta para a esquerda"]	#  0xeb02	(en: 'arrow right over arrow left', google translation)
+ - "": [t: "arpão à direita sobre o arpão à esquerda"]	#  0xeb03	(en: 'harpoon right over harpoon left', google translation)
+ - "": [t: "arpão à direita sobre o arpão à esquerda"]	#  0xeb04	(en: 'harpoon right over harpoon left', google translation)
+ - "": [t: "seta dupla nordeste sudoeste"]     	#  0xeb05	(en: 'double arrow northeast southwest', google translation)
+ - "": [t: "seta dupla noroeste sudeste"]      	#  0xeb06	(en: 'double arrow northwest southeast', google translation)
+ - "": [t: "extensor de arpão horizontal"]     	#  0xeb07	(en: 'horizontal harpoon extender', google translation)
+ - "": [t: "seta para a esquerda em arco no sentido anti-horário"]	#  0xeb08	(en: 'anticlockwise arc left arrow', google translation)
+ - "": [t: "seta para a direita em arco no sentido anti-horário"]	#  0xeb09	(en: 'anticlockwise arc right arrow', google translation)
+ - "": [t: "grande acento de seta para a direita"]	#  0xeb0b	(en: 'large right arrow accent', google translation)
+ - "": [t: "grande acento de seta para a esquerda"]	#  0xeb0c	(en: 'large left arrow accent', google translation)
+ - "": [t: "ponta de seta esquerda"]           	#  0xeb0d	(en: 'left arrowhead', google translation)
+ - "": [t: "ponta de seta para a direita"]     	#  0xeb0e	(en: 'right arrowhead', google translation)
+ - "": [t: "grande seta esquerda para a direita com traço"]	#  0xeb0f	(en: 'large left right arrow with stroke', google translation)
+ - "": [t: "extensor de seta dupla horizontal"]	#  0xeb10	(en: 'horizontal double arrow extender', google translation)
+ - "": [t: "grande seta dupla esquerda direita com traço"]	#  0xeb11	(en: 'large left right double arrow with stroke', google translation)
+ - "": [t: "seta para baixo à esquerda da seta para cima"]	#  0xeb12	(en: 'down arrow left of up arrow', google translation)
+ - "": [t: "seta para a esquerda com canto para baixo"]	#  0xeb13	(en: 'left arrow with corner down', google translation)
+ - "": [t: "seta para a direita com canto para cima"]	#  0xeb14	(en: 'right arrow with corner up', google translation)
+ - "": [t: "seta para a esquerda com canto para cima"]	#  0xeb15	(en: 'left arrow with corner up', google translation)
+ - "": [t: "seta semicírculo superior no sentido anti-horário com mais"]	#  0xeb16	(en: 'anticlockwise top semicircle arrow with plus', google translation)
+ - "": [t: "seta semicírculo superior no sentido horário com menos"]	#  0xeb17	(en: 'clockwise top semicircle arrow with minus', google translation)
+ - "": [t: "seta para a direita com cauda com traço"]	#  0xeb18	(en: 'right arrow with tail with stroke', google translation)
+ - "": [t: "arpão direito para baixo"]         	#  0xeb19	(en: 'right harpoon down', google translation)
+ - "": [t: "deixou o arpão abaixado"]          	#  0xeb1a	(en: 'left harpoon down', google translation)
+ - "": [t: "esquerda direita arpão para baixo"]	#  0xeb1b	(en: 'left right harpoon down', google translation)
+ - "": [t: "esquerda direita arpão para cima"] 	#  0xeb1c	(en: 'left right harpoon up', google translation)
+ - "": [t: "para cima, para baixo, arpão para a esquerda"]	#  0xeb1d	(en: 'up down harpoon left', google translation)
+ - "": [t: "para cima, para baixo, arpão para a direita"]	#  0xeb1e	(en: 'up down harpoon right', google translation)
+ - "": [t: "seta para cima à direita da seta para baixo"]	#  0xeb1f	(en: 'up arrow to the right of down arrow', google translation)
+ - "": [t: "deixou o arpão na barra com a farpa para cima"]	#  0xeb20	(en: 'left harpoon to bar with barb up', google translation)
+ - "": [t: "arpão direito para barrar com a farpa para cima"]	#  0xeb21	(en: 'right harpoon to bar with barb up', google translation)
+ - "": [t: "deixou o arpão na barra com a farpa para baixo"]	#  0xeb22	(en: 'left harpoon to bar with barb down', google translation)
+ - "": [t: "arpão direito na barra com a farpa para baixo"]	#  0xeb23	(en: 'right harpoon to bar with barb down', google translation)
+ - "": [t: "arpão esquerdo da barra com a farpa para cima"]	#  0xeb24	(en: 'left harpoon from bar with barb up', google translation)
+ - "": [t: "arpão direito da barra com a farpa para cima"]	#  0xeb25	(en: 'right harpoon from bar with barb up', google translation)
+ - "": [t: "arpão esquerdo da barra com a farpa para baixo"]	#  0xeb26	(en: 'left harpoon from bar with barb down', google translation)
+ - "": [t: "arpão direito da barra com a farpa para baixo"]	#  0xeb27	(en: 'right harpoon from bar with barb down', google translation)
+ - "": [t: "levante o arpão até a barra com a farpa à esquerda"]	#  0xeb28	(en: 'up harpoon to bar with barb left', google translation)
+ - "": [t: "desça o arpão até a barra com a farpa à esquerda"]	#  0xeb29	(en: 'down harpoon to bar with barb left', google translation)
+ - "": [t: "levante o arpão até a barra com a farpa à direita"]	#  0xeb2a	(en: 'up harpoon to bar with barb right', google translation)
+ - "": [t: "desça o arpão até a barra com a farpa para a direita"]	#  0xeb2b	(en: 'down harpoon to bar with barb right', google translation)
+ - "": [t: "levante o arpão da barra com a farpa à esquerda"]	#  0xeb2c	(en: 'up harpoon from bar with barb left', google translation)
+ - "": [t: "desça o arpão da barra com a farpa à esquerda"]	#  0xeb2d	(en: 'down harpoon from bar with barb left', google translation)
+ - "": [t: "levante o arpão da barra com a farpa à direita"]	#  0xeb2e	(en: 'up harpoon from bar with barb right', google translation)
+ - "": [t: "desça o arpão da barra com a farpa à direita"]	#  0xeb2f	(en: 'down harpoon from bar with barb right', google translation)
+ - "": [t: "seta para cima na barra"]          	#  0xeb30	(en: 'up arrow to bar', google translation)
+ - "": [t: "seta para baixo até a barra"]      	#  0xeb31	(en: 'down arrow to bar', google translation)
+ - "": [t: "arpão para cima à esquerda do arpão para baixo"]	#  0xeb32	(en: 'up harpoon to the left of down harpoon', google translation)
+ - "": [t: "arpão para cima à direita do arpão para baixo"]	#  0xeb33	(en: 'up harpoon to the right of down harpoon', google translation)
+ - "": [t: "ponta de seta para cima"]          	#  0xeb34	(en: 'up arrowhead', google translation)
+ - "": [t: "seta para baixo"]                  	#  0xeb35	(en: 'down arrowhead', google translation)
+ - "": [t: "arpão duplo com a farpa esquerda para baixo e a farpa direita para cima"]	#  0xeb36	(en: 'double harpoon with left barb down right barb up', google translation)
+ - "": [t: "arpão duplo com a farpa esquerda para cima e a farpa direita para baixo"]	#  0xeb37	(en: 'double harpoon with left barb up right barb down', google translation)
+ - "": [t: "seta para a esquerda sobre a barra"]	#  0xeb38	(en: 'left arrow over bar', google translation)
+ - "": [t: "seta para a direita sobre a barra"]	#  0xeb39	(en: 'right arrow over bar', google translation)
+ - "": [t: "seta para a esquerda sob a barra"] 	#  0xeb3a	(en: 'left arrow under bar', google translation)
+ - "": [t: "seta para a direita sob a barra"]  	#  0xeb3b	(en: 'right arrow under bar', google translation)
+ - "": [t: "seta tripla esquerda direita"]     	#  0xeb3c	(en: 'left right triple arrow', google translation)
+ - "": [t: "seta dupla nordeste sudeste"]      	#  0xeb3f	(en: 'double arrow northeast southeast', google translation)
+ - "": [t: "seta semicírculo esquerdo no sentido anti-horário"]	#  0xeb40	(en: 'anticlockwise left semicircle arrow', google translation)
+ - "": [t: "seta semicírculo esquerdo no sentido horário"]	#  0xeb41	(en: 'clockwise left semicircle arrow', google translation)
+ - "": [t: "esquerda círculo aberto esquerda seta direita"]	#  0xeb42	(en: 'left open circle left right arrow', google translation)
+ - "": [t: "seta para a direita sobre o til"]  	#  0xeb44	(en: 'right arrow over tilde', google translation)
+ - "": [t: "seta para a esquerda sobre o til"] 	#  0xeb45	(en: 'left arrow over tilde', google translation)
+ - "": [t: "deixou o arpão sobre a barra"]     	#  0xeb48	(en: 'left harpoon over bar', google translation)
+ - "": [t: "arpão direito sobre a barra"]      	#  0xeb49	(en: 'right harpoon over bar', google translation)
+ - "": [t: "deixou o arpão embaixo da barra"]  	#  0xeb4a	(en: 'left harpoon under bar', google translation)
+ - "": [t: "arpão direito sob a barra"]        	#  0xeb4b	(en: 'right harpoon under bar', google translation)
+ - "": [t: "agachamento seta preta para a esquerda"]	#  0xeb4c	(en: 'squat black left arrow', google translation)
+ - "": [t: "seta semicírculo direita no sentido horário"]	#  0xeb50	(en: 'clockwise right semicircle arrow', google translation)
+ - "": [t: "seta semicírculo direita no sentido anti-horário"]	#  0xeb51	(en: 'anticlockwise right semicircle arrow', google translation)
+ - "": [t: "círculo aberto esquerdo arpão esquerdo direito"]	#  0xeb52	(en: 'left open circle left right harpoon', google translation)
+ - "": [t: "seta para cima à esquerda da barra vertical"]	#  0xeb58	(en: 'up arrow left of vertical bar', google translation)
+ - "": [t: "seta para baixo à esquerda da barra vertical"]	#  0xeb59	(en: 'down arrow left of vertical bar', google translation)
+ - "": [t: "seta para cima à direita da barra vertical"]	#  0xeb5a	(en: 'up arrow right of vertical bar', google translation)
+ - "": [t: "seta para baixo à direita da barra vertical"]	#  0xeb5b	(en: 'down arrow right of vertical bar', google translation)
+ - "": [t: "seta para a direita com gancho estendido para baixo"]	#  0xeb5c	(en: 'right arrow with extended down hook', google translation)
+ - "": [t: "seta para a esquerda com gancho estendido"]	#  0xeb5d	(en: 'left arrow with extended hook', google translation)
+ - "": [t: "seta para a esquerda com gancho estendido para baixo"]	#  0xeb5e	(en: 'left arrow with extended down hook', google translation)
+ - "": [t: "seta para a direita com gancho estendido"]	#  0xeb5f	(en: 'right arrow with extended hook', google translation)
+ - "": [t: "não seta para a direita ondulada"] 	#  0xeb60	(en: 'not right arrow wavy', google translation)
+ - "": [t: "não seta para a direita curvada"]  	#  0xeb61	(en: 'not right arrow curved', google translation)
+ - "": [t: "arpão à esquerda da barra vertical"]	#  0xeb68	(en: 'up harpoon left of vertical bar', google translation)
+ - "": [t: "arpão para baixo à esquerda da barra vertical"]	#  0xeb69	(en: 'down harpoon left of vertical bar', google translation)
+ - "": [t: "arpão à direita da barra vertical"]	#  0xeb6a	(en: 'up harpoon right of vertical bar', google translation)
+ - "": [t: "para baixo do arpão à direita da barra vertical"]	#  0xeb6b	(en: 'down harpoon right of vertical bar', google translation)
+ - "": [t: "extensor de seta dupla vertical"]  	#  0xeb6c	(en: 'vertical double arrow extender', google translation)
+ - "": [t: "arpão vertical com extensor de farpa esquerda"]	#  0xeb6d	(en: 'vertical harpoon with barb left extender', google translation)
+ - "": [t: "arpão vertical com extensor direito de farpa"]	#  0xeb6e	(en: 'vertical harpoon with barb right extender', google translation)
+ - "": [t: "arpão direito sobre arpão esquerdo direito"]	#  0xeb6f	(en: 'right harpoon over left harpoon right', google translation)
+ - "": [t: "arpão direito sobre arpão esquerdo, arpão esquerdo"]	#  0xeb70	(en: 'right harpoon over left harpoon left', google translation)
+ - "": [t: "arpão esquerdo sobre arpão direito, direito"]	#  0xeb71	(en: 'left harpoon over right harpoon right', google translation)
+ - "": [t: "arpão esquerdo sobre arpão direito e esquerdo"]	#  0xeb72	(en: 'left harpoon over right harpoon left', google translation)
+ - "": [t: "seta para a esquerda da ponta da seta da barra"]	#  0xeb73	(en: 'left arrow from bar arrowhead', google translation)
+ - "": [t: "seta para a esquerda e para a direita do extensor da barra"]	#  0xeb74	(en: 'left right arrow from bar extender', google translation)
+ - "": [t: "seta para a esquerda da cauda da barra"]	#  0xeb75	(en: 'left arrow from bar tail', google translation)
+ - "": [t: "seta para a direita da cauda da barra"]	#  0xeb76	(en: 'right arrow from bar tail', google translation)
+ - "": [t: "seta para a direita da ponta da seta da barra"]	#  0xeb77	(en: 'right arrow from bar arrowhead', google translation)
+ - "": [t: "arpão da barra com ponta de seta para a esquerda"]	#  0xeb78	(en: 'up harpoon from bar with barb left arrowhead', google translation)
+ - "": [t: "seta para a direita sobre a seta para a esquerda para a direita"]	#  0xeb79	(en: 'right arrow over left arrow right', google translation)
+ - "": [t: "seta para a direita sobre a seta para a esquerda para a esquerda"]	#  0xeb7a	(en: 'right arrow over left arrow left', google translation)
+ - "": [t: "seta para a esquerda sobre a seta para a direita"]	#  0xeb7b	(en: 'left arrow over right arrow right', google translation)
+ - "": [t: "seta para a esquerda sobre a seta para a direita para a esquerda"]	#  0xeb7c	(en: 'left arrow over right arrow left', google translation)
+ - "": [t: "seta para cima da ponta da seta da barra"]	#  0xeb7d	(en: 'up arrow from bar arrowhead', google translation)
+ - "": [t: "seta para cima da cauda da barra"] 	#  0xeb7e	(en: 'up arrow from bar tail', google translation)
+ - "": [t: "seta para baixo da cauda da barra"]	#  0xeb7f	(en: 'down arrow from bar tail', google translation)
+ - "": [t: "seta para baixo da ponta da seta da barra"]	#  0xeb80	(en: 'down arrow from bar arrowhead', google translation)
+ - "": [t: "arpão para baixo da barra com ponta de seta para a direita"]	#  0xeb81	(en: 'down harpoon from bar with barb right arrowhead', google translation)
+ - "": [t: "arpão para cima à esquerda da parte inferior do arpão"]	#  0xeb82	(en: 'up harpoon to the left of down harpoon bottom', google translation)
+ - "": [t: "arpão para cima à esquerda do extensor de arpão para baixo"]	#  0xeb83	(en: 'up harpoon to the left of down harpoon extender', google translation)
+ - "": [t: "para baixo do arpão à esquerda do topo do arpão"]	#  0xeb84	(en: 'down harpoon to the left of up harpoon top', google translation)
+ - "": [t: "arpão para cima à esquerda do topo do arpão para baixo"]	#  0xeb85	(en: 'up harpoon to the left of down harpoon top', google translation)
+ - "": [t: "arpão para baixo à esquerda do extensor de arpão para cima"]	#  0xeb86	(en: 'down harpoon to the left of the up harpoon extender', google translation)
+ - "": [t: "arpão para baixo à esquerda da parte inferior do arpão para cima"]	#  0xeb87	(en: 'down harpoon to the left of the up harpoon bottom', google translation)
+ - "": [t: "seta para cima à esquerda da seta para baixo na parte inferior"]	#  0xeb88	(en: 'up arrow left of down arrow bottom', google translation)
+ - "": [t: "seta para baixo à esquerda da seta para cima no topo"]	#  0xeb89	(en: 'down arrow left of up arrow top', google translation)
+ - "": [t: "seta para cima à esquerda da seta para baixo no topo"]	#  0xeb8a	(en: 'up arrow left of down arrow top', google translation)
+ - "": [t: "seta para baixo à esquerda da seta para cima na parte inferior"]	#  0xeb8b	(en: 'down arrow left of up arrow bottom', google translation)
+ - "": [t: "extensor de setas esquerda direita"]	#  0xeb8c	(en: 'left right arrows extender', google translation)
+ - "": [t: "extensor de seta nordeste"]        	#  0xeb8d	(en: 'north east arrow extender', google translation)
+ - "": [t: "extensor de seta noroeste"]        	#  0xeb8e	(en: 'north west arrow extender', google translation)
+ - "": [t: "para baixo apontando a chave para a esquerda"]	#  0xec00	(en: 'down pointing brace left', google translation)
+ - "": [t: "chave apontando para baixo no meio"]	#  0xec01	(en: 'down pointing brace mid', google translation)
+ - "": [t: "para baixo apontando a chave para a direita"]	#  0xec02	(en: 'down pointing brace right', google translation)
+ - "": [t: "extensor de suporte horizontal"]   	#  0xec03	(en: 'horizontal brace extender', google translation)
+ - "": [t: "para cima apontando a chave para a esquerda"]	#  0xec04	(en: 'up pointing brace left', google translation)
+ - "": [t: "apontando para cima no meio"]      	#  0xec05	(en: 'up pointing brace mid', google translation)
+ - "": [t: "suporte apontando para cima para a direita"]	#  0xec06	(en: 'up-pointing brace right', google translation)
+ - "": [t: "barra vertical esquerda"]          	#  0xec07	(en: 'left vertical bar', google translation)
+ - "": [t: "barra vertical direita"]           	#  0xec08	(en: 'right vertical bar', google translation)
+ - "": [t: "barra vertical dupla esquerda"]    	#  0xec09	(en: 'left double vertical bar', google translation)
+ - "": [t: "barra vertical dupla direita"]     	#  0xec0a	(en: 'right double vertical bar', google translation)
+ - "": [t: "extensor de suporte horizontal"]   	#  0xec0b	(en: 'horizontal bracket extender', google translation)
+ - "": [t: "sob colchete"]                     	#  0xec0c	(en: 'under square bracket', google translation)
+ - "⎵": [t: "sob colchete"]                     	#  0x23b5	(en: 'under square bracket', google translation)
+ - "": [t: "sobre colchete"]                   	#  0xec0d	(en: 'over square bracket', google translation)
+ - "⎴": [t: "sobre colchete"]                   	#  0x23b4	(en: 'over square bracket', google translation)
+ - "": [t: "sob o colchete esquerdo"]          	#  0xec0e	(en: 'under bracket left', google translation)
+ - "": [t: "abaixo do colchete à direita"]     	#  0xec0f	(en: 'under bracket right', google translation)
+ - "": [t: "acima do colchete esquerdo"]       	#  0xec10	(en: 'over bracket left', google translation)
+ - "": [t: "acima do colchete à direita"]      	#  0xec11	(en: 'over bracket right', google translation)
+ - "": [t: "parêntese esquerdo 1"]             	#  0xec12	(en: 'left parens 1', google translation)
+ - "": [t: "parêntese esquerdo 2"]             	#  0xec13	(en: 'left parens 2', google translation)
+ - "": [t: "parêntese esquerdo 3"]             	#  0xec14	(en: 'left parens 3', google translation)
+ - "": [t: "parêntese esquerdo 4"]             	#  0xec15	(en: 'left parens 4', google translation)
+ - "": [t: "parêntese direito 1"]              	#  0xec16	(en: 'right parens 1', google translation)
+ - "": [t: "parêntese direito 2"]              	#  0xec17	(en: 'right parens 2', google translation)
+ - "": [t: "parêntese direito 3"]              	#  0xec18	(en: 'right parens 3', google translation)
+ - "": [t: "parêntese direito 4"]              	#  0xec19	(en: 'right parens 4', google translation)
+ - "": [t: "radical 1"]                        	#  0xec1a	(google translation)
+ - "": [t: "radicais 2"]                       	#  0xec1b	(en: 'radical 2', google translation)
+ - "": [t: "radicais 3"]                       	#  0xec1c	(en: 'radical 3', google translation)
+ - "": [t: "radicais 4"]                       	#  0xec1d	(en: 'radical 4', google translation)
+ - "": [t: "radicais 5"]                       	#  0xec1e	(en: 'radical 5', google translation)
+ - "": [t: "fundo radical"]                    	#  0xec1f	(en: 'radical bottom', google translation)
+ - "": [t: "extensor vertical radical"]        	#  0xec20	(en: 'radical vertical extender', google translation)
+ - "": [t: "topo radical"]                     	#  0xec21	(en: 'radical top', google translation)
+ - "": [t: "topo do colchete branco esquerdo"] 	#  0xec22	(en: 'left white bracket top', google translation)
+ - "": [t: "extensor de colchete branco esquerdo"]	#  0xec23	(en: 'left white bracket extender', google translation)
+ - "": [t: "parte inferior do colchete branco esquerdo"]	#  0xec24	(en: 'left white bracket bottom', google translation)
+ - "": [t: "topo do colchete branco direito"]  	#  0xec25	(en: 'right white bracket top', google translation)
+ - "": [t: "extensor de suporte branco direito"]	#  0xec26	(en: 'right white bracket extender', google translation)
+ - "": [t: "parte inferior do colchete branco direito"]	#  0xec27	(en: 'right white bracket bottom', google translation)
+ - "": [t: "colchete branco esquerdo"]         	#  0xec30	(en: 'left white curly bracket', google translation)
+ - "": [t: "chave branca direita"]             	#  0xec31	(en: 'right white curly bracket', google translation)
+ - "": [t: "sinal de divisão longa"]           	#  0xec32	(en: 'long division sign', google translation)
+ - "": [t: "extensor de sinal de divisão longa"]	#  0xec33	(en: 'long division sign extender', google translation)
+ - "": [t: "divisão curta"]                    	#  0xec34	(en: 'short division', google translation)
+ - "": [t: "duplo sudoeste para nordeste em bond"]	#  0xec40	(en: 'double southwest to northeast em bond', google translation)
+ - "": [t: "duplo noroeste para sudeste em bond"]	#  0xec41	(en: 'double northwest to southeast em bond', google translation)
+ - "": [t: "ligação em horizontal única"]      	#  0xec42	(en: 'single horizontal em bond', google translation)
+ - "": [t: "ligação dupla horizontal"]         	#  0xec43	(en: 'double horizontal em bond', google translation)
+ - "": [t: "ligação tripla horizontal"]        	#  0xec44	(en: 'triple horizontal em bond', google translation)
+ - "": [t: "ligação em vertical única"]        	#  0xec45	(en: 'single vertical em bond', google translation)
+ - "": [t: "ligação em dupla vertical"]        	#  0xec46	(en: 'double vertical em bond', google translation)
+ - "": [t: "ligação vertical tripla em"]       	#  0xec47	(en: 'triple vertical em bond', google translation)
+ - "": [t: "menos do que em vínculo"]          	#  0xec48	(en: 'less than em bond', google translation)
+ - "": [t: "maior que em bond"]                	#  0xec49	(en: 'greater than em bond', google translation)
+ - "": [t: "horizontal único en bond"]         	#  0xec4a	(en: 'single horizontal en bond', google translation)
+ - "": [t: "duplo horizontal en bond"]         	#  0xec4b	(en: 'double horizontal en bond', google translation)
+ - "": [t: "triplo horizontal en bond"]        	#  0xec4c	(en: 'triple horizontal en bond', google translation)
+ - "": [t: "retângulo superior esquerdo"]      	#  0xec80	(en: 'top left rectangle', google translation)
+ - "": [t: "retângulo inferior esquerdo"]      	#  0xec81	(en: 'bottom left rectangle', google translation)
+ - "": [t: "retângulo superior direito"]       	#  0xec90	(en: 'top right rectangle', google translation)
+ - "": [t: "retângulo inferior direito"]       	#  0xec91	(en: 'bottom right rectangle', google translation)
+ - "": [t: "canto de divisão sintético"]       	#  0xec92	(en: 'synthetic division corner', google translation)
+ - "": [t: "extensor horizontal de divisão sintética"]	#  0xec93	(en: 'synthetic division horizontal extender', google translation)
+ - "": [t: "extensor vertical de divisão sintética"]	#  0xec94	(en: 'synthetic division vertical extender', google translation)
+ - "": [t: "extensor de piso de teto esquerdo"]	#  0xec95	(en: 'left ceiling floor extender', google translation)
+ - "": [t: "extensor de piso de teto direito"] 	#  0xec96	(en: 'right ceiling floor extender', google translation)
+ - "": [t: "sobre o extensor do suporte"]      	#  0xec97	(en: 'over bracket extender', google translation)
+ - "": [t: "extensor de barra vertical"]       	#  0xec98	(en: 'vertical bar extender', google translation)
+ - "": [t: "extensor de barra vertical dupla esquerda"]	#  0xec99	(en: 'left double vertical bar extender', google translation)
+ - "": [t: "extensor de barra horizontal"]     	#  0xec9a	(en: 'horizontal bar extender', google translation)
+ - "": [t: "sob o extensor do suporte"]        	#  0xec9c	(en: 'under bracket extender', google translation)
+ - "": [t: "para baixo apontando parênteses para a direita"]	#  0xec9d	(en: 'down pointing paren right', google translation)
+ - "": [t: "extensor de parênteses apontando para baixo"]	#  0xec9e	(en: 'down pointing paren extender', google translation)
+ - "": [t: "para baixo apontando parênteses para a esquerda"]	#  0xec9f	(en: 'down pointing paren left', google translation)
+ - "": [t: "extensor de suporte apontador para cima"]	#  0xeca0	(en: 'up pointing brace extender', google translation)
+ - "": [t: "para cima apontando parênteses para a esquerda"]	#  0xeca1	(en: 'up pointing paren left', google translation)
+ - "": [t: "apontando para cima extensor de parênteses"]	#  0xeca2	(en: 'up pointing paren extender', google translation)
+ - "": [t: "apontando parênteses para a direita"]	#  0xeca3	(en: 'up pointing paren right', google translation)
+ - "": [t: "extensor de cinta apontando para baixo"]	#  0xeca4	(en: 'down pointing brace extender', google translation)
+ - "": [t: "constante de planck em duas barras pi"]	#  0xed00	(en: 'planck constant over two pi bar', google translation)
+ - "": [t: "espelho g"]                        	#  0xed01	(en: 'mirror g', google translation)
+ - "": [t: "sem ponto j"]                      	#  0xed02	(en: 'dotless j', google translation)
+ - "": [t: "digamma"]                          	#  0xed03	(google translation)
+ - "ϝ": [t: "digamma"]                          	#  0x3dd	(google translation)
+ - "": [t: "d"]                                	#  0xed10	(google translation)
+ - "": [t: "e"]                                	#  0xed11	(google translation)
+ - "": [t: "i"]                                	#  0xed12	(google translation)
+ - "": [t: "j"]                                	#  0xed13	(google translation)
+ - "ⅅ":
+    - spell: "translate('.', 'ⅅ', 'DD')"       	#  0xed16, 0x2145
+
+# The private use chars are from MathType
+ - "": [t: "loop integral de contorno no sentido anti-horário"]	#  0xee00	(en: 'anticlockwise contour integral loop', google translation)
+ - "": [t: "loop integral de contorno no sentido horário"]	#  0xee01	(en: 'clockwise contour integral loop', google translation)
+ - "": [t: ""]                                 	#  0xee04
+ - "": [t: ""]                                 	#  0xee05
+ - "": [t: ""]                                 	#  0xee06
+ - "": [t: ""]                                 	#  0xee07
+ - "": [t: ""]                                 	#  0xee08
+ - "": [t: ""]                                 	#  0xee09
+ - "": [t: ""]                                 	#  0xee0a
+ - "": [t: ""]                                 	#  0xee0b
+ - "": [t: ""]                                 	#  0xee0c
+ - "": [t: "embelezamento de status conjunto"] 	#  0xee0d	(en: 'joint status embellishment', google translation)
+ - "": [t: "embelezamento de status conjunto deixado"]	#  0xee0e	(en: 'joint status embellishment left', google translation)
+ - "": [t: "direito de embelezamento de status conjunto"]	#  0xee0f	(en: 'joint status embellishment right', google translation)
+ - "": [t: "extensor de embelezamento de status conjunto"]	#  0xee10	(en: 'joint status embellishment extender', google translation)
+ - "": [t: "circuito integral"]                	#  0xee11	(en: 'integral loop', google translation)
+ - "": [t: "loop integral duplo"]              	#  0xee12	(en: 'integral loop double', google translation)
+ - "": [t: "loop integral triplo"]             	#  0xee13	(en: 'integral loop triple', google translation)
+ - "": [t: "expandindo o loop integral duplo"] 	#  0xee15	(en: 'expanding integral loop double', google translation)
+ - "": [t: "expandindo o loop integral triplo"]	#  0xee16	(en: 'expanding integral loop triple', google translation)
+ - "": [t: "assintoticamente igual ao acento"] 	#  0xee17	(en: 'asymptotically equal to accent', google translation)
+ - "": [t: "acento de sinal de igual"]         	#  0xee18	(en: 'equal sign accent', google translation)
+ - "": [t: "quádruplo primo"]                  	#  0xee19	(en: 'quadruple prime', google translation)
+ - "": [t: "acento de barra com círculo aberto à esquerda"]	#  0xee1a	(en: 'bar accent with open circle left', google translation)
+ - "": [t: "acento de barra com círculo fechado à esquerda"]	#  0xee1b	(en: 'bar accent with closed circle left', google translation)
+ - "": [t: "acento de barra com círculo aberto à direita"]	#  0xee1c	(en: 'bar accent with open circle right', google translation)
+ - "": [t: "acento de barra com ponto sobreposto"]	#  0xee1d	(en: 'bar accent with over dot', google translation)
+ - "": [t: "acento de barra com ponto inferior"]	#  0xee1e	(en: 'bar accent with under dot', google translation)
+ - "": [t: "acento de barra com ponto duplo"]  	#  0xee1f	(en: 'bar accent with double over dot', google translation)
+ - "": [t: "acento de barra com ponto duplo sob"]	#  0xee20	(en: 'bar accent with double under dot', google translation)
+ - "": [t: "acento de barra com cursor"]       	#  0xee21	(en: 'bar accent with caret', google translation)
+ - "": [t: "grosso sob o acento da barra"]     	#  0xee22	(en: 'thick under bar accent', google translation)
+ - "": [t: "acento de barra com círculo fechado à direita"]	#  0xee23	(en: 'bar accent with closed circle right', google translation)
+ - "": [t: "ponto grande acima"]               	#  0xee24	(en: 'large dot above', google translation)
+ - "": [t: "marca de alinhamento"]             	#  0xef00	(en: 'alignment mark', google translation)
+ - "": [t: ""]                                 	#  0xef01
+ - "​": [t: ""]                                 	#  0x200b
+ - "": [t: ""]                                 	#  0xef02
+ - " ": [t: ""]                                 	#  0x2009
+ - "": [t: ""]                                 	#  0xef03
+ - " ": [t: ""]                                 	#  0x205f
+ - "": [t: ""]                                 	#  0xef04
+ - "": [t: ""]                                 	#  0xef05
+ - "": [t: ""]                                 	#  0xef06
+ - "": [t: ""]                                 	#  0xef07
+ - "": [t: ""]                                 	#  0xef08
+ - "": [t: ""]                                 	#  0xef09
+ - "": [t: ""]                                 	#  0xef0a
+ - " ": [t: ""]                                 	#  0x200a
+ - "": [t: ""]                                 	#  0xef22
+ - "": [t: ""]                                 	#  0xef23
+ - "": [t: ""]                                 	#  0xef24
+ - "": [t: ""]                                 	#  0xef29
+ - "": [t: "termo faltante"]                   	#  0xef41	(en: 'missing term', google translation)
+ - "": [t: "seta integral do contorno no sentido horário à esquerda"]	#  0xef80	(en: 'clockwise contour integral arrow on left', google translation)
+ - "": [t: "integral com quadrado"]            	#  0xef81	(en: 'integral with square', google translation)
+ - "": [t: "integral com barra"]               	#  0xef82	(en: 'integral with slash', google translation)
+ - "": [t: "integral invertida"]               	#  0xef83	(en: 'reversed integral', google translation)
+ - "": [t: "duplo zero sobre duplo zero"]      	#  0xef90	(en: 'double zero over double zero', google translation)
+ - "": [t: "zero com barra"]                   	#  0xef91	(en: 'zero with slash', google translation)
+
+ # fraktur chars in math alphabetic block and also MathType private use area
+ # Some of these are reserved because they were used in Plane 0 -- that shouldn't be an issue other than causing the other chars to not display
+ - "𝔄-𝔜":                                       	#  0x1d504 - 0x1d51d ('z' version is reserved)
+    - t: "gótica"                              	# 	(en: 'fraktur', google translation)
+    - spell: "translate('.', '𝔄𝔅𝔆𝔇𝔈𝔉𝔊𝔋𝔌𝔍𝔎𝔏𝔐𝔑𝔒𝔓𝔔𝔕𝔖𝔗𝔘𝔙𝔚𝔛𝔜', 'ABCDEFGHIJKLMNOPQRSTUVWXY')"
+
+ - "-":                                       	#  0xf000 - 0xf018
+    - t: "gótica"                              	# 	(en: 'fraktur', google translation)
+    - spell: "translate('.', '', 'ABCDEFGHIJKLMNOPQRSTUVWXY')"
+
+ - "𝔞-𝔷":                                       	#  0x1d51e - 0x1d537
+    - t: "gótica"                              	# 	(en: 'fraktur', google translation)
+    - spell: "translate('.', '𝔞𝔟𝔠𝔡𝔢𝔣𝔤𝔥𝔦𝔧𝔨𝔩𝔪𝔫𝔬𝔭𝔮𝔯𝔰𝔱𝔲𝔳𝔴𝔵𝔶𝔷', 'abcdefghijklmnopqrstuvwxyz')"
+ - "-":                                       	#  0xf01a - 0xf033
+    - t: "gótica"                              	# 	(en: 'fraktur', google translation)
+    - spell: "translate('.', '', 'abcdefghijklmnopqrstuvwxyz')"
+    
+ - "𝕬-𝖅":                                       	#  0x1D56C - 0x1D585
+    - t: "gótica"                              	# 	(en: 'fraktur', google translation)
+    - test:
+        if: "not($IgnoreBold)"
+        then: [t: "audacioso"]                  	# 	(en: 'bold', google translation)
+    - spell: "translate('.', '𝕬𝕭𝕮𝕯𝕰𝕱𝕲𝕳𝕴𝕵𝕶𝕷𝕸𝕹𝕺𝕻𝕼𝕽𝕾𝕿𝖀𝖁𝖂𝖃𝖄𝖅', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ')"
+
+ - "-":                                       	#  0xf040 - 0xf059
+    - t: "gótica"                              	# 	(en: 'fraktur', google translation)
+    - test:
+        if: "not($IgnoreBold)"
+        then: [t: "audacioso"]                  	# 	(en: 'bold', google translation)
+    - spell: "translate('.', '', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ')"
+
+ - "𝖆-𝖟":                                       	#  0x1d586 - 0x1d59f
+    - t: "gótica"                              	# 	(en: 'fraktur', google translation)
+    - test:
+        if: "not($IgnoreBold)"
+        then: [t: "audacioso"]                  	# 	(en: 'bold', google translation)
+    - spell: "translate('.', '𝖆𝖇𝖈𝖉𝖊𝖋𝖌𝖍𝖎𝖏𝖐𝖑𝖒𝖓𝖔𝖕𝖖𝖗𝖘𝖙𝖚𝖛𝖜𝖝𝖞𝖟', 'abcdefghijklmnopqrstuvwxyz')"
+ - "-":                                       	#  0xf05a - 0xf073
+    - t: "gótica"                              	# 	(en: 'fraktur', google translation)
+    - test:
+        if: "not($IgnoreBold)"
+        then: [t: "audacioso"]                  	# 	(en: 'bold', google translation)
+    - spell: "translate('.', '', 'abcdefghijklmnopqrstuvwxyz')"
+
+ # double struck (blackboard bold) chars in math alphabetic block and also MathType private use area
+ # Some of these are reserved because they were used in Plane 0 -- that shouldn't be an issue other than causing the other chars to not display
+ - "𝔸-𝕐":                                       	#  0x1d504 - 0x1d51d ('z' version is reserved)
+    - t: "dupla escrita"                          	# 	(en: 'double struck', google translation)
+    - spell: "translate('.', '𝔸𝔹𝔺𝔻𝔼𝔽𝔾𝔿𝕀𝕁𝕂𝕃𝕄𝕅𝕆𝕇𝕈𝕉𝕊𝕋𝕌𝕍𝕎𝕏𝕐', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ')"
+
+ - "-":                                       	#  0xf080 - 0xf098
+    - t: "dupla escrita"                          	# 	(en: 'double struck', google translation)
+    - spell: "translate('.', '', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ')"
+
+ - "𝕒-𝕫":                                       	#  0x1d552 - 0x1d56b
+    - t: "dupla escrita"                          	# 	(en: 'double struck', google translation)
+    - spell: "translate('.', '𝕒𝕓𝕔𝕕𝕖𝕗𝕘𝕙𝕚𝕛𝕜𝕝𝕞𝕟𝕠𝕡𝕢𝕣𝕤𝕥𝕦𝕧𝕨𝕩𝕪𝕫', 'abcdefghijklmnopqrstuvwxyz')"
+ - "-":                                       	#  0xf09a - 0xf0b3
+    - t: "dupla escrita"                          	# 	(en: 'double struck', google translation)
+    - spell: "translate('.', '', 'abcdefghijklmnopqrstuvwxyz')"
+ - "𝟘-𝟡":                                       	#  0x1d7d8 - 0x1d7e1
+    - t: "dupla escrita"                          	# 	(en: 'double struck', google translation)
+    - spell: "translate('.', '𝟘𝟙𝟚𝟛𝟜𝟝𝟞𝟟𝟠𝟡', '0123456789')"
+ - "-":                                       	#  0xf0c0 - 0xf0c9
+    - t: "dupla escrita"                          	# 	(en: 'double struck', google translation)
+    - spell: "translate('.', '', '0123456789')"
+
+ - "": [t: "nabla em dupla escrita"]              	#  0xf0ca	(en: 'double struck nahblah', google translation)
+ - "": [t: "constante de Euler em dupla escrita"]	#  0xf0cb	(en: 'double struck euler constant', google translation)
+ 
+ # script chars in math alphabetic block and also MathType private use area
+ - "𝒜-𝒵":                                       	#  0x1d49c - 0x1d4b5
+    - t: "cursiva"                              	# 	(en: 'script', google translation)
+    - spell: "translate('.', '𝒜𝒝𝒞𝒟𝒠𝒡𝒢𝒣𝒤𝒥𝒦𝒧𝒨𝒩𝒪𝒫𝒬𝒭𝒮𝒯𝒰𝒱𝒲𝒳𝒴𝒵', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ')"
+
+ - "-":                                       	#  0xf100 - 0xf119
+    - t: "cursiva"                              	# 	(en: 'script', google translation)
+    - spell: "translate('.', '', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ')"
+
+ - "𝒶-𝓏":                                       	#  0x1d4b6 - 0x1d4cf
+    - t: "cursiva"                              	# 	(en: 'script', google translation)
+    - spell: "translate('.', '𝒶𝒷𝒸𝒹𝒺𝒻𝒼𝒽𝒾𝒿𝓀𝓁𝓂𝓃𝓄𝓅𝓆𝓇𝓈𝓉𝓊𝓋𝓌𝓍𝓎𝓏', 'abcdefghijklmnopqrstuvwxyz')"
+ - "-":                                       	#  0xf11a - 0xf133
+    - t: "cursiva"                              	# 	(en: 'script', google translation)
+    - spell: "translate('.', '', 'abcdefghijklmnopqrstuvwxyz')"
+
+ # bold script chars in math alphabetic block and also MathType private use area
+ - "𝓐-𝓩":                                       	#  0x1d4d0 - 0x1d4e9
+    - t: "cursiva"                              	# 	(en: 'script', google translation)
+    - test:
+        if: "not($IgnoreBold)"
+        then: [t: "audacioso"]                  	# 	(en: 'bold', google translation)
+    - spell: "translate('.', '𝓐𝓑𝓒𝓓𝓔𝓕𝓖𝓗𝓘𝓙𝓚𝓛𝓜𝓝𝓞𝓟𝓠𝓡𝓢𝓣𝓤𝓥𝓦𝓧𝓨𝓩', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ')"
+
+ - "-":                                       	#  0xf140 - 0xf159
+    - t: "cursiva"                              	# 	(en: 'script', google translation)
+    - test:
+        if: "not($IgnoreBold)"
+        then: [t: "audacioso"]                  	# 	(en: 'bold', google translation)
+    - spell: "translate('.', '', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ')"
+
+ - "𝓪-𝔃":                                       	#  0x1d4ea - 0x1d503
+    - t: "cursiva"                              	# 	(en: 'script', google translation)
+    - test:
+        if: "not($IgnoreBold)"
+        then: [t: "audacioso"]                  	# 	(en: 'bold', google translation)
+    - spell: "translate('.', '𝓪𝓫𝓬𝓭𝓮𝓯𝓰𝓱𝓲𝓳𝓴𝓵𝓶𝓷𝓸𝓹𝓺𝓻𝓼𝓽𝓾𝓿𝔀𝔁𝔂𝔃', 'abcdefghijklmnopqrstuvwxyz')"
+ - "-":                                       	#  0xf15a - 0xf173
+    - t: "cursiva"                              	# 	(en: 'script', google translation)
+    - test:
+        if: "not($IgnoreBold)"
+        then: [t: "audacioso"]                  	# 	(en: 'bold', google translation)
+    - spell: "translate('.', '', 'abcdefghijklmnopqrstuvwxyz')"
+
+ - "-":                                       	#  0xf180 - 0xf199
+    - spell: "translate('.', '', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ')" 
+
+ - "":                                         	#  0xf19a
+    - test: 
+        if: "$CapitalLetters_Beep"
+        then:
+        - audio:
+            value: "beep.mp4"
+            replace: []
+    - test: 
+        if: "$CapitalLetters_UseWord"
+        then_test:
+          if: "$SpeechOverrides_CapitalLetters = ''"
+          then_test:
+            if: "$Impairment = 'Blindness'"
+            then: [t: "maiúsculas"]             	# 	(en: 'cap', google translation)
+          else: [x: "$SpeechOverrides_CapitalLetters"] 
+    - pitch:
+        value: "$CapitalLetters_Pitch"
+        replace: [t: "ligadura ae"]             	# 	(en: 'ligature ae', google translation)
+ - "":                                         	#  0xf19b
+    - test: 
+        if: "$CapitalLetters_Beep"
+        then:
+        - audio:
+            value: "beep.mp4"
+            replace: []
+    - test: 
+        if: "$CapitalLetters_UseWord"
+        then_test:
+          if: "$SpeechOverrides_CapitalLetters = ''"
+          then_test:
+            if: "$Impairment = 'Blindness'"
+            then: [t: "maiúsculas"]             	# 	(en: 'cap', google translation)
+          else: [x: "$SpeechOverrides_CapitalLetters"] 
+    - pitch:
+        value: "$CapitalLetters_Pitch"
+        replace: [t: "afiado s"]                	# 	(en: 'sharp s', google translation)
+ - "":                                         	#  0xf19c
+    - test: 
+        if: "$CapitalLetters_Beep"
+        then:
+        - audio:
+            value: "beep.mp4"
+            replace: []
+    - test: 
+        if: "$CapitalLetters_UseWord"
+        then_test:
+          if: "$SpeechOverrides_CapitalLetters = ''"
+          then_test:
+            if: "$Impairment = 'Blindness'"
+            then: [t: "maiúsculas"]             	# 	(en: 'cap', google translation)
+          else: [x: "$SpeechOverrides_CapitalLetters"] 
+    - pitch:
+        value: "$CapitalLetters_Pitch"
+        replace: [t: "o com acidente vascular cerebral"]	# 	(en: 'o with stroke', google translation)
+
+ # MathType only has a few of the cap Greek letters in PUA
+ - "":                                 	#  0xf201 - 0xf209
+    - t: "dupla escrita"                          	# 	(en: 'double struck', google translation)
+    - spell: "translate('.', '', 'ΔΨΛΠΣΘΓΩΥ')"
+
+ - "-":                                       	#  0xf220 - 0xf236
+    - t: "dupla escrita"                          	# 	(en: 'double struck', google translation)
+    - spell: "translate('.', '', 'ΑΒΓΔΕΖΗΘΙΚΛΜΝΞΟΠΡ΢ΣΤΥΦΧΨΩ')"
+
+ - "": [t: "sigma final em dupla escrita"]      	#  0xf237	(en: 'double struck final sigma', google translation)
+ - "": [t: "rô em dupla escrita"]                	#  0xf250	(en: 'double struck rho', google translation)
+ - "": [t: "fi em dupla escrita"]                  	#  0xf251	(en: 'double struck phi', google translation)
+ - "𝐀-𝐙":                                       	#  0x1d400 - 0x1d419
+    - test:
+        if: "not($IgnoreBold)"
+        then: [t: "audacioso"]                  	# 	(en: 'bold', google translation)
+    - spell: "translate('.', '𝐀𝐁𝐂𝐃𝐄𝐅𝐆𝐇𝐈𝐉𝐊𝐋𝐌𝐍𝐎𝐏𝐐𝐑𝐒𝐓𝐔𝐕𝐖𝐗𝐘𝐙', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ')"
+
+ - "-":                                       	#  0xf260 - 0xf279
+    - test:
+        if: "not($IgnoreBold)"
+        then: [t: "audacioso"]                  	# 	(en: 'bold', google translation)
+    - spell: "translate('.', '', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ')"
+
+ - "𝐚-𝐳":                                       	#  0x1d41a - 0x1d433
+    - test:
+        if: "not($IgnoreBold)"
+        then: [t: "audacioso"]                  	# 	(en: 'bold', google translation)
+    - spell: "translate('.', '𝐚𝐛𝐜𝐝𝐞𝐟𝐠𝐡𝐢𝐣𝐤𝐥𝐦𝐧𝐨𝐩𝐪𝐫𝐬𝐭𝐮𝐯𝐰𝐱𝐲𝐳', 'abcdefghijklmnopqrstuvwxyz')"
+
+ - "-":                                       	#  0xf27a - 0xf293
+    - test:
+        if: "not($IgnoreBold)"
+        then: [t: "audacioso"]                  	# 	(en: 'bold', google translation)
+    - spell: "translate('.', '', 'abcdefghijklmnopqrstuvwxyz')"
+
+ - "𝐴-𝑍":                                       	#  0x1d434 - 0x1d44d
+    - spell: "translate('.', '𝐴𝐵𝐶𝐷𝐸𝐹𝐺𝐻𝐼𝐽𝐾𝐿𝑀𝑁𝑂𝑃𝑄𝑅𝑆𝑇𝑈𝑉𝑊𝑋𝑌𝑍', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ')"
+
+ - "-":                                       	#  0xf294 - 0xf2ad
+    - spell: "translate('.', '', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ')"
+
+ - "𝑎-𝑧":                                       	#  0x1d44e - 0x1d467
+    - spell: "translate('.', '𝑎𝑏𝑐𝑑𝑒𝑓𝑔𝑕𝑖𝑗𝑘𝑙𝑚𝑛𝑜𝑝𝑞𝑟𝑠𝑡𝑢𝑣𝑤𝑥𝑦𝑧', 'abcdefghijklmnopqrstuvwxyz')"
+
+ - "-":                                       	#  0xf2ae - 0xf2c7
+    - spell: "translate('.', '', 'abcdefghijklmnopqrstuvwxyz')"
+
+ - "𝑨-𝒁":                                       	#  0x1d468 - 0x1d481
+    # - t: "bold italic"
+    - test:
+        if: "not($IgnoreBold)"
+        then: [t: "audacioso"]                  	# 	(en: 'bold', google translation)
+    - spell: "translate('.', '𝑨𝑩𝑪𝑫𝑬𝑭𝑮𝑯𝑰𝑱𝑲𝑳𝑴𝑵𝑶𝑷𝑸𝑹𝑺𝑻𝑼𝑽𝑾𝑿𝒀𝒁', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ')"
+
+ - "-":                                       	#  0xf2c8 - 0xf2e1
+    # - t: "bold italic"
+    - test:
+        if: "not($IgnoreBold)"
+        then: [t: "audacioso"]                  	# 	(en: 'bold', google translation)
+    - spell: "translate('.', '', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ')"
+
+ - "𝒂-𝒛":                                       	#  0x1d482 - 0x1d49b
+    # - t: "bold italic"
+    - test:
+        if: "not($IgnoreBold)"
+        then: [t: "audacioso"]                  	# 	(en: 'bold', google translation)
+    - spell: "translate('.', '𝒂𝒃𝒄𝒅𝒆𝒇𝒈𝒉𝒊𝒋𝒌𝒍𝒎𝒏𝒐𝒑𝒒𝒓𝒔𝒕𝒖𝒗𝒘𝒙𝒚𝒛', 'abcdefghijklmnopqrstuvwxyz')"
+
+ - "-":                                       	#  0xf2e2 - 0xf2fb
+    # - t: "bold italic"
+    - test:
+        if: "not($IgnoreBold)"
+        then: [t: "audacioso"]                  	# 	(en: 'bold', google translation)
+    - spell: "translate('.', '', 'abcdefghijklmnopqrstuvwxyz')"
+
+ - "𝖠-𝖹":                                       	#  0x1d5a0 - 0x1d5b9
+    - spell: "translate('.', '𝖠𝖡𝖢𝖣𝖤𝖥𝖦𝖧𝖨𝖩𝖪𝖫𝖬𝖭𝖮𝖯𝖰𝖱𝖲𝖳𝖴𝖵𝖶𝖷𝖸𝖹', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ')"
+
+ - "-":                                       	#  0xf300 - 0xf319
+    - spell: "translate('.', '', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ')"
+
+ - "𝖺-𝗓":                                       	#  0x1d5ba - 0x1d5d3
+    - spell: "translate('.', '𝖺𝖻𝖼𝖽𝖾𝖿𝗀𝗁𝗂𝗃𝗄𝗅𝗆𝗇𝗈𝗉𝗊𝗋𝗌𝗍𝗎𝗏𝗐𝗑𝗒𝗓', 'abcdefghijklmnopqrstuvwxyz')"
+
+ - "-":                                       	#  0xf31a - 0xf333
+    - spell: "translate('.', '', 'abcdefghijklmnopqrstuvwxyz')"
+ 
+ - "𝗔-𝗭":                                       	#  0x1d5d4 - 0x1d5ed
+    - test:
+        if: "not($IgnoreBold)"
+        then: [t: "audacioso"]                  	# 	(en: 'bold', google translation)
+    - spell: "translate('.', '𝗔𝗕𝗖𝗗𝗘𝗙𝗚𝗛𝗜𝗝𝗞𝗟𝗠𝗡𝗢𝗣𝗤𝗥𝗦𝗧𝗨𝗩𝗪𝗫𝗬𝗭', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ')"
+
+ - "-":                                       	#  0xf334 - 0xf34d
+    - test:
+        if: "not($IgnoreBold)"
+        then: [t: "audacioso"]                  	# 	(en: 'bold', google translation)
+    - spell: "translate('.', '', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ')"
+
+ - "𝗮-𝘇":                                       	#  0x1d5ee - 0x1d607
+    - test:
+        if: "not($IgnoreBold)"
+        then: [t: "audacioso"]                  	# 	(en: 'bold', google translation)
+    - spell: "translate('.', '𝗮𝗯𝗰𝗱𝗲𝗳𝗴𝗵𝗶𝗷𝗸𝗹𝗺𝗻𝗼𝗽𝗾𝗿𝘀𝘁𝘂𝘃𝘄𝘅𝘆𝘇', 'abcdefghijklmnopqrstuvwxyz')"
+
+ - "-":                                       	#  0xf34e - 0xf367
+    - test:
+        if: "not($IgnoreBold)"
+        then: [t: "audacioso"]                  	# 	(en: 'bold', google translation)
+    - spell: "translate('.', '', 'abcdefghijklmnopqrstuvwxyz')"
+ - "𝘈-𝘡":                                       	#  0x1d608 - 0x1d621
+    # - t: "italic"
+    - spell: "translate('.', '𝘈𝘉𝘊𝘋𝘌𝘍𝘎𝘏𝘐𝘑𝘒𝘓𝘔𝘕𝘖𝘗𝘘𝘙𝘚𝘛𝘜𝘝𝘞𝘟𝘠𝘡', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ')"
+ - "-":                                       	#  0xf368 - 0xf381
+      # - t: "italic"
+    - spell: "translate('.', '', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ')"
+
+ - "𝘢-𝘻":                                       	#  0x1d622 - 0x1d63b
+      # - t: "italic"
+    - spell: "translate('.', '𝘢𝘣𝘤𝘥𝘦𝘧𝘨𝘩𝘪𝘫𝘬𝘭𝘮𝘯𝘰𝘱𝘲𝘳𝘴𝘵𝘶𝘷𝘸𝘹𝘺𝘻', 'abcdefghijklmnopqrstuvwxyz')"
+
+ - "-":                                       	#  0xf382 - 0xf39b
+      # - t: "italic"
+    - spell: "translate('.', '', 'abcdefghijklmnopqrstuvwxyz')"
+
+ - "𝘼-𝙕":                                       	#  0x1d63c - 0x1d655
+    # - t: "bold italic"
+    - test:
+        if: "not($IgnoreBold)"
+        then: [t: "audacioso"]                  	# 	(en: 'bold', google translation)
+    - spell: "translate('.', '𝘼𝘽𝘾𝘿𝙀𝙁𝙂𝙃𝙄𝙅𝙆𝙇𝙈𝙉𝙊𝙋𝙌𝙍𝙎𝙏𝙐𝙑𝙒𝙓𝙔𝙕', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ')"
+
+ - "-":                                       	#  0xf39c - 0xf3b5
+    # - t: "bold italic"
+    - test:
+        if: "not($IgnoreBold)"
+        then: [t: "audacioso"]                  	# 	(en: 'bold', google translation)
+    - spell: "translate('.', '', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ')"
+
+ - "𝙖-𝙯":                                       	#  0x1d656 - 0x1d66f
+    # - t: "bold italic"
+    - test:
+        if: "not($IgnoreBold)"
+        then: [t: "audacioso"]                  	# 	(en: 'bold', google translation)
+    - spell: "translate('.', '𝙖𝙗𝙘𝙙𝙚𝙛𝙜𝙝𝙞𝙟𝙠𝙡𝙢𝙣𝙤𝙥𝙦𝙧𝙨𝙩𝙪𝙫𝙬𝙭𝙮𝙯', 'abcdefghijklmnopqrstuvwxyz')"
+
+ - "-":                                       	#  0xf3b6 - 0xf3cf
+    # - t: "bold italic"
+    - test:
+        if: "not($IgnoreBold)"
+        then: [t: "audacioso"]                  	# 	(en: 'bold', google translation)
+    - spell: "translate('.', '', 'abcdefghijklmnopqrstuvwxyz')"
+
+ - "𝙰-𝚉":                                       	#  0x1d670 - 0x1d689
+    - spell: "translate('.', '𝙰𝙱𝙲𝙳𝙴𝙵𝙶𝙷𝙸𝙹𝙺𝙻𝙼𝙽𝙾𝙿𝚀𝚁𝚂𝚃𝚄𝚅𝚆𝚇𝚈𝚉', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ')"
+
+ - "-":                                       	#  0xf3d0 - 0xf3e9
+    - spell: "translate('.', '', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ')"
+
+ - "𝚊-𝚣":                                       	#  0x1d68a - 0x1d6a3
+    - spell: "translate('.', '𝚊𝚋𝚌𝚍𝚎𝚏𝚐𝚑𝚒𝚓𝚔𝚕𝚖𝚗𝚘𝚙𝚚𝚛𝚜𝚝𝚞𝚟𝚠𝚡𝚢𝚣', 'abcdefghijklmnopqrstuvwxyz')"
+
+ - "-":                                       	#  0xf3ea - 0xf403
+    - spell: "translate('.', '', 'abcdefghijklmnopqrstuvwxyz')"
+
+ - "": [t: "sem ponto eu"]                     	#  0xf404	(en: 'dotless i', google translation)
+ - "𝚤": [t: "sem ponto eu"]                     	#  0x1d6a4	(en: 'dotless i', google translation)
+ - "𝚥": [t: "sem ponto j"]                      	#  0x1d6a5	(en: 'dotless j', google translation)
+
+ - "𝚨-𝛀":                                       	#  0x1d6a8 - 0x1d6c0
+    - test:
+        if: "not($IgnoreBold)"
+        then: [t: "audacioso"]                  	# 	(en: 'bold', google translation)
+    - spell: "translate('.', '𝚨𝚩𝚪𝚫𝚬𝚭𝚮𝚯𝚰𝚱𝚲𝚳𝚴𝚵𝚶𝚷𝚸𝚹𝚺𝚻𝚼𝚽𝚾𝚿𝛀', 'ΑΒΓΔΕΖΗΘΙΚΛΜΝΞΟΠΡ΢ΣΤΥΦΧΨΩ')"
+
+ - "-":                                       	#  0xf408 - 0xf420
+    - test:
+        if: "not($IgnoreBold)"
+        then: [t: "audacioso"]                  	# 	(en: 'bold', google translation)
+    - spell: "translate('.', '', 'ΑΒΓΔΕΖΗΘΙΚΛΜΝΞΟΠΡ΢ΣΤΥΦΧΨΩ')"
+
+ - "𝛂-𝛚":                                       	#  0x1d6c2 - 0x1d6da
+    - test:
+        if: "not($IgnoreBold)"
+        then: [t: "audacioso"]                  	# 	(en: 'bold', google translation)
+    - spell: "translate('.', '𝛂𝛃𝛄𝛅𝛆𝛇𝛈𝛉𝛊𝛋𝛌𝛍𝛎𝛏𝛐𝛑𝛒𝛓𝛔𝛕𝛖𝛗𝛘𝛙𝛚', 'αβγδεζηθικλμνξοπρςστυφχψω')"
+
+ - "-":                                       	#  0xf422 - 0xf43a
+    - test:
+        if: "not($IgnoreBold)"
+        then: [t: "audacioso"]                  	# 	(en: 'bold', google translation)
+    - spell: "translate('.', '', 'αβγδεζηθικλμνξοπρςστυφχψω')"
+
+ - "": [t: "ousado nabla"]                   	#  0xf421	(en: 'bold nahblah', google translation)
+ - "𝛁": [t: "ousado nabla"]                   	#  0x1d6c1	(en: 'bold nahblah', google translation)
+
+ - "𝛛𝛜𝛝𝛞𝛟𝛠𝛡":                                   	#  0x1D6DB - 0x1D6E1
+    - test:
+        if: "not($IgnoreBold)"
+        then: [t: "audacioso"]                  	# 	(en: 'bold', google translation)
+    - spell: "translate('.', '𝛛𝛜𝛝𝛞𝛟𝛠𝛡', '∂εθκφρπ')"
+
+ - "":                                   	#  0xF43C - 0xF441
+    - test:
+        if: "not($IgnoreBold)"
+        then: [t: "audacioso"]                  	# 	(en: 'bold', google translation)
+    - spell: "translate('.', '', '∂εθκφρπ')"
+
+ - "𝛢-𝛺":                                       	#  0x1d6e2 - 0x1d6fa
+      # - t: "italic"
+    - spell: "translate('.', '𝛢𝛣𝛤𝛥𝛦𝛧𝛨𝛩𝛪𝛫𝛬𝛭𝛮𝛯𝛰𝛱𝛲𝛳𝛴𝛵𝛶𝛷𝛸𝛹𝛺', 'ΑΒΓΔΕΖΗΘΙΚΛΜΝΞΟΠΡ΢ΣΤΥΦΧΨΩ')"
+
+ - "-":                                       	#  0xf442 - 0xf45a
+      # - t: "italic"
+    - spell: "translate('.', '', 'ΑΒΓΔΕΖΗΘΙΚΛΜΝΞΟΠΡ΢ΣΤΥΦΧΨΩ')"
+
+ - "𝛼-𝜔":                                       	#  0x1d6fc - 0x1d714
+      # - t: "italic"
+    - spell: "translate('.', '𝛼𝛽𝛾𝛿𝜀𝜁𝜂𝜃𝜄𝜅𝜆𝜇𝜈𝜉𝜊𝜋𝜌𝜍𝜎𝜏𝜐𝜑𝜒𝜓𝜔', 'αβγδεζηθικλμνξοπρςστυφχψω')"
+
+ - "-":                                       	#  0xf45c - 0xf474
+      # - t: "italic"
+    - spell: "translate('.', '', 'αβγδεζηθικλμνξοπρςστυφχψω')"
+
+ - "": [t: "itálico nabla"]                  	#  0xf45b	(en: 'italic nahblah', google translation)
+ - "𝛻": [t: "itálico nabla"]                  	#  0x1d6fb	(en: 'italic nahblah', google translation)
+
+ - "𝜕𝜖𝜗𝜘𝜙𝜚𝜛":                                   	#  0x1d715 - 0x1d71b
+      # - t: "italic"
+    - spell: "translate('.', '𝜕𝜖𝜗𝜘𝜙𝜚𝜛', '∂εθκφρπ')"
+
+ - "":                                   	#  0xf475  - 0xf47b
+      # - t: "italic"
+    - spell: "translate('.', '', '∂εθκφρπ')"
+
+ - "𝜜-𝜴":                                       	#  0x1d71c - 0x1d734
+    # - t: "bold italic"
+    - test:
+        if: "not($IgnoreBold)"
+        then: [t: "audacioso"]                  	# 	(en: 'bold', google translation)
+    - spell: "translate('.', '𝜜𝜝𝜞𝜟𝜠𝜡𝜢𝜣𝜤𝜥𝜦𝜧𝜨𝜩𝜪𝜫𝜬𝜭𝜮𝜯𝜰𝜱𝜲𝜳𝜴', 'ΑΒΓΔΕΖΗΘΙΚΛΜΝΞΟΠΡ΢ΣΤΥΦΧΨΩ')"
+
+ - "-":                                       	#  0xf47c - 0xf494
+    # - t: "bold italic"
+    - test:
+        if: "not($IgnoreBold)"
+        then: [t: "audacioso"]                  	# 	(en: 'bold', google translation)
+    - spell: "translate('.', '', 'ΑΒΓΔΕΖΗΘΙΚΛΜΝΞΟΠΡ΢ΣΤΥΦΧΨΩ')"
+
+ - "𝜶-𝝎":                                       	#  0x1d736 - 0x1d74e
+    # - t: "bold italic"
+    - test:
+        if: "not($IgnoreBold)"
+        then: [t: "audacioso"]                  	# 	(en: 'bold', google translation)
+    - spell: "translate('.', '𝜶𝜷𝜸𝜹𝜺𝜻𝜼𝜽𝜾𝜿𝝀𝝁𝝂𝝃𝝄𝝅𝝆𝝇𝝈𝝉𝝊𝝋𝝌𝝍𝝎', 'αβγδεζηθικλμνξοπρςστυφχψω')"
+
+ - "-":                                       	#  0xf496 - 0xf4ae
+    # - t: "bold italic"
+    - test:
+        if: "not($IgnoreBold)"
+        then: [t: "audacioso"]                  	# 	(en: 'bold', google translation)
+    - spell: "translate('.', '', 'αβγδεζηθικλμνξοπρςστυφχψω')"
+
+ - "𝝏𝝐𝝑𝝒𝝓𝝔𝝕":                                   	#  0x1d74f - 0x1d755
+    # - t: "bold italic"
+    - test:
+        if: "not($IgnoreBold)"
+        then: [t: "audacioso"]                  	# 	(en: 'bold', google translation)
+    - spell: "translate('.', '𝝏𝝐𝝑𝝒𝝓𝝔𝝕', '∂εθκφρπ')"
+
+ - "":                                   	#  0xf422 - 0xf43a
+    # - t: "bold italic"
+    - test:
+        if: "not($IgnoreBold)"
+        then: [t: "audacioso"]                  	# 	(en: 'bold', google translation)
+    - spell: "translate('.', '', '∂εθκφρπ')"
+
+ - "𝜵": [t: "negrito itálico nabla"]          	#  0x1d735	(en: 'bold italic nahblah', google translation)
+ - "": [t: "negrito itálico nabla"]          	#  0xf495	(en: 'bold italic nahblah', google translation)
+
+ - "𝝖-𝝮":                                       	#  0x1d756 - 0x1d76e
+    - test:
+        if: "not($IgnoreBold)"
+        then: [t: "audacioso"]                  	# 	(en: 'bold', google translation)
+    - spell: "translate('.', '𝝖𝝗𝝘𝝙𝝚𝝛𝝜𝝝𝝞𝝟𝝠𝝡𝝢𝝣𝝤𝝥𝝦𝝧𝝨𝝩𝝪𝝫𝝬𝝭𝝮', 'ΑΒΓΔΕΖΗΘΙΚΛΜΝΞΟΠΡ΢ΣΤΥΦΧΨΩ')"
+ - "-":                                       	#  0xf4b6 - 0xf4ce
+    - test:
+        if: "not($IgnoreBold)"
+        then: [t: "audacioso"]                  	# 	(en: 'bold', google translation)
+    - spell: "translate('.', '', 'ΑΒΓΔΕΖΗΘΙΚΛΜΝΞΟΠΡ΢ΣΤΥΦΧΨΩ')"
+
+ - "𝝰-𝞈":                                       	#  0x1d770 - 0x1d788
+    - test:
+        if: "not($IgnoreBold)"
+        then: [t: "audacioso"]                  	# 	(en: 'bold', google translation)
+    - spell: "translate('.', '𝝰𝝱𝝲𝝳𝝴𝝵𝝶𝝷𝝸𝝹𝝺𝝻𝝼𝝽𝝾𝝿𝞀𝞁𝞂𝞃𝞄𝞅𝞆𝞇𝞈', 'αβγδεζηθικλμνξοπρςστυφχψω')"
+
+ - "-":                                       	#  0xf4d0 - 0xf4e8
+    - test:
+        if: "not($IgnoreBold)"
+        then: [t: "audacioso"]                  	# 	(en: 'bold', google translation)
+    - spell: "translate('.', '', 'αβγδεζηθικλμνξοπρςστυφχψω')"
+
+ - "𝞉𝞊𝞋𝞌𝞍𝞎𝞏":                                   	#  0x1d789 - 0x1d78f
+    - test:
+        if: "not($IgnoreBold)"
+        then: [t: "audacioso"]                  	# 	(en: 'bold', google translation)
+    - spell: "translate('.', '𝞉𝞊𝞋𝞌𝞍𝞎𝞏', '∂εθκφρπ')"
+
+ - "":                                   	#  0xf4e9 - 0xf4ef
+    - test:
+        if: "not($IgnoreBold)"
+        then: [t: "audacioso"]                  	# 	(en: 'bold', google translation)
+    - spell: "translate('.', '', '∂εθκφρπ')"
+
+ - "": [t: "ousado nabla"]                   	#  0xf4cf	(en: 'bold nahblah', google translation)
+ - "𝝯": [t: "ousado nabla"]                   	#  0x1d76f	(en: 'bold nahblah', google translation)
+
+ - "𝞐-𝞨":                                       	#  0x1d790 - 0x1d7a8
+    # - t: "bold italic"
+    - test:
+        if: "not($IgnoreBold)"
+        then: [t: "audacioso"]                  	# 	(en: 'bold', google translation)
+    - spell: "translate('.', '𝞐𝞑𝞒𝞓𝞔𝞕𝞖𝞗𝞘𝞙𝞚𝞛𝞜𝞝𝞞𝞟𝞠𝞡𝞢𝞣𝞤𝞥𝞦𝞧𝞨', 'ΑΒΓΔΕΖΗΘΙΚΛΜΝΞΟΠΡ΢ΣΤΥΦΧΨΩ')"
+
+ - "-":                                       	#  0xf4f0 - 0xf508
+    # - t: "bold italic"
+    - test:
+        if: "not($IgnoreBold)"
+        then: [t: "audacioso"]                  	# 	(en: 'bold', google translation)
+    - spell: "translate('.', '', 'ΑΒΓΔΕΖΗΘΙΚΛΜΝΞΟΠΡ΢ΣΤΥΦΧΨΩ')"
+
+ - "𝞪-𝟂":                                       	#  0x1d7aa - 0x1d7c2
+    # - t: "bold italic"
+    - test:
+        if: "not($IgnoreBold)"
+        then: [t: "audacioso"]                  	# 	(en: 'bold', google translation)
+    - spell: "translate('.', '𝞪𝞫𝞬𝞭𝞮𝞯𝞰𝞱𝞲𝞳𝞴𝞵𝞶𝞷𝞸𝞹𝞺𝞻𝞼𝞽𝞾𝞿𝟀𝟁𝟂', 'αβγδεζηθικλμνξοπρςστυφχψω')"
+
+ - "-":                                       	#  0xf50a - 0xf522
+    # - t: "bold italic"
+    - test:
+        if: "not($IgnoreBold)"
+        then: [t: "audacioso"]                  	# 	(en: 'bold', google translation)
+    - spell: "translate('.', '', 'αβγδεζηθικλμνξοπρςστυφχψω')"
+
+ - "𝟃𝟄𝟅𝟆𝟇𝟈𝟉":                                   	#  0x1d7c3 - 0x1d7c9
+    # - t: "bold italic"
+    - test:
+        if: "not($IgnoreBold)"
+        then: [t: "audacioso"]                  	# 	(en: 'bold', google translation)
+    - spell: "translate('.', '𝟃𝟄𝟅𝟆𝟇𝟈𝟉', '∂εθκφρπ')"
+
+ - "":                                   	#  0xf523 - 0xf529
+    # - t: "bold italic"
+    - test:
+        if: "not($IgnoreBold)"
+        then: [t: "audacioso"]                  	# 	(en: 'bold', google translation)
+    - spell: "translate('.', '', '∂εθκφρπ')"
+
+ - "": [t: "ousado nabla"]                   	#  0xf509	(en: 'bold nahblah', google translation)
+ - "𝞩": [t: "ousado nabla"]                   	#  0x1d7a9	(en: 'bold nahblah', google translation)
+
+ - "-":                                       	#  0xf52e - 0xf537  (old MathType)
+    - test:
+        if: "not($IgnoreBold)"
+        then: [t: "audacioso"]                  	# 	(en: 'bold', google translation)
+    - spell: "translate('.', '', '0123456789')"
+
+ - "𝟎-𝟗":                                       	#  0x1d7ce - 0x1d7d7
+    - test:
+        if: "not($IgnoreBold)"
+        then: [t: "audacioso"]                  	# 	(en: 'bold', google translation)
+    - spell: "translate('.', '𝟎𝟏𝟐𝟑𝟒𝟓𝟔𝟕𝟖𝟗', '0123456789')"
+
+ - "𝟬-𝟵":                                       	#  0x1D7EC - 0x1D7F5
+    - test:
+        if: "not($IgnoreBold)"
+        then: [t: "audacioso"]                  	# 	(en: 'bold', google translation)
+    - spell: "translate('.', '𝟬𝟭𝟮𝟯𝟰𝟱𝟲𝟳𝟴𝟵', '0123456789')"
+
+ - "-":                                       	#  0xf556 - 0xf55f  (old MathType)
+    - spell: "translate('.', '', '0123456789')"
+
+ - "𝟢-𝟫":                                       	#  0x1d7e2 - 0x1d7eb
+    - spell: "translate('.', '𝟢𝟣𝟤𝟥𝟦𝟧𝟨𝟩𝟪𝟫', '0123456789')"
+
+
+ - "𝟶-𝟿":                                       	#  0x1d7f6 - 0x1d7ff
+    - spell: "translate('.', '𝟶𝟷𝟸𝟹𝟺𝟻𝟼𝟽𝟾𝟿', '0123456789')"
+
+
+ - "": [t: "personagem desconhecido"]          	#  0xf700	(en: 'unknown character', google translation)
+ - "": [t: "triângulos inferior direito e inferior esquerdo"]	#  0xf726	(en: 'lower right and lower left triangles', google translation)
+ - "": [t: "extensor de reticências horizontais"]	#  0xf72d	(en: 'horizontal ellipsis extender', google translation)
+ - "": [t: "extensor de elipse horizontal da linha média"]	#  0xf72e	(en: 'midline horizontal ellipsis extender', google translation)
+ - "": [t: "extensor radical"]                 	#  0xf8e5	(en: 'radical extender', google translation)
+ - "": [t: "extensor de seta vertical"]        	#  0xf8e6	(en: 'vertical arrow extender', google translation)
+ - "": [t: "extensor de seta horizontal"]      	#  0xf8e7	(en: 'horizontal arrow extender', google translation)
+ - "": [t: "sinal registrado sem serifa"]      	#  0xf8e8	(en: 'registered sign sans serif', google translation)
+ - "": [t: "sinal de direitos autorais sem serifa"]	#  0xf8e9	(en: 'copyright sign sans serif', google translation)
+ - "": [t: "sinal de marca sem serifa"]        	#  0xf8ea	(en: 'trade mark sign sans serif', google translation)
+ - "": [t: "parêntese esquerdo superior"]      	#  0xf8eb	(en: 'left paren top', google translation)
+ - "": [t: "extensor de parênteses esquerdo"]  	#  0xf8ec	(en: 'left paren extender', google translation)
+ - "": [t: "parêntese esquerdo inferior"]      	#  0xf8ed	(en: 'left paren bottom', google translation)
+ - "": [t: "topo do colchete esquerdo"]        	#  0xf8ee	(en: 'left bracket top', google translation)
+ - "": [t: "extensor de suporte esquerdo"]     	#  0xf8ef	(en: 'left bracket extender', google translation)
+ - "": [t: "parte inferior do colchete esquerdo"]	#  0xf8f0	(en: 'left bracket bottom', google translation)
+ - "": [t: "parte superior da chave esquerda"] 	#  0xf8f1	(en: 'left brace top', google translation)
+ - "": [t: "chave esquerda no meio"]           	#  0xf8f2	(en: 'left brace mid', google translation)
+ - "": [t: "parte inferior da chave esquerda"] 	#  0xf8f3	(en: 'left brace bottom', google translation)
+ - "": [t: "extensor de cinta"]                	#  0xf8f4	(en: 'brace extender', google translation)
+ - "": [t: "extensor integral"]                	#  0xf8f5	(en: 'integral extender', google translation)
+ - "": [t: "parêntese direito no topo"]        	#  0xf8f6	(en: 'right paren top', google translation)
+ - "": [t: "extensor de parênteses direito"]   	#  0xf8f7	(en: 'right paren extender', google translation)
+ - "": [t: "parêntese direito inferior"]       	#  0xf8f8	(en: 'right paren bottom', google translation)
+ - "": [t: "topo do suporte direito"]          	#  0xf8f9	(en: 'right bracket top', google translation)
+ - "": [t: "extensor de suporte direito"]      	#  0xf8fa	(en: 'right bracket extender', google translation)
+ - "": [t: "parte inferior do suporte direito"]	#  0xf8fb	(en: 'right bracket bottom', google translation)
+ - "": [t: "topo da chave direita"]            	#  0xf8fc	(en: 'right brace top', google translation)
+ - "": [t: "chave direita no meio"]            	#  0xf8fd	(en: 'right brace mid', google translation)
+ - "": [t: "parte inferior da chave direita"]  	#  0xf8fe	(en: 'right brace bottom', google translation)
+ - "": [t: "logotipo da maçã"]                 	#  0xf8ff	(en: 'apple logo', google translation)
+ - "ﬀ": [t: "ss"]                               	#  0xfb00	(en: 'ff', google translation)
+ - "ﬁ": [t: "fi"]                               	#  0xfb01	(google translation)
+ - "ﬂ": [t: "flor"]                             	#  0xfb02	(en: 'fl', google translation)
+ - "ﬃ": [t: "ffi"]                              	#  0xfb03	(google translation)
+ - "ﬄ": [t: "ffl"]                              	#  0xfb04	(google translation)
+ - "ﬅ": [t: "pés"]                              	#  0xfb05	(en: 'ft', google translation)
+ - "ﬆ": [t: "rua"]                              	#  0xfb06	(en: 'st', google translation)
+ - "﬩": [t: "carta hebraica alternativa plus"]  	#  0xfb29	(en: 'hebrew letter alternative plus', google translation)
+ - "︠": [t: "ligadura deixou meio embelezamento"]	#  0xfe20	(en: 'ligature left half embellishment', google translation)
+ - "︡": [t: "enfeite da metade direita da ligadura"]	#  0xfe21	(en: 'ligature right half embellishment', google translation)
+ - "︢": [t: "til duplo à esquerda meio enfeite"]	#  0xfe22	(en: 'double tilde left half embellishment', google translation)
+ - "︣": [t: "enfeite de til duplo na metade direita"]	#  0xfe23	(en: 'double tilde right half embellishment', google translation)
+ - "︤": [t: "macron deixou meio enfeite"]       	#  0xfe24	(en: 'macron left half embellishment', google translation)
+ - "︥": [t: "enfeite da metade direita de macron"]	#  0xfe25	(en: 'macron right half embellishment', google translation)
+ - "︦": [t: "combinando embelezamento macron"]  	#  0xfe26	(en: 'conjoining macron embellishment', google translation)
+ - "︵": [t: "acima dos parênteses"]             	#  0xfe35	(en: 'over paren', google translation)
+ - "︶": [t: "entre parênteses"]                 	#  0xfe36	(en: 'under paren', google translation)
+ - "︷": [t: "sobre a cinta"]                    	#  0xfe37	(en: 'over brace', google translation)
+ - "︸": [t: "sob a cinta"]                      	#  0xfe38	(en: 'under brace', google translation)
+ - "︿": [t: "sobre o colchete angular"]         	#  0xfe3f	(en: 'over angle bracket', google translation)
+ - "﹀": [t: "sob colchete angular"]             	#  0xfe40	(en: 'under angle bracket', google translation)
+ - "﹡": [t: "pequeno asterisco"]                	#  0xfe61	(en: 'small asterisk', google translation)
+ - "﹢": [t: "pequena vantagem"]                 	#  0xfe62	(en: 'small plus', google translation)
+ - "﹣": [t: "pequeno menos"]                    	#  0xfe63	(en: 'small minus', google translation)
+ - "﹤": [t: "pequeno menos que"]                	#  0xfe64	(en: 'small less than', google translation)
+ - "﹥": [t: "pequeno maior que"]                	#  0xfe65	(en: 'small greater than', google translation)
+ - "﹦": [t: "pequenos iguais"]                  	#  0xfe66	(en: 'small equals', google translation)
+ - "＋": [t: "sinal de mais largura total"]      	#  0xff0b	(en: 'fullwidth plus sign', google translation)
+ - "＜": [t: "menor que"]                        	#  0xff1c	(en: 'less than', google translation)
+ - "＝": [t: "iguais"]                           	#  0xff1d	(en: 'equals', google translation)
+ - "＞": [t: "maior que"]                        	#  0xff1e	(en: 'greater than', google translation)
+ - "＼": [t: "barra invertida"]                  	#  0xff3c	(en: 'backslash', google translation)
+ - "＾": [t: "chapéu"]                           	#  0xff3e	(en: 'hat', google translation)
+ - "｜":                                         	#  0xff5c
+    # note: for ClearSpeak and SimpleSpeak, "|" inside of sets is handled at the mrow level, same for 'sets'
+     - with:
+        variables: [DefaultToGiven: "count(preceding-sibling::*)=1 and count(following-sibling::*)=1 and ../../../*[1][.='P']"]	#  P(A|B)
+        replace:
+        - test:
+            - if: "$SpeechStyle != 'ClearSpeak'"
+              then_test:
+                  if: "$DefaultToGiven"
+                  then: [t: "dado"]             	# 	(en: 'given', google translation)
+                  else: [t: "linha vertical"]   	# 	(en: 'vertical line', google translation)
+            - else_if: "not(preceding-sibling::*) or not(following-sibling::*)"
+              then: [t: "linha vertical"]       	# 	(en: 'vertical line', google translation)
+            - else_if: "$ClearSpeak_VerticalLine = 'SuchThat'"
+              then: [t: "tal isso"]             	# 	(en: 'such that', google translation)
+            - else_if: "$ClearSpeak_VerticalLine = 'Given' or $DefaultToGiven"
+              then: [t: "dado"]                 	# 	(en: 'given', google translation)
+            - else: [t: "divide"]               	# 	(en: 'divides', google translation)
+ - "～": [t: "til"]                              	#  0xff5e	(en: 'tilde', google translation)
+ - "￢": [t: "não"]                              	#  0xffe2	(en: 'not', google translation)
+ - "￩": [t: "seta para a esquerda"]             	#  0xffe9	(en: 'left arrow', google translation)
+ - "￪": [t: "seta para cima"]                   	#  0xffea	(en: 'up arrow', google translation)
+ - "￫": [t: "seta para a direita"]              	#  0xffeb	(en: 'right arrow', google translation)
+ - "￬": [t: "seta para baixo"]                  	#  0xffec	(en: 'down arrow', google translation)
+ - "￼": [t: "objeto desconhecido ou ausente"]   	#  0xfffc	(en: 'unknown or missing object', google translation)
+ - "�": [t: "caractere desconhecido ou ausente"]	#  0xfffd	(en: 'unknown or missing character', google translation)
+
+ - "🣑": [t: "está em equilíbrio com"]           	#  0x1F8D1	(en: 'is in equilibrium with', google translation)
+ - "🣒": [t: "está em equilíbrio polarizado para a direita com"]	#  0x1F8D2	(en: 'is in equilibrium biased to the right with', google translation)
+ - "🣓": [t: "está em equilíbrio inclinado para a esquerda com"]	#  0x1F8D3	(en: 'is in equilibrium biased to the left with', google translation)
+
+# MathJax v4 has adopted these PUA values for some partial chem bonds that aren't in Unicode
+ - "\uE410": [t: "ligação parcial"]             	#  0xe410	(en: 'partial bond ', google translation)
+ - "\uE411": [t: "ligação parcial dupla"]       	#  0xe411	(en: 'double partial bond ', google translation)
+ - "\uE412": [t: "ligação parcial tripla"]      	#  0xe412	(en: 'triple partial bond ', google translation)
+
+# MathJax v4 also adopted these PUA values for some arrows thar are in Unicode
+# Hopefully these will be exported properly in future versions of MathJax
+ - "\uE428": [spell: "'⟵'"]                     	#  0xe428  defer to def of arrow
+ - "\uE429": [spell: "'⟶'"]                     	#  0xe429  defer to def of arrow
+ - "\uE42A": [spell: "'⟷'"]                     	#  0xe42a  defer to def of arrow
+ - "\uE408": [spell: "'🣑'"]                     	#  0xe408  defer to def of arrow
+ - "\uE409": [spell: "'🣒'"]                     	#  0xe409  defer to def of arrow
+ - "\uE40A": [spell: "'🣓'"]                     	#  0xe40a  defer to def of arrow
+ - "\uE42B": [spell: "'⇄'"]                     	#  0xe42b  defer to def of arrow
+ - "\uE42C": [spell: "'←'"]                     	#  0xe42c  defer to def of arrow
+ - "\uE42D": [spell: "'→'"]                     	#  0xe42d  defer to def of arrow
+ - "\uE42E": [spell: "'⇄'"]                     	#  0xe42e  defer to def of arrow

--- a/Rules/Languages/pt/unicode.yaml
+++ b/Rules/Languages/pt/unicode.yaml
@@ -1,0 +1,506 @@
+---
+ # Note to translators:
+ #   most languages don't have two ways to pronounce 'a' -- if not need, remove the rules and change "B-Z" to "A-Z"
+ #   some languages say the word for "uppercase" after the letter. Make sure to change that where appropriate by moving some code around
+ - "a-z": 
+    - test: 
+        if: "$TTS='none'"
+        then: [t: "."]                          	# 	(google translation)
+        else: [spell: "'.'"]                       
+
+ # Capital letters are a little tricky: users can pick their favorite word (something that was requested) and 
+ # screen readers have options to use pitch changes or beeps instead of or in addition to say "cap"
+ # Also, if a user can see the screen, they probably don't need to hear "cap", but if they specified an override, they must want to hear the override.
+
+ - "A-Z":
+    - test: 
+        if: "$CapitalLetters_Beep"
+        then:
+        - audio:
+            value: "beep.mp4"
+            replace: []
+    - test: 
+        if: "$CapitalLetters_UseWord"
+        then_test:
+          if: "$SpeechOverrides_CapitalLetters = ''"
+          then_test:
+            if: "$Impairment = 'Blindness'"
+            then: [t: "maiúsculas"]             	# 	(en: 'cap', google translation)
+          else: [x: "$SpeechOverrides_CapitalLetters"] 
+    - pitch:
+        value: "$CapitalLetters_Pitch"
+        # note: processing of ranges converts '.' into the character, so it needs to be in quotes below
+        replace: [spell: "translate('.', 'ABCDEFGHIJKLMNOPQRSTUVWXYZ', 'abcdefghijklmnopqrstuvwxyz')"]
+
+ - "0-9": [t: "."]                              	# 	(google translation)
+
+ - " ": [t: " "]                                	#  0x20	(google translation)
+
+ - "!":                                         	#  0x21
+    - test:
+        if: "ancestor-or-self::*[contains(@data-intent-property, ':literal:')]"
+        then_test:
+            if: "$Verbosity = 'Terse'"
+            then: [t: "estrondo"]               	#  0x21	(en: 'bang', google translation)
+            else: [t: "ponto de exclamação"]    	#  0x21	(en: 'exclamation point', google translation)
+        else: [t: "fatorial"]                   	#  0x21	(en: 'factorial', google translation)
+          
+ - "\"": [t: "aspas"]                           	#  0x22	(en: 'quotation mark', google translation)
+ - "#": [t: "número"]                           	#  0x23	(en: 'number', google translation)
+ - "$": [t: "dólares"]                          	#  0x24	(en: 'dollars', google translation)
+ - "%": [t: "por cento"]                        	#  0x25	(en: 'percent', google translation)
+ - "&": [t: "e comercial"]                      	#  0x26	(en: 'ampersand', google translation)
+ - "'": [t: "apóstrofo"]                        	#  0x27	(en: 'apostrophe', google translation)
+ - "(":                                         	#  0x28
+    - test:
+        if: $SpeechStyle = 'ClearSpeak' or $SpeechStyle = 'SimpleSpeak'
+        then_test:
+            if: "$Verbosity='Terse'"
+            then: [t: "abrir"]                  	#  0x28	(en: 'open', google translation)
+            else: [t: "parênteses abertos"]     	#  0x28	(en: 'open paren', google translation)
+        else: [t: "parêntese esquerdo"]         	#  0x28	(en: 'left paren', google translation)
+ - ")":                                         	#  0x29
+    - test:
+        if: $SpeechStyle = 'ClearSpeak' or $SpeechStyle = 'SimpleSpeak'
+        then_test:
+            if: "$Verbosity='Terse'"
+            then: [t: "fechar"]                 	#  0x29	(en: 'close', google translation)
+            else: [t: "fechar parênteses"]      	#  0x29	(en: 'close paren', google translation)
+        else: [t: "parêntese direito"]          	#  0x29	(en: 'right paren', google translation)
+
+ - "*":                                         	#  0x2a
+    test:
+        if: "parent::*[name(.)='msup' or name(.)='msubsup' or name(.)='skip-super']"
+        then: [t: "estrela"]                    	#  0x2a	(en: 'star', google translation)
+        else: [t: "vezes"]                      	#  0x2a	(en: 'times', google translation)
+ - "+": [t: "mais"]                             	#  0x2b	(en: 'plus', google translation)
+ - ",":                                         	#  0x2c
+    # the following deals with the interaction of "," with "…" which sometimes wants the ',' to be silent
+    # that this test is here and not with "…" is not ideal, but seems simplest
+     test:
+        if:
+            - "$SpeechStyle != 'ClearSpeak' or $ClearSpeak_Ellipses = 'Auto' or "
+               # must be ClearSpeak and $ClearSpeak_Ellipses = 'AndSoOn'
+               # speak "comma" when not adjacent to '…'
+            - "( following-sibling::*[1][text()!= '…'] and preceding-sibling::*[1][text()!='…']  ) or "
+               # except if expression starts with '…'
+            - "../*[1][.='…'] "
+        then:
+        - t: "vírgula"                            	#  	(en: 'comma', google translation)
+        - test:
+            if: "$Verbosity != Terse"
+            then: [pause: short]
+        # else silent
+
+ - "-": [t: "menos"]                            	#  0x2d	(en: 'minus', google translation)
+ - ".":                                         	#  0x2e
+    - test:
+        if: "parent::*[1][self::m:mn]"
+        then: [t: "ponto"]                    	# 	(en: 'point', google translation)
+        else: [t: "ponto"]                      	# 	(en: 'dot', google translation)
+ - "/":                                         	#  0x2f
+    - test:
+        if: "ancestor-or-self::*[contains(@data-intent-property, ':literal:')]"
+        then: [t: "barra"]                      	#  0x2f	(en: 'slash', google translation)
+        else: [t: "dividido por"]               	#  0x2f	(en: 'divided by', google translation)
+
+ - ":": [t: "cólon"]                            	#  0x3a	(en: 'colon', google translation)
+ - ";": [t: "ponto e vírgula"]                  	#  0x3b	(en: 'semicolon', google translation)
+ - "<":                                         	#  0x3c
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [t: "é"]                         	# 	(en: 'is', google translation)
+     - t: "menor que"                           	# 	(en: 'less than', google translation)
+ - "=":                                         	#  0x3d
+    - test: 
+        if: "$Verbosity!='Terse'"
+        then: [t: "é igual a"]                  	# 	(en: 'is equal to', google translation)
+        else: [t: "iguais"]                     	# 	(en: 'equals', google translation)
+
+ - ">":                                         	#  0x3e
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [t: "é"]                         	# 	(en: 'is', google translation)
+     - t: "maior que"                           	# 	(en: 'greater than', google translation)
+ - "?": [t: "ponto de interrogação"]            	#  0x3f	(en: 'question mark', google translation)
+ - "@": [t: "no sinal"]                         	#  0x40	(en: 'at sign', google translation)
+ - "[":                                         	#  0x5b
+    - test:
+        if: $SpeechStyle = 'ClearSpeak' or $SpeechStyle = 'SimpleSpeak'
+        then: [t: "colchete aberto"]            	# 	(en: 'open bracket', google translation)
+        else: [t: "colchete esquerdo"]          	# 	(en: 'left bracket', google translation)
+ - "\\": [t: "barra invertida"]                 	#  0x5c	(en: 'back slash', google translation)
+ - "]":                                         	#  0x5d
+    - test:
+        if: $SpeechStyle = 'ClearSpeak' or $SpeechStyle = 'SimpleSpeak'
+        then: [t: "fechar colchete"]            	# 	(en: 'close bracket', google translation)
+        else: [t: "colchete direito"]           	# 	(en: 'right bracket', google translation)
+ - "^":                                         	#  0x5e
+    - test:
+        if: "parent::m:modified-variable or parent::m:mover"
+        then: [t: "chapéu"]                     	# 	(en: 'hat', google translation)
+        else: [t: "circunflexo"]                	# 	(en: 'caret', google translation)
+ - "_": [t: "sob a barra"]                      	#  0x5f	(en: 'under bar', google translation)
+ - "`": [t: "cova"]                             	#  0x60	(en: 'grave', google translation)
+ - "{":                                         	#  0x7b
+    - test:
+        if: $SpeechStyle = 'ClearSpeak' or $SpeechStyle = 'SimpleSpeak'
+        then: [t: "chave aberta"]               	# 	(en: 'open brace', google translation)
+        else: [t: "chave esquerda"]             	# 	(en: 'left brace', google translation)
+ - "|":                                         	#  0x7c
+    # note: for ClearSpeak and SimpleSpeak, "|" inside of sets is handled at the mrow level, same for 'sets'
+     - with:
+        variables: [DefaultToGiven: "count(preceding-sibling::*)=1 and count(following-sibling::*)=1 and ../../../*[1][.='P']"]	#  P(A|B)
+        replace:
+        - test:
+            - if: "ancestor-or-self::*[contains(@data-intent-property, ':literal:')]"
+              then: [t: "linha vertical"]       	# 	(en: 'vertical line', google translation)
+            - else_if: "$SpeechStyle != 'ClearSpeak'"
+              then_test:
+                - if: "$DefaultToGiven"
+                  then: [t: "dado"]             	# 	(en: 'given', google translation)
+                - else_if: "preceding-sibling::*[1][self::m:mn and not(contains(., $DecimalSeparators))] and 
+                            following-sibling::*[1][self::m:mn and not(contains(., $DecimalSeparators))]"
+                  then: [t: "divide"]           	# 	(en: 'divides', google translation)
+                  else: [t: "linha vertical"]   	# 	(en: 'vertical line', google translation)
+            - else_if: "not(preceding-sibling::*) or not(following-sibling::*)"
+              then: [t: "linha vertical"]       	# 	(en: 'vertical line', google translation)
+            - else_if: "$ClearSpeak_VerticalLine = 'SuchThat'"
+              then: [t: "tal isso"]             	# 	(en: 'such that', google translation)
+            - else_if: "$ClearSpeak_VerticalLine = 'Given' or $DefaultToGiven"
+              then: [t: "dado"]                 	# 	(en: 'given', google translation)
+            - else: [t: "divide"]               	# 	(en: 'divides', google translation)
+
+ - "}":                                         	#  0x7d
+    - test:
+        if: $SpeechStyle = 'ClearSpeak' or $SpeechStyle = 'SimpleSpeak'
+        then: [t: "chave fechada"]              	# 	(en: 'close brace', google translation)
+        else: [t: "chave direita"]              	# 	(en: 'right brace', google translation)
+
+ - "~": [t: "til"]                              	#  0x7e	(en: 'tilde', google translation)
+ - " ":                                         	#  0xa0
+    - test:
+        # could be mtext in mtd or mtext in an mrow that is a concatenation of mtd's. Is there a better solution?
+        if: "@data-empty-in-2D and not(ancestor::*[self::m:piecewise or self::m:system-of-equations or self::m:lines])"
+        then: [t: "vazio"]                      	#  want to say something for fraction (etc) with empty child	(en: 'empty', google translation)
+        else: [t: ""]                            
+
+ - "¬": [t: "não"]                              	#  0xac	(en: 'not', google translation)
+ - "°": [t: "graus"]                            	#  0xb0	(en: 'degrees', google translation)
+ - "±": [t: "mais ou menos"]                    	#  0xb1	(en: 'plus or minus', google translation)
+ - "´": [t: "agudo"]                            	#  0xb4	(en: 'acute', google translation)
+ - "·":                                         	#  0xB7
+    - test:
+        if: "ancestor-or-self::*[contains(@data-intent-property, ':literal:')] or not($SpeechStyle = 'ClearSpeak' and $ClearSpeak_MultSymbolDot = 'Auto')"
+        then: [t: "ponto"]                      	# 	(en: 'dot', google translation)
+        else: [t: "vezes"]                      	# 	(en: 'times', google translation)
+ - "×":                                         	#  0xd7
+    - test:
+        if: "$SpeechStyle = 'ClearSpeak'"
+        then_test:
+        - if: "$ClearSpeak_MultSymbolX = 'Auto'"
+          then: [t: "vezes"]                    	# 	(en: 'times', google translation)
+        - else_if: "$ClearSpeak_MultSymbolX = 'By'"
+          then: [t: "por"]                      	# 	(en: 'by', google translation)
+          else: [t: "cruzar"]                   	# 	(en: 'cross', google translation)
+        else_test:
+            if: "ancestor-or-self::*[contains(@data-intent-property, ':literal:')]"
+            then: [t: "cruzar"]                 	# 	(en: 'cross', google translation)
+            else: [t: "vezes"]                  	# 	(en: 'times', google translation)
+
+ - "÷": [t: "dividido por"]                     	#  0xf7	(en: 'divided by', google translation)
+ - "̀": [t: "embelezamento com sotaque grave"]  	#  0x300	(en: 'grave accent embellishment', google translation)
+ - "́": [t: "embelezamento de acento agudo"]    	#  0x301	(en: 'acute accent embellishment', google translation)
+ - "̂": [t: "embelezamento de acento circunflexo"]	#  0x302	(en: 'circumflex accent embellishment', google translation)
+ - "̃": [t: "enfeite de til"]                   	#  0x303	(en: 'tilde embellishment', google translation)
+ - "̄": [t: "embelezamento de macron"]          	#  0x304	(en: 'macron embellishment', google translation)
+ - "̅": [t: "enfeite superior"]                 	#  0x305	(en: 'overbar embellishment', google translation)
+ - "̆": [t: "breve"]                            	#  0x306	(google translation)
+ - "̇": [t: "ponto acima do enfeite"]           	#  0x307	(en: 'dot above embellishment', google translation)
+
+   # Note: ClearSpeak has pref TriangleSymbol for "Δ", but that is wrong
+ - "Α-Ω": 
+    - test: 
+        if: "$CapitalLetters_Beep"
+        then:
+        - audio:
+            value: "beep.mp4"
+            replace: []
+    - test: 
+        if: "$CapitalLetters_UseWord"
+        then_test:
+          if: "$SpeechOverrides_CapitalLetters = ''"
+          then_test:
+            if: "$Impairment = 'Blindness'"
+            then: [t: "maiúsculas"]             	# 	(en: 'cap', google translation)
+          else: [x: "$SpeechOverrides_CapitalLetters"] 
+    - pitch:
+        value: "$CapitalLetters_Pitch"
+        # note: processing of ranges converts '.' into the character, so it needs to be in quotes below
+        replace: [spell: "translate('.', 'ΑΒΓΔΕΖΗΘΙΚΛΜΝΞΟΠΡ΢ΣΤΥΦΧΨΩ', 'αβγδεζηθικλμνξοπρςστυφχψω')"]
+
+ - "α": [t: "alfa"]                             	#  0x3b1	(en: 'alpha', google translation)
+ - "β": [t: "beta"]                             	#  0x3b2	(google translation)
+ - "γ": [t: "gama"]                             	#  0x3b3	(en: 'gamma', google translation)
+ - "δ": [t: "delta"]                            	#  0x3b4	(google translation)
+ - "ε": [t: "épsilon"]                          	#  0x3b5	(en: 'epsilon', google translation)
+ - "ζ": [t: "zeta"]                             	#  0x3b6	(google translation)
+ - "η": [t: "eta"]                              	#  0x3b7	(google translation)
+ - "θ": [t: "teta"]                             	#  0x3b8	(en: 'theta', google translation)
+ - "ι": [t: "iota"]                             	#  0x3b9	(google translation)
+ - "κ": [t: "capa"]                             	#  0x3ba	(en: 'kappa', google translation)
+ - "λ": [t: "lambda"]                           	#  0x3bb	(google translation)
+ - "μ": [t: "mu"]                               	#  0x3bc	(google translation)
+ - "ν": [t: "nu"]                               	#  0x3bd	(en: 'nu', google translation)
+ - "ξ": [t: "xi"]                               	#  0x3be	(google translation)
+ - "ο": [t: "ômicron"]                          	#  0x3bf	(en: 'omicron', google translation)
+ - "π": [t: "pi"]                               	#  0x3c0	(google translation)
+ - "ρ": [t: "rô"]                               	#  0x3c1	(en: 'rho', google translation)
+ - "ς": [t: "sigma final"]                      	#  0x3c2	(en: 'final sigma', google translation)
+ - "σ": [t: "sigma"]                            	#  0x3c3	(google translation)
+ - "τ": [t: "tau"]                              	#  0x3c4	(google translation)
+ - "υ": [t: "upsilon"]                          	#  0x3c5	(google translation)
+ - "φ": [t: "fi"]                               	#  0x3c6	(en: 'phi', google translation)
+ - "χ": [t: "qui"]                              	#  0x3c7	(en: 'chi', google translation)
+ - "ψ": [t: "psi"]                              	#  0x3c8	(google translation)
+ - "ω": [t: "ômega"]                            	#  0x3c9	(en: 'omega', google translation)
+ - "ϕ": [t: "fi"]                               	#  0x3d5	(en: 'phi', google translation)
+ - "ϖ": [t: "pi"]                               	#  0x3d6	(google translation)
+ - "ϵ": [t: "épsilon"]                          	#  0x3f5	(en: 'epsilon', google translation)
+ - "϶": [t: "épsilon invertido"]                	#  0x3f6	(en: 'reversed epsilon', google translation)
+
+ - "⁡":                                         	#  0x2061
+    - test:
+        # skip saying "of" when Terse and a trig function, when it is a shape (does this happen?), or we are in :literal mode
+        if: "not(
+              ( $Verbosity='Terse' or ($SpeechStyle = 'ClearSpeak' and IsNode(following-sibling::*[1],'simple')) and
+                preceding-sibling::*[1][IfThenElse($SpeechStyle='ClearSpeak',
+                                                   IsInDefinition(., 'ClearSpeakTrigFunctionNames'),
+                                                   IsInDefinition(., 'TrigFunctionNames') )]
+              ) or
+              preceding-sibling::*[1][IsInDefinition(., 'GeometryShapes')] or
+              (@data-changed='added' and ancestor-or-self::*[contains(@data-intent-property, ':literal:')])
+            )"
+        then: [t: "de"]                         	# 	(en: 'of', google translation)
+ - "⁢": [t: ""]                                 	#  0x2062
+ - "⁣": [t: ""]                                 	#  0x2063
+ - "⁤": [t: "e"]                                	#  0x2064	(en: 'and', google translation)
+ - "ℂℕℚℝℤ":                                     	#  here we rely on this running through the table again to speak "cap xxx"
+    - t: "dupla escrita"                        	# 	(en: 'double-struck', google translation)
+    - spell: "translate('.', 'ℂℕℚℝℤ', 'CNQRZ')"
+
+ - "℃": [t: "graus celsius"]                    	#  0x2103	(en: 'degrees celsius', google translation)
+ - "ℋℛℓ":                                       	#  0x210b
+    - t: "cursiva"                              	# 	(en: 'script', google translation)
+    - spell: "translate('.', 'ℋℛℓ', 'HRl')"
+ - "ℜ":                                         	#  0x211c
+    - t: "gótica"                               	# 	(en: 'fraktur', google translation)
+    - spell: "'R'"
+
+ - "ⅆⅇⅈⅉ":                                      	#  0x2146-9
+    - t: "dupla escrita itálica"                	# 	(en: 'double-struck italic', google translation)
+    - spell: "translate('.', 'ⅆⅇⅈⅉ', 'deij')"
+
+ - "←": [t: "seta para a esquerda"]             	#  0x2190	(en: 'left arrow', google translation)
+ - "↑": [t: "seta para cima"]                   	#  0x2191	(en: 'up arrow', google translation)
+ - "→":                                         	#  0x2192
+     - test:
+        if: "ancestor::*[2][self::m:limit]"
+        then: [t: "abordagens"]                 	# 	(en: 'approaches', google translation)
+        else: [t: "seta para a direita"]        	# 	(en: 'right arrow', google translation)
+
+ - "↓": [t: "seta para baixo"]                  	#  0x2193	(en: 'down arrow', google translation)
+ - "∈":                                         	#  0x2208
+     - test:
+        if: "$SpeechStyle != 'ClearSpeak'"
+        then:
+        - test:
+            if: "$Verbosity!='Terse' and not(ancestor::*[self::m:set])"	#  "the set x is an element of ..." sounds bad"
+            then: [t: "é"]                      	# 	(en: 'is', google translation)
+        - t: "um elemento de"                   	# 	(en: 'an element of', google translation)
+        # Several options for speaking elements in ClearSpeak -- they split between being inside a set or not and then the option
+        else_test:
+            if: "../../self::m:set or ../../../self::m:set"	#  inside a set
+            then_test:
+              - if: $ClearSpeak_SetMemberSymbol = 'Auto' or $ClearSpeak_SetMemberSymbol = 'In'
+                then: [t: "dentro"]             	# 	(en: 'in', google translation)
+              - else_if: $ClearSpeak_SetMemberSymbol = 'Member'
+                then: [t: "membro de"]          	# 	(en: 'member of', google translation)
+              - else_if: $ClearSpeak_SetMemberSymbol = 'Element'
+                then: [t: "elemento de"]        	# 	(en: 'element of', google translation)
+              - else: [t: "pertencente a"]      	#  $ClearSpeak_SetMemberSymbol = 'Belongs'	(en: 'belonging to', google translation)
+            else_test:
+              - if: $ClearSpeak_SetMemberSymbol = 'Auto' or $ClearSpeak_SetMemberSymbol = 'Member'
+                then: [t: "é membro de"]        	# 	(en: 'is a member of', google translation)
+              - else_if: $ClearSpeak_SetMemberSymbol = 'Element'
+                then: [t: "é um elemento de"]   	# 	(en: 'is an element of', google translation)
+              - else_if: $ClearSpeak_SetMemberSymbol = 'In'
+                then: [t: "está dentro"]        	# 	(en: 'is in', google translation)
+              - else: [t: "pertence"]           	#  $ClearSpeak_SetMemberSymbol = 'Belongs'	(en: 'belongs to', google translation)
+ - "∥":                                         	#  0x2225
+     - test:
+         if: "ancestor-or-self::*[contains(@data-intent-property, ':literal:')]"
+         then: [t: "linha vertical dupla"]      	# 	(en: 'double vertical line', google translation)
+         else:
+         - test:
+              if: "$Verbosity!='Terse'"
+              then: [t: "é"]                    	# 	(en: 'is', google translation)
+         - t: "paralelo a"                      	# 	(en: 'parallel to', google translation)
+ - "∦":                                         	#  0x2226
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [t: "é"]                         	# 	(en: 'is', google translation)
+     - t: "não paralelo a"                      	# 	(en: 'not parallel to', google translation)
+ - "≤":                                         	#  0x2264
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [t: "é"]                         	# 	(en: 'is', google translation)
+     - t: "menor ou igual a"                    	# 	(en: 'less than or equal to', google translation)
+ - "≥":                                         	#  0x2265
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [t: "é"]                         	# 	(en: 'is', google translation)
+     - t: "maior ou igual a"                    	# 	(en: 'greater than or equal to', google translation)
+
+ # --- restored complex short definitions (prefer over unicode-full) ---
+ - "…":                                         	#  0x2026
+    test:
+        if:
+            - "$SpeechStyle != 'ClearSpeak' or $ClearSpeak_Ellipses = 'Auto' or"
+               # must be ClearSpeak and $ClearSpeak_Ellipses = 'AndSoOn'
+               # speak '…' as 'and so on...' unless expr starts with '…'
+            - "../*[1][.='…']"
+        then: [t: "ponto ponto ponto"]          	# 	(en: 'dot dot dot', google translation)
+        else_test:                              	#  must have $ClearSpeak_Ellipses = 'AndSoOn'
+            if: "count(following-sibling::*) = 0"
+            then: [t: "e assim por diante"]     	# 	(en: 'and so on', google translation)
+            else: [t: "e assim por diante"]     	# 	(en: 'and so on up to', google translation)
+ - "∂":                                         	#  0x2202
+     - test: 
+         if: "$Verbosity='Terse'"
+         then: [t: "parcial"]                   	# 	(en: 'partial', google translation)
+         else: [t: "derivada parcial"]          	# 	(en: 'partial derivative', google translation)
+ - "∆":                                         	#  0x2206
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [ot: "o"]                        	# 	(en: 'the', google translation)
+     - t: "laplaciano de"                       	# 	(en: 'laplacian of', google translation)
+ - "∉":                                         	#  0x2209
+    # rule is identical to 0x2208
+     - test:
+        if: "$SpeechStyle != 'ClearSpeak'"
+        then:
+        - test: 
+            if: "$Verbosity!='Terse'"
+            then: [t: "é"]                      	# 	(en: 'is', google translation)
+        - t: "não é um elemento de"             	# 	(en: 'not an element of', google translation)
+        # Several options for speaking elements in ClearSpeak -- they split between being inside a set or not and then the option
+        else_test:
+            if: "../../self::m:set or ../../../self::m:set"	#  inside a set
+            then_test:
+              - if: $ClearSpeak_SetMemberSymbol = 'Auto' or $ClearSpeak_SetMemberSymbol = 'In'
+                then: [t: "não dentro"]         	# 	(en: 'not in', google translation)
+              - else_if: $ClearSpeak_SetMemberSymbol = 'Member'
+                then: [t: "não é membro de"]    	# 	(en: 'not member of', google translation)
+              - else_if: $ClearSpeak_SetMemberSymbol = 'Element'
+                then: [t: "não elemento de"]    	# 	(en: 'not element of', google translation)
+              - else: [t: "não pertencente a"]  	#  $ClearSpeak_SetMemberSymbol = 'Belongs'	(en: 'not belonging to', google translation)
+            else_test:
+              - if: $ClearSpeak_SetMemberSymbol = 'Auto' or $ClearSpeak_SetMemberSymbol = 'Member'
+                then: [t: "não é membro de"]    	# 	(en: 'is not a member of', google translation)
+              - else_if: $ClearSpeak_SetMemberSymbol = 'Element'
+                then: [t: "não é um elemento de"]	# 	(en: 'is not an element of', google translation)
+              - else_if: $ClearSpeak_SetMemberSymbol = 'In'
+                then: [t: "não está dentro"]    	# 	(en: 'is not in', google translation)
+              - else: [t: "não pertence"]       	#  $ClearSpeak_SetMemberSymbol = 'Belongs'	(en: 'does not belong to', google translation)
+ - "∊":                                         	#  0x220a
+     - test:
+        if: "$SpeechStyle != 'ClearSpeak'"
+        then:
+        - test: 
+            if: "$Verbosity!='Terse' and not(ancestor::*[self::m:set])"	#  "the set x is an element of ..." sounds bad"
+            then: [t: "é"]                      	# 	(en: 'is', google translation)
+        - t: "um elemento de"                   	# 	(en: 'an element of', google translation)
+        # Several options for speaking elements in ClearSpeak -- they split between being inside a set or not and then the option
+        else_test:
+            if: "../../self::m:set or ../../../self::m:set"	#  inside a set
+            then_test:
+              - if: $ClearSpeak_SetMemberSymbol = 'Auto' or $ClearSpeak_SetMemberSymbol = 'In'
+                then: [t: "dentro"]             	# 	(en: 'in', google translation)
+              - else_if: $ClearSpeak_SetMemberSymbol = 'Member'
+                then: [t: "membro de"]          	# 	(en: 'member of', google translation)
+              - else_if: $ClearSpeak_SetMemberSymbol = 'Element'
+                then: [t: "elemento de"]        	# 	(en: 'element of', google translation)
+              - else: [t: "pertencente a"]      	#  $ClearSpeak_SetMemberSymbol = 'Belongs'	(en: 'belonging to', google translation)
+            else_test:
+              - if: $ClearSpeak_SetMemberSymbol = 'Auto' or $ClearSpeak_SetMemberSymbol = 'Member'
+                then: [t: "é membro de"]        	# 	(en: 'is a member of', google translation)
+              - else_if: $ClearSpeak_SetMemberSymbol = 'Element'
+                then: [t: "é um elemento de"]   	# 	(en: 'is an element of', google translation)
+              - else_if: $ClearSpeak_SetMemberSymbol = 'In'
+                then: [t: "está dentro"]        	# 	(en: 'is in', google translation)
+              - else: [t: "pertence"]           	#  $ClearSpeak_SetMemberSymbol = 'Belongs'	(en: 'belongs to', google translation)
+ - "√":                                         	#  0x221a
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [ot: "o"]                        	# 	(en: 'the', google translation)
+     - t: "raiz quadrada de"                    	# 	(en: 'square root of', google translation)
+ - "∝":                                         	#  0x221d
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [t: "é"]                         	# 	(en: 'is', google translation)
+     - t: "proporcional a"                      	# 	(en: 'proportional to', google translation)
+ - "∶":                                         	#  0x2236
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [t: "é"]                         	# 	(en: 'is', google translation)
+     - t: "para"                                	# 	(en: 'to', google translation)
+ - "∾":                                         	#  0x223e
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [t: "é"]                         	# 	(en: 'is', google translation)
+     - t: "mais positivo"                       	# 	(en: 'most positive', google translation)
+ - "≠":                                         	#  0x2260
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [t: "é"]                         	# 	(en: 'is', google translation)
+     - t: "não é igual a"                       	# 	(en: 'not equal to', google translation)
+ - "≡":                                         	#  0x2261
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [t: "é"]                         	# 	(en: 'is', google translation)
+     - t: "idêntico a"                          	# 	(en: 'identical to', google translation)
+ - "⊂":                                         	#  0x2282
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [t: "é um"]                      	# 	(en: 'is a', google translation)
+     - t: "subconjunto de"                      	# 	(en: 'subset of', google translation)
+ - "⊃":                                         	#  0x2283
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [t: "é um"]                      	# 	(en: 'is a', google translation)
+     - t: "superconjunto de"                    	# 	(en: 'superset of', google translation)
+ - "⊄":                                         	#  0x2284
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [t: "é"]                         	# 	(en: 'is', google translation)
+     - t: "não é um subconjunto de"             	# 	(en: 'not a subset of', google translation)
+ - "⊅":                                         	#  0x2285
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [t: "é"]                         	# 	(en: 'is', google translation)
+     - t: "não um superconjunto de"             	# 	(en: 'not a superset of', google translation)
+ - "⊆":                                         	#  0x2286
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [t: "é um"]                      	# 	(en: 'is a', google translation)
+     - t: "subconjunto de ou igual a"           	# 	(en: 'subset of or equal to', google translation)
+ - "⊇":                                         	#  0x2287
+     - test: 
+         if: "$Verbosity!='Terse'"
+         then: [t: "é um"]                      	# 	(en: 'is a', google translation)
+     - t: "superconjunto de ou igual a"         	# 	(en: 'superset of or equal to', google translation)
+
+ # --- restored short definitions that differ from unicode-full ---
+ - "⇒": [t: "seta dupla para a direita"]        	#  0x21d2	(en: 'right double arrow', google translation)
+ - "∐": [t: "coproduto"]                        	#  0x2210	(en: 'co-product', google translation)

--- a/tests/Languages/pt.rs
+++ b/tests/Languages/pt.rs
@@ -1,0 +1,34 @@
+#![allow(non_snake_case)]
+
+mod ClearSpeak {
+    mod functions;
+    mod large_ops;
+    mod menclose;
+    mod mfrac;
+    mod mroot;
+    mod msup;
+    mod sets;
+    mod symbols_and_adornments;
+    mod multiline;
+}
+
+mod SimpleSpeak {
+    mod functions;
+    mod large_ops;
+    // mod menclose;
+    mod mfrac;
+    // mod mroot;
+    mod msup;
+    mod sets;
+    mod geometry;
+    mod linear_algebra;
+    mod multiline;
+    mod subscripts;
+}
+mod shared;
+mod units;
+mod chemistry;
+mod alphabets;
+mod intent;
+mod mtable;
+

--- a/tests/Languages/pt/ClearSpeak/functions.rs
+++ b/tests/Languages/pt/ClearSpeak/functions.rs
@@ -1,0 +1,574 @@
+﻿/// Tests for:
+/// *  functions including trig functions, logs, and functions to powers
+/// *  implied times/functional call and explicit times/function call
+/// *  parens
+/// These are all intertwined, so they are in one file
+use crate::common::*;
+use anyhow::Result;
+
+#[test]
+fn trig_names() -> Result<()> {
+    let expr = "<math><mrow>
+    <mi>sin</mi><mi>x</mi><mo>+</mo>
+    <mi>cos</mi><mi>y</mi><mo>+</mo>
+    <mi>tan</mi><mi>z</mi><mo>+</mo>
+    <mi>sec</mi><mi>&#x03B1;</mi><mo>+</mo>
+    <mi>csc</mi><mi>&#x03D5;</mi><mo>+</mo>
+    <mi>cot</mi><mi>&#x03C6;</mi>
+    </mrow></math>";
+    test("pt", "ClearSpeak", expr, "sine x plus cosine y plus tangent z plus secant alpha, plus cosecant phi, plus cotangent phi")?;
+    return Ok(());
+
+}
+
+#[test]
+fn hyperbolic_trig_names() -> Result<()> {
+    let expr = "<math><mrow>
+    <mi>sinh</mi><mi>x</mi><mo>+</mo>
+    <mi>cosh</mi><mi>y</mi><mo>+</mo>
+    <mi>tanh</mi><mi>z</mi><mo>+</mo>
+    <mi>sech</mi><mi>&#x03B1;</mi><mo>+</mo>
+    <mi>csch</mi><mi>&#x03D5;</mi><mo>+</mo>
+    <mi>coth</mi><mi>&#x03C6;</mi>
+    </mrow></math>";
+    test("pt", "ClearSpeak", expr, "hyperbolic sine of x, plus \
+                                hyperbolic cosine of y, plus \
+                                hyperbolic tangent of z, plus \
+                                hyperbolic secant of alpha, plus \
+                                hyperbolic cosecant of phi, plus \
+                                hyperbolic cotangent of phi")?;
+                                return Ok(());
+
+}
+
+
+#[test]
+fn inverse_trig() -> Result<()> {
+    let expr = "<math><msup><mi>sin</mi><mrow><mo>-</mo><mn>1</mn></mrow></msup><mi>x</mi></math>";
+    test("pt", "ClearSpeak", expr, "inverse sine of x")?;
+    return Ok(());
+
+}
+
+#[test]
+fn inverse_trig_trig_inverse() -> Result<()> {
+    let expr = "<math><msup><mi>tan</mi><mrow><mo>-</mo><mn>1</mn></mrow></msup><mi>x</mi></math>";
+    test_ClearSpeak("pt", "ClearSpeak_Trig", "TrigInverse",expr,
+        "tangent inverse of x")?;
+        return Ok(());
+
+}
+
+#[test]
+fn inverse_trig_arc() -> Result<()> {
+    let expr = "<math><msup><mi>cosh</mi><mrow><mo>-</mo><mn>1</mn></mrow></msup><mi>x</mi></math>";
+    test_ClearSpeak("pt", "ClearSpeak_Trig", "ArcTrig",expr,
+        "arc hyperbolic cosine of x")?;
+        return Ok(());
+
+}
+
+#[test]
+fn trig_squared() -> Result<()> {
+    let expr = "<math><msup><mi>sin</mi><mn>2</mn></msup><mi>x</mi></math>";
+    test("pt", "ClearSpeak", expr, "sine squared of x")?;
+    return Ok(());
+
+}
+
+#[test]
+fn trig_cubed() -> Result<()> {
+    let expr = "<math><msup><mi>tan</mi><mn>3</mn></msup><mi>x</mi></math>";
+    test("pt", "ClearSpeak", expr, "tangent cubed of x")?;
+    return Ok(());
+
+}
+
+#[test]
+fn trig_fourth() -> Result<()> {
+    let expr = "<math><msup><mi>sec</mi><mn>4</mn></msup><mi>x</mi></math>";
+    test("pt", "ClearSpeak", expr, "the fourth power of, secant of x")?;
+    return Ok(());
+
+}
+
+
+#[test]
+fn trig_power_other() -> Result<()> {
+    let expr = "<math><msup><mi>sinh</mi><mrow>><mi>n</mi><mo>-</mo><mn>1</mn></mrow></msup><mi>x</mi></math>";
+    test("pt", "ClearSpeak", expr, "the n minus 1 power of, hyperbolic sine of x")?;
+    return Ok(());
+
+}
+
+#[test]
+fn simple_log() -> Result<()> {
+    let expr = "<math> <mrow>  <mi>log</mi><mi>x</mi></mrow> </math>";
+    test("pt", "ClearSpeak", expr, "log x")?;
+    return Ok(());
+
+}
+
+#[test]
+fn principal_value_log() -> Result<()> {
+    let expr = "<math><mrow><mi>Log</mi><mi>z</mi></mrow></math>";
+    test("pt", "ClearSpeak", expr, "the principal value log of z")?;
+    return Ok(());
+
+}
+
+#[test]
+fn normal_log() -> Result<()> {
+    let expr = "<math><mrow><mi>log</mi><mrow><mo>(</mo><mrow><mi>x</mi><mo>+</mo><mi>y</mi></mrow><mo>)</mo></mrow></mrow></math>";
+    test("pt", "ClearSpeak", expr, "the log of, open paren x plus y, close paren")?;
+    return Ok(());
+
+}
+
+#[test]
+fn simple_log_with_base() -> Result<()> {
+    let expr = "<math> <mrow>  <msub><mi>log</mi><mi>b</mi></msub><mi>x</mi></mrow> </math>";
+    test("pt", "ClearSpeak", expr, "the log base b, of x")?;
+    return Ok(());
+
+}
+
+#[test]
+fn normal_log_with_base() -> Result<()> {
+    let expr = "<math><mrow><msub><mi>log</mi><mi>b</mi></msub><mrow><mo>(</mo><mrow><mi>x</mi><mo>+</mo><mi>y</mi></mrow><mo>)</mo></mrow></mrow></math>";
+    test("pt", "ClearSpeak", expr, "the log base b, of, open paren x plus y, close paren")?;
+    return Ok(());
+
+}
+
+#[test]
+fn simple_ln() -> Result<()> {
+    let expr = "<math> <mrow>  <mi>ln</mi><mi>x</mi></mrow> </math>";
+    test("pt", "ClearSpeak", expr, "l n x")?;
+    return Ok(());
+
+}
+
+#[test]
+fn normal_ln() -> Result<()> {
+    let expr = "<math><mrow><mi>ln</mi><mrow><mo>(</mo><mrow><mi>x</mi><mo>+</mo><mi>y</mi></mrow><mo>)</mo></mrow></mrow></math>";
+    test("pt", "ClearSpeak", expr, "the l n of, open paren x plus y, close paren")?;
+    return Ok(());
+
+}
+
+    
+#[test]
+fn simple_natural_log() -> Result<()> {
+    let expr = "<math> <mrow>  <mi>ln</mi><mi>x</mi></mrow> </math>";
+    test_ClearSpeak("pt", "ClearSpeak_Log", "LnAsNaturalLog",expr,
+        "natural log x")?;
+        return Ok(());
+
+}
+
+    
+#[test]
+fn natural_log() -> Result<()> {
+    let expr = "<math><mi>ln</mi><mo>(</mo><mi>x</mi><mo>+</mo><mi>y</mi><mo>)</mo></math>";
+    test_ClearSpeak("pt", "ClearSpeak_Log", "LnAsNaturalLog",expr,
+        "the natural log of, open paren x plus y, close paren")?;
+        return Ok(());
+
+}
+
+
+#[test]
+fn explicit_function_call_with_parens() -> Result<()> {
+    let expr = "<math><mrow><mi>t</mi><mo>&#x2061;</mo><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>";
+    test("pt", "ClearSpeak", expr, "t of x")?;
+    return Ok(());
+
+}
+
+
+#[test]
+fn explicit_times_with_parens() -> Result<()> {
+    let expr = "<math><mrow><mi>t</mi><mo>&#x2062;</mo><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>";
+    test("pt", "ClearSpeak", expr, "t times x")?;
+    return Ok(());
+
+}
+
+#[test]
+fn explicit_function_call() -> Result<()> {
+    let expr = "<math><mrow><mi>t</mi><mo>&#x2061;</mo><mrow><mi>x</mi></mrow></mrow></math>";
+    test("pt", "ClearSpeak", expr, "t of x")?;
+    return Ok(());
+
+}
+
+#[test]
+fn explicit_times() -> Result<()> {
+    let expr = "<math><mrow><mi>t</mi><mo>&#x2062;</mo><mrow><mi>x</mi></mrow></mrow></math>";
+    test("pt", "ClearSpeak", expr, "t x")?;
+    return Ok(());
+
+}
+
+
+#[test]
+fn test_functions_none_pref() -> Result<()> {
+    let expr = "<math>
+    <mi>log</mi><mo>&#x2061;</mo><mrow><mo>(</mo><mrow><mi>x</mi><mo>+</mo><mi>y</mi></mrow><mo>)</mo></mrow>
+    <mo>+</mo>
+    <mi>f</mi><mo>&#x2061;</mo><mrow><mo>(</mo><mrow><mi>x</mi><mo>+</mo><mi>y</mi></mrow><mo>)</mo></mrow>
+    </math>";
+    test_ClearSpeak("pt", "ClearSpeak_Functions", "None",expr,
+        "the log of, open paren x plus y, close paren; plus, f times, open paren x plus y, close paren")?;
+        return Ok(());
+
+}
+
+#[test]
+fn test_functions_none_pref_multiple_args() -> Result<()> {
+    let expr = "<math>
+        <mi>B</mi> <mrow><mo>(</mo> <mrow> <mn>2</mn><mo>,</mo><mn>6</mn></mrow> <mo>)</mo></mrow>
+    </math>";
+    test_ClearSpeak("pt", "ClearSpeak_Functions", "None",expr,
+        "cap b times, open paren 2 comma, 6, close paren")?;
+        return Ok(());
+
+}
+
+
+/*
+    * Tests for times
+    */
+#[test]
+fn no_times_binomial() -> Result<()> {
+    let expr = "<math><mrow><mi>x</mi> <mo>&#x2062;</mo> <mi>y</mi></mrow></math>";
+    test("pt", "ClearSpeak", expr, "x y")?;
+    return Ok(());
+
+}
+
+#[test]
+fn times_following_paren() -> Result<()> {
+    let expr = "<math><mrow>
+        <mn>2</mn>
+        <mrow>  <mo>(</mo> <mn>3</mn>  <mo>)</mo> </mrow>
+        </mrow></math>";
+    test("pt", "ClearSpeak", expr, "2 times 3")?;
+    return Ok(());
+
+}
+
+#[test]
+fn times_preceding_paren() -> Result<()> {
+    let expr = "<math><mrow>
+        <mrow>  <mo>(</mo> <mn>2</mn>  <mo>)</mo> </mrow>
+        <mn>3</mn>
+        </mrow></math>";
+    test("pt", "ClearSpeak", expr, "2 times 3")?;
+    return Ok(());
+
+}
+
+#[test]
+fn times_sqrt() -> Result<()> {
+    let expr = "<math><mrow>
+        <msqrt> <mi>a</mi>  </msqrt>
+        <msqrt> <mi>b</mi>  </msqrt>
+        <mo>=</mo>
+        <msqrt> <mrow>  <mi>a</mi><mi>b</mi></mrow> </msqrt>
+        </mrow></math>";
+    test("pt", "ClearSpeak", expr, "the square root of eigh; times the square root of b; is equal to, the square root of eigh b")?;
+    return Ok(());
+
+}
+
+#[test]
+fn more_implied_times() -> Result<()> {
+    let expr = "<math><mrow>
+    <mrow>
+    <msup>
+        <mrow>
+        <mrow><mo>(</mo>
+        <mrow> <mn>2</mn><mi>x</mi></mrow>
+        <mo>)</mo></mrow></mrow>
+        <mn>2</mn>
+    </msup>
+    </mrow>
+    </mrow></math>";
+    test_ClearSpeak("pt", "ClearSpeak_ImpliedTimes", "MoreImpliedTimes",expr,
+        "open paren 2 times x, close paren squared")?;
+        return Ok(());
+
+}
+
+#[test]
+fn explicit_times_more_implied_times() -> Result<()> {
+    let expr = "<math><mrow><mi>t</mi><mo>&#x2062;</mo><mrow><mi>x</mi></mrow></mrow></math>";
+    test_ClearSpeak("pt", "ClearSpeak_ImpliedTimes", "MoreImpliedTimes",expr, "t times x")?;
+    return Ok(());
+
+}
+
+#[test]
+fn explicit_times_none_simple_right() -> Result<()> {
+    let expr = "<math><mn>2</mn><mo>[</mo><mn>3</mn> <mo>]</mo></math>";
+    test_ClearSpeak("pt", "ClearSpeak_ImpliedTimes", "None",
+        expr, "2, open bracket 3 close bracket")?;
+        return Ok(());
+
+}
+
+#[test]
+fn explicit_times_none_simple_left() -> Result<()> {
+    let expr = "<math><mo>(</mo><mn>2</mn><mo>&#x2212;</mo><mn>1</mn><mo>)</mo><mi>x</mi></math>";
+    test_ClearSpeak("pt", "ClearSpeak_ImpliedTimes", "None",
+        expr, "open paren 2 minus 1, close paren; x")?;
+        return Ok(());
+
+}
+
+#[test]
+fn explicit_times_none_superscript() -> Result<()> {
+    let expr = "<math> 
+    <mi>f</mi><mo>(</mo><mi>x</mi><mo>)</mo><mo>=</mo><msup>
+<mi>x</mi>
+<mn>2</mn>
+</msup>
+<mrow><mo>(</mo>
+<mrow>
+<mi>x</mi><mo>+</mo><mn>1</mn></mrow>
+<mo>)</mo></mrow>
+    </math>";
+    test_ClearSpeak_prefs("pt", 
+        vec![("ClearSpeak_ImpliedTimes", "None"), ("ClearSpeak_Functions", "None")],
+        expr, "f open paren x close paren; is equal to; x squared, open paren x plus 1, close paren")?;
+        return Ok(());
+
+}
+
+/*
+    * Tests for parens
+    */
+    #[test]
+    fn no_parens_number() -> Result<()> {
+        let expr = "<math><mrow>
+        <mrow><mo>(</mo>
+        <mn>25</mn>
+        <mo>)</mo></mrow>
+        <mi>x</mi>
+        </mrow></math>";
+        test("pt", "ClearSpeak", expr, "25 times x")?;
+        return Ok(());
+
+    }
+
+    #[test]
+    fn no_parens_monomial() -> Result<()> {
+        let expr = "<math><mrow>
+        <mi>b</mi>
+        <mrow><mo>(</mo>
+        <mrow><mi>x</mi><mi>y</mi></mrow>
+        <mo>)</mo></mrow>
+        </mrow></math>";
+        test("pt", "ClearSpeak", expr, "b, open paren x y close paren")?;
+        return Ok(());
+
+    }
+
+    #[test]
+    fn no_parens_negative_number() -> Result<()> {
+        let expr = "<math><mrow>
+        <mn>2</mn><mo>+</mo>
+        <mrow><mo>(</mo>
+        <mrow><mo>&#x2212;</mo><mn>2</mn></mrow>
+        <mo>)</mo></mrow>
+        </mrow></math>";
+        test("pt", "ClearSpeak", expr, "2 plus negative 2")?;
+        return Ok(());
+
+    }
+
+
+    #[test]
+    fn no_parens_negative_number_with_var() -> Result<()> {
+        let expr = "<math><mrow>
+        <mrow><mo>(</mo>
+        <mrow><mo>&#x2212;</mo><mn>2</mn></mrow><mi>x</mi>
+        <mo>)</mo>
+        </mrow>
+        <mo>+</mo><mn>1</mn>
+        </mrow></math>";
+        test("pt", "ClearSpeak", expr, "negative 2 x, plus 1")?;
+        return Ok(());
+
+    }
+
+    #[test]
+    fn parens_superscript() -> Result<()> {
+        let expr = "<math><mrow>
+        <mrow>
+        <msup>
+        <mrow>
+            <mrow><mo>(</mo>
+            <mrow> <mn>2</mn><mi>x</mi></mrow>
+            <mo>)</mo></mrow></mrow>
+        <mn>2</mn>
+        </msup>
+        </mrow>
+    </mrow></math>";
+        test("pt", "ClearSpeak", expr, "open paren 2 x close paren squared")?;
+        return Ok(());
+
+    }
+
+    #[test]
+    fn no_parens_fraction() -> Result<()> {
+        let expr = "<math><mrow>
+        <mn>2</mn>
+        <mo>+</mo>
+        <mrow>
+            <mrow><mo>(</mo>
+            <mfrac> <mn>1</mn><mn>2</mn></mfrac>
+            <mo>)</mo></mrow></mrow>
+    </mrow></math>";
+        test("pt", "ClearSpeak", expr, "2 plus 1 half")?;
+        return Ok(());
+
+    }
+
+
+    // Tests for the ten types of intervals in ClearSpeak
+    #[test]
+    fn parens_interval_open_open() -> Result<()> {
+        let expr = "<math> 
+        <mrow><mo>(</mo>
+        <mrow> <mi>c</mi><mo>,</mo><mi>d</mi></mrow>
+        <mo>)</mo></mrow>
+    </math>";
+    test_ClearSpeak("pt", "ClearSpeak_Paren", "Interval",expr,
+    "the interval from c to d, not including c or d")?;
+    return Ok(());
+
+}
+
+#[test]
+    fn parens_interval_closed_open() -> Result<()> {
+        let expr = "<math> 
+        <mrow><mo>[</mo>
+        <mrow> <mi>c</mi><mo>,</mo><mi>d</mi></mrow>
+        <mo>)</mo></mrow>
+    </math>";
+    test_ClearSpeak("pt", "ClearSpeak_Paren", "Interval ",expr,
+    "the interval from c to d, including c but not including d")?;
+    return Ok(());
+
+}
+
+
+#[test]
+fn parens_interval_open_closed() -> Result<()> {
+    let expr = "<math> 
+    <mrow><mo>(</mo>
+        <mrow> <mi>c</mi><mo>,</mo><mi>d</mi></mrow>
+    <mo>]</mo></mrow>
+    </math>";
+    test_ClearSpeak("pt", "ClearSpeak_Paren", "Interval ",expr,
+    "the interval from c to d, not including c but including d")?;
+    return Ok(());
+
+}
+
+
+#[test]
+fn parens_interval_closed_closed() -> Result<()> {
+    let expr = "<math> 
+    <mrow><mo>[</mo>
+    <mrow> <mi>c</mi><mo>,</mo><mi>d</mi></mrow>
+    <mo>]</mo></mrow>
+</math>";
+test_ClearSpeak("pt", "ClearSpeak_Paren", "Interval ",expr,
+"the interval from c to d, including c and d")?;
+return Ok(());
+
+}
+
+    #[test]
+    fn parens_interval_neg_infinity_open_open() -> Result<()> {
+        let expr = "<math> 
+        <mrow><mo>(</mo>
+        <mrow><mo>-</mo> <mi>âˆž</mi><mo>,</mo><mi>d</mi></mrow>
+        <mo>)</mo></mrow>
+    </math>";
+    test_ClearSpeak("pt", "ClearSpeak_Paren", "Interval ",expr,
+    "the interval from negative infinity to d, not including d")?;
+    return Ok(());
+
+}
+
+    #[test]
+    fn parens_interval_neg_infinity_closed_open() -> Result<()> {
+        let expr = "<math> 
+        <mrow><mo>(</mo>
+        <mrow> <mo>-</mo> <mi>âˆž</mi><mo>,</mo><mi>d</mi></mrow>
+        <mo>]</mo></mrow>
+    </math>";
+    test_ClearSpeak("pt", "ClearSpeak_Paren", "Interval ",expr,
+    "the interval from negative infinity to d, including d")?;
+    return Ok(());
+
+}
+
+
+#[test]
+fn parens_interval_open_open_infinity() -> Result<()> {
+    let expr = "<math> 
+    <mrow><mo>(</mo>
+        <mrow> <mi>c</mi><mo>,</mo><mi>âˆž</mi></mrow>
+    <mo>)</mo></mrow>
+    </math>";
+    test_ClearSpeak("pt", "ClearSpeak_Paren", "Interval ",expr,
+    "the interval from c to infinity, not including c")?;
+    return Ok(());
+
+}
+
+
+#[test]
+fn parens_interval_closed_open_infinity() -> Result<()> {
+    let expr = "<math> 
+        <mrow><mo>[</mo>
+        <mrow> <mi>c</mi><mo>,</mo><mi>âˆž</mi></mrow>
+        <mo>)</mo></mrow>
+    </math>";
+    test_ClearSpeak("pt", "ClearSpeak_Paren", "Interval ",expr,
+"the interval from c to infinity, including c")?;
+return Ok(());
+
+}
+
+#[test]
+fn parens_interval_neg_infinity_to_infinity() -> Result<()> {
+    let expr = "<math> 
+    <mrow><mo>(</mo>
+        <mrow><mo>-</mo> <mi>âˆž</mi><mo>,</mo><mi>âˆž</mi></mrow>
+        <mo>)</mo></mrow>
+    </math>";
+    test_ClearSpeak("pt", "ClearSpeak_Paren", "Interval ",expr,
+    "the interval from negative infinity to infinity")?;
+    return Ok(());
+
+}
+
+#[test]
+fn parens_interval_neg_infinity_to_pos_infinity() -> Result<()> {
+    let expr = "<math> 
+    <mrow><mo>(</mo>
+        <mrow><mo>-</mo> <mi>âˆž</mi><mo>,</mo><mo>+</mo><mi>âˆž</mi></mrow>
+    <mo>)</mo></mrow>
+    </math>";
+    test_ClearSpeak("pt", "ClearSpeak_Paren", "Interval ",expr,
+    "the interval from negative infinity to positive infinity")?;
+    return Ok(());
+
+}

--- a/tests/Languages/pt/ClearSpeak/large_ops.rs
+++ b/tests/Languages/pt/ClearSpeak/large_ops.rs
@@ -1,0 +1,235 @@
+﻿use crate::common::*;
+use anyhow::Result;
+
+#[test]
+fn sum_both() -> Result<()> {
+    let expr = "<math>
+        <munderover>
+            <mo>âˆ‘</mo>
+            <mrow><mi>n</mi><mo>=</mo><mn>1</mn></mrow>
+            <mrow><mn>10</mn></mrow>
+        </munderover>
+        <mi>n</mi>
+    </math>";
+    test("pt", "ClearSpeak", expr, "the sum from n is equal to 1, to 10 of n")?;
+    return Ok(());
+
+}
+
+#[test]
+fn sum_under() -> Result<()> {
+    let expr = "<math>
+        <munder>
+            <mo>âˆ‘</mo>
+            <mi>S</mi>
+        </munder>
+        <mi>i</mi>
+    </math>";
+    test("pt", "ClearSpeak", expr, "the sum over cap s of i")?;
+    return Ok(());
+
+}
+#[test]
+fn sum_both_msubsup() -> Result<()> {
+    let expr = "<math>
+        <msubsup>
+            <mo>âˆ‘</mo>
+            <mrow><mi>n</mi><mo>=</mo><mn>1</mn></mrow>
+            <mrow><mn>10</mn></mrow>
+        </msubsup>
+        <mi>n</mi>
+    </math>";
+    test("pt", "ClearSpeak", expr, "the sum from n is equal to 1, to 10 of n")?;
+    return Ok(());
+
+}
+
+#[test]
+fn sum_sub() -> Result<()> {
+    let expr = "<math>
+        <msub>
+            <mo>âˆ‘</mo>
+            <mi>S</mi>
+        </msub>
+        <mi>i</mi>
+    </math>";
+    test("pt", "ClearSpeak", expr, "the sum over cap s of i")?;
+    return Ok(());
+
+}
+
+#[test]
+fn sum() -> Result<()> {
+    let expr = "<math>
+            <mo>âˆ‘</mo>
+            <msub><mi>a</mi><mi>i</mi></msub>
+    </math>";
+    test("pt", "ClearSpeak", expr, "the sum of eigh sub i")?;
+    return Ok(());
+
+}
+
+#[test]
+fn product_both() -> Result<()> {
+    let expr = "<math>
+        <munderover>
+            <mo>âˆ</mo>
+            <mrow><mi>n</mi><mo>=</mo><mn>1</mn></mrow>
+            <mrow><mn>10</mn></mrow>
+        </munderover>
+        <mi>n</mi>
+    </math>";
+    test("pt", "ClearSpeak", expr, "the product from n is equal to 1, to 10 of n")?;
+    return Ok(());
+
+}
+
+#[test]
+fn product_under() -> Result<()> {
+    let expr = "<math>
+        <munder>
+            <mo>âˆ</mo>
+            <mi>S</mi>
+        </munder>
+        <mi>i</mi>
+    </math>";
+    test("pt", "ClearSpeak", expr, "the product over cap s of i")?;
+    return Ok(());
+
+}
+
+#[test]
+fn product() -> Result<()> {
+    let expr = "<math>
+            <mo>âˆ</mo>
+            <msub><mi>a</mi><mi>i</mi></msub>
+    </math>";
+    test("pt", "ClearSpeak", expr, "the product of eigh sub i")?;
+    return Ok(());
+
+}
+
+#[test]
+fn intersection_both() -> Result<()> {
+    let expr = "<math>
+        <munderover>
+            <mo>â‹‚</mo>
+            <mrow><mi>i</mi><mo>=</mo><mn>1</mn> </mrow>
+            <mn>10</mn>
+        </munderover>
+        <msub><mi>S</mi><mi>i</mi></msub>
+    </math>";
+    test("pt", "ClearSpeak", expr, "the intersection from i is equal to 1, to 10 of; cap s sub i")?;
+    return Ok(());
+
+}
+
+#[test]
+fn intersection_under() -> Result<()> {
+    let expr = "<math>
+        <munder>
+            <mo>â‹‚</mo>
+            <mi>C</mi>
+        </munder>
+        <msub><mi>S</mi><mi>i</mi></msub>
+    </math>";
+    test("pt", "ClearSpeak", expr, "the intersection over cap c of, cap s sub i")?;
+    return Ok(());
+
+}
+
+#[test]
+fn intersection() -> Result<()> {
+    let expr = "<math>
+            <mo>â‹‚</mo>
+            <msub><mi>S</mi><mi>i</mi></msub>
+            </math>";
+    test("pt", "ClearSpeak", expr, "the intersection of cap s sub i")?;
+    return Ok(());
+
+}
+
+#[test]
+fn union_both() -> Result<()> {
+    let expr = "<math>
+        <munderover>
+            <mo>â‹ƒ</mo>
+            <mrow><mi>i</mi><mo>=</mo><mn>1</mn> </mrow>
+            <mn>10</mn>
+        </munderover>
+        <msub><mi>S</mi><mi>i</mi></msub>
+    </math>";
+    test("pt", "ClearSpeak", expr, "the union from i is equal to 1, to 10 of; cap s sub i")?;
+    return Ok(());
+
+}
+
+#[test]
+fn union_under() -> Result<()> {
+    let expr = "<math>
+        <munder>
+            <mo>â‹ƒ</mo>
+            <mi>C</mi>
+        </munder>
+        <msub><mi>S</mi><mi>i</mi></msub>
+    </math>";
+    test("pt", "ClearSpeak", expr, "the union over cap c of, cap s sub i")?;
+    return Ok(());
+
+}
+
+#[test]
+fn union() -> Result<()> {
+    let expr = "<math>
+            <mo>â‹ƒ</mo>
+            <msub><mi>S</mi><mi>i</mi></msub>
+            </math>";
+    test("pt", "ClearSpeak", expr, "the union of cap s sub i")?;
+    return Ok(());
+
+}
+
+#[test]
+fn integral_both() -> Result<()> {
+    let expr = "<math>
+            <mrow>
+                <msubsup>
+                    <mo>âˆ«</mo>
+                    <mn>0</mn>
+                    <mn>1</mn>
+                </msubsup>
+                <mrow><mi>f</mi><mrow><mo>(</mo><mi>x</mi> <mo>)</mo></mrow></mrow>
+            </mrow>
+            <mtext>&#x2009;</mtext><mi>d</mi><mi>x</mi>
+        </math>";
+    test("pt", "ClearSpeak", expr, "the integral from 0, to 1 of, f of x; d x")?;
+    return Ok(());
+
+}
+
+#[test]
+fn integral_under() -> Result<()> {
+    let expr = "<math>
+        <munder>
+            <mo>âˆ«</mo>
+            <mi>â„</mi>
+        </munder>
+        <mrow><mi>f</mi><mrow><mo>(</mo><mi>x</mi> <mo>)</mo></mrow></mrow>
+        <mi>d</mi><mi>x</mi>
+        </math>";
+    test("pt", "ClearSpeak", expr, "the integral over the real numbers of; f of x d x")?;
+    return Ok(());
+
+}
+
+#[test]
+fn integral() -> Result<()> {
+    let expr = "<math>
+            <mo>âˆ«</mo>
+            <mrow><mi>f</mi><mrow><mo>(</mo><mi>x</mi> <mo>)</mo></mrow></mrow>
+            <mi>d</mi><mi>x</mi>
+            </math>";
+    test("pt", "ClearSpeak", expr, "the integral of f of x d x")?;
+    return Ok(());
+
+}

--- a/tests/Languages/pt/ClearSpeak/menclose.rs
+++ b/tests/Languages/pt/ClearSpeak/menclose.rs
@@ -1,0 +1,242 @@
+﻿use crate::common::*;
+use anyhow::Result;
+
+#[test]
+fn menclose_actuarial() -> Result<()> {
+    let expr = "<math>
+                    <menclose notation='actuarial'>  <mn>3</mn><mo>+</mo><mn>2</mn><mi>i</mi> </menclose>
+                </math>";
+    test("pt", "ClearSpeak", expr, "actuarial symbol, enclosing 3 plus 2 i end enclosure")?;
+    return Ok(());
+
+}
+
+#[test]
+fn menclose_box() -> Result<()> {
+    let expr = "<math>
+                    <menclose notation='box circle'>  <mn>3</mn><mo>+</mo><mn>2</mn><mi>i</mi> </menclose>
+                </math>";
+    test("pt", "ClearSpeak", expr, "box, circle, enclosing 3 plus 2 i end enclosure")?;
+    return Ok(());
+
+}
+
+#[test]
+fn menclose_left() -> Result<()> {
+    let expr = "<math>
+                    <menclose notation='left'>  <mfrac><mn>3</mn><mn>2</mn></mfrac> </menclose>
+                </math>";
+    test("pt", "ClearSpeak", expr, "line on left, enclosing 3 halves end enclosure")?;
+    return Ok(());
+
+}
+
+#[test]
+fn menclose_right() -> Result<()> {
+    let expr = "<math>
+                    <menclose notation='right'>  <mfrac><mn>3</mn><mn>2</mn></mfrac> </menclose>
+                </math>";
+    test("pt", "ClearSpeak", expr, "line on right, enclosing 3 halves end enclosure")?;
+    return Ok(());
+
+}
+
+#[test]
+fn menclose_top_bottom() -> Result<()> {
+    let expr = "<math>
+                    <menclose notation='top bottom'>  <mfrac><mn>3</mn><mn>2</mn></mfrac> </menclose>
+                </math>";
+    test("pt", "ClearSpeak", expr, "line on top, bottom, enclosing 3 halves end enclosure")?;
+    return Ok(());
+
+}
+
+#[test]
+fn menclose_updiagonalstrike() -> Result<()> {
+    let expr = "<math>
+                    <menclose notation='updiagonalstrike'>  <mfrac><mn>3</mn><mn>2</mn></mfrac> </menclose>
+                </math>";
+    test("pt", "ClearSpeak", expr, "up diagonal, cross out, enclosing 3 halves end enclosure")?;
+    return Ok(());
+
+}
+
+#[test]
+fn menclose_downdiagonalstrike() -> Result<()> {
+    let expr = "<math>
+                    <menclose notation='downdiagonalstrike'>  <mfrac><mn>3</mn><mn>2</mn></mfrac> </menclose>
+                </math>";
+    test("pt", "ClearSpeak", expr, "down diagonal, cross out, enclosing 3 halves end enclosure")?;
+    return Ok(());
+
+}
+
+#[test]
+fn menclose_cross_out() -> Result<()> {
+    let expr = "<math>
+                    <menclose notation='updiagonalstrike downdiagonalstrike'>  <mfrac><mn>3</mn><mn>2</mn></mfrac> </menclose>
+                </math>";
+    test("pt", "ClearSpeak", expr, "x, cross out, enclosing 3 halves end enclosure")?;
+    return Ok(());
+
+}
+
+#[test]
+fn menclose_vertical_horizontal_strike() -> Result<()> {
+    let expr = "<math>
+                    <menclose notation='verticalstrike horizontalstrike'>  <mfrac><mn>3</mn><mn>2</mn></mfrac> </menclose>
+                </math>";
+    test("pt", "ClearSpeak", expr, "vertical, horizontal, cross out, enclosing 3 halves end enclosure")?;
+    return Ok(());
+
+}
+
+#[test]
+fn menclose_leftarrow() -> Result<()> {
+    let expr = "<math>
+                    <menclose notation='leftarrow'> <mfrac><mn>3</mn><mn>2</mn></mfrac> </menclose>
+                </math>";
+    test("pt", "ClearSpeak", expr, "left arrow, enclosing 3 halves end enclosure")?;
+    return Ok(());
+
+}
+
+#[test]
+fn menclose_right_up_down_arrow() -> Result<()> {
+    let expr = "<math>
+                    <menclose notation=' rightarrow downarrow  uparrow  '> <mfrac><mn>3</mn><mn>2</mn></mfrac> </menclose>
+                </math>";
+    test("pt", "ClearSpeak", expr, "up arrow, down arrow, right arrow, enclosing 3 halves end enclosure")?;
+    return Ok(());
+
+}
+
+#[test]
+fn menclose_northeastarrow() -> Result<()> {
+    let expr = "<math>
+                    <menclose notation='northeastarrow'> <mfrac><mn>3</mn><mn>2</mn></mfrac> </menclose>
+                </math>";
+    test("pt", "ClearSpeak", expr, "northeast arrow, enclosing 3 halves end enclosure")?;
+    return Ok(());
+
+}
+
+#[test]
+fn menclose_other_single_arrows() -> Result<()> {
+    let expr = "<math>
+                    <menclose notation='northwestarrow southwestarrow southeastarrow'> <mfrac><mn>3</mn><mn>2</mn></mfrac> </menclose>
+                </math>";
+    test("pt", "ClearSpeak", expr, "southeast arrow, southwest arrow, northwest arrow, enclosing 3 halves end enclosure")?;
+    return Ok(());
+
+}
+
+#[test]
+fn menclose_northwestsoutheastarrow() -> Result<()> {
+    let expr = "<math>
+                    <menclose notation='northwestsoutheastarrow'> <mfrac><mn>3</mn><mn>2</mn></mfrac> </menclose>
+                </math>";
+    test("pt", "ClearSpeak", expr, "double ended down diagonal arrow, enclosing 3 halves end enclosure")?;
+    return Ok(());
+
+}
+
+#[test]
+fn menclose_other_double_arrows() -> Result<()> {
+    let expr = "<math>
+                    <menclose notation='updownarrow leftrightarrow northeastsouthwestarrow'>  <mfrac><mn>3</mn><mn>2</mn></mfrac> </menclose>
+                </math>";
+    test("pt", "ClearSpeak", expr, "double ended vertical arrow, double ended horizontal arrow, double ended up diagonal arrow, enclosing 3 halves end enclosure")?;
+    return Ok(());
+
+}
+
+#[test]
+fn menclose_madrub() -> Result<()> {
+    let expr = "<math>
+                    <menclose notation='madrub'> <mfrac><mn>3</mn><mn>2</mn></mfrac> </menclose>
+                </math>";
+    test("pt", "ClearSpeak", expr, "arabic factorial symbol, enclosing 3 halves end enclosure")?;
+    return Ok(());
+
+}
+
+#[test]
+fn menclose_phasorangle() -> Result<()> {
+    let expr = "<math>
+                    <menclose notation='phasorangle'> <mfrac><mn>3</mn><mn>2</mn></mfrac> </menclose>
+                </math>";
+    test("pt", "ClearSpeak", expr, "phasor angle, enclosing 3 halves end enclosure")?;
+    return Ok(());
+
+}
+
+#[test]
+fn menclose_circle_phasorangle() -> Result<()> {
+    let expr = "<math>
+                    <menclose notation='phasorangle circle'> <mfrac><mn>3</mn><mn>2</mn></mfrac> </menclose>
+                </math>";
+    test("pt", "ClearSpeak", expr, "circle, phasor angle, enclosing 3 halves end enclosure")?;
+    return Ok(());
+
+}
+
+#[test]
+fn menclose_longdiv() -> Result<()> {
+    let expr = "<math>
+                    <menclose notation='longdiv'> <mfrac><mn>3</mn><mn>2</mn></mfrac> </menclose>
+                </math>";
+    test("pt", "ClearSpeak", expr, "long division symbol, enclosing 3 halves end enclosure")?;
+    return Ok(());
+
+}
+
+#[test]
+fn menclose_longdiv_default() -> Result<()> {
+    let expr = "<math>
+                    <menclose> <mfrac><mn>3</mn><mn>2</mn></mfrac> </menclose>
+                </math>";
+    test("pt", "ClearSpeak", expr, "long division symbol, enclosing 3 halves end enclosure")?;
+    return Ok(());
+
+}
+
+#[test]
+fn menclose_longdiv_empty_string() -> Result<()> {
+    let expr = "<math>
+                    <menclose notation=''> <mfrac><mn>3</mn><mn>2</mn></mfrac> </menclose>
+                </math>";
+    test("pt", "ClearSpeak", expr, "long division symbol, enclosing 3 halves end enclosure")?;
+    return Ok(());
+
+}
+
+#[test]
+fn menclose_longdiv_whitespace_string() -> Result<()> {
+    let expr = "<math>
+                    <menclose notation='  '> <mfrac><mn>3</mn><mn>2</mn></mfrac> </menclose>
+                </math>";
+    test("pt", "ClearSpeak", expr, "long division symbol, enclosing 3 halves end enclosure")?;
+    return Ok(());
+
+}
+
+#[test]
+fn menclose_radical() -> Result<()> {
+    let expr = "<math>
+                    <menclose notation='radical'> <mfrac><mn>3</mn><mn>2</mn></mfrac> </menclose>
+                </math>";
+    test("pt", "ClearSpeak", expr, "square root, enclosing 3 halves end enclosure")?;
+    return Ok(());
+
+}
+
+#[test]
+fn simple_speak_menclose_top_bottom() -> Result<()> {
+    let expr = "<math>
+                    <menclose notation='top bottom'>  <mfrac><mn>3</mn><mn>2</mn></mfrac> </menclose>
+                </math>";
+    test("pt", "SimpleSpeak", expr, "line on top, bottom, enclosing 3 halves end enclosure")?;
+    return Ok(());
+
+}

--- a/tests/Languages/pt/ClearSpeak/mfrac.rs
+++ b/tests/Languages/pt/ClearSpeak/mfrac.rs
@@ -1,0 +1,313 @@
+﻿/// Tests for fractions
+///   includes simple fractions and more complex fractions
+///   also tests mixed fractions (implicit and explicit)
+use crate::common::*;
+use anyhow::Result;
+
+#[test]
+fn common_fraction_half() -> Result<()> {
+    let expr = "<math>
+                    <mfrac> <mn>1</mn> <mn>2</mn> </mfrac>
+                </math>";
+    test("pt", "ClearSpeak", expr, "1 half")?;
+    return Ok(());
+
+}
+
+#[test]
+fn common_fraction_thirds() -> Result<()> {
+    let expr = "<math>
+                    <mfrac> <mn>2</mn> <mn>3</mn> </mfrac>
+                </math>";
+    test("pt", "ClearSpeak", expr, "2 thirds")?;
+    return Ok(());
+
+}
+
+#[test]
+fn common_fraction_tenths() -> Result<()> {
+    let expr = "<math>
+                    <mfrac> <mn>17</mn> <mn>10</mn> </mfrac>
+                </math>";
+    test_prefs("pt", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Fractions", "Auto")], expr, "17 tenths")?;
+    test_prefs("pt", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Fractions", "Ordinal")], expr, "17 tenths")?;
+    return Ok(());
+
+}
+
+#[test]
+#[allow(non_snake_case)]
+fn not_ClearSpeak_common_fraction_tenths() -> Result<()> {
+    let expr = "<math>
+                    <mfrac> <mn>89</mn> <mn>10</mn> </mfrac>
+                </math>";
+    test_prefs("pt", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Fractions", "Auto")], expr, "89 over 10")?;
+    test_prefs("pt", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Fractions", "Ordinal")], expr, "89 tenths")?;
+    return Ok(());
+
+}
+
+#[test]
+fn non_simple_fraction() -> Result<()> {
+    let expr = "
+    <math>
+        <mrow>
+        <mfrac>
+        <mrow>
+        <mi>x</mi><mo>+</mo><mi>y</mi></mrow>
+        <mrow>
+        <mi>x</mi><mo>-</mo><mi>y</mi></mrow>
+        </mfrac>
+        </mrow>
+    </math>";
+    test_prefs("pt", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Fractions", "Auto")], expr, "the fraction with numerator; x plus y; and denominator x minus y")?;
+    test_prefs("pt", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Fractions", "Ordinal")], expr, "the fraction with numerator; x plus y; and denominator x minus y")?;
+    test_prefs("pt", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Fractions", "Over")], expr, "x plus y over x minus y")?;
+    test_prefs("pt", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Fractions", "FracOver")], expr, "the fraction x plus y over x minus y")?;
+    test_prefs("pt", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Fractions", "General")], expr, "the fraction with numerator; x plus y; and denominator x minus y")?;
+    test_prefs("pt", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Fractions", "EndFrac")], expr, "the fraction with numerator; x plus y; and denominator x minus y; end fraction")?;
+    test_prefs("pt", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Fractions", "GeneralEndFrac")], expr, "the fraction with numerator; x plus y; and denominator x minus y; end fraction")?;
+    test_prefs("pt", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Fractions", "OverEndFrac")], expr, "x plus y over x minus y, end fraction")?;
+    test_prefs("pt", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Fractions", "Per")], expr, "x plus y per x minus y")?;
+    test_prefs("pt", "ClearSpeak", vec![("Verbosity", "Verbose"),("ClearSpeak_Fractions", "Auto")], expr, "the fraction with numerator; x plus y; and denominator x minus y; end fraction")?;
+    return Ok(());
+
+}
+
+#[test]
+fn frac_with_units() -> Result<()> {
+    let expr = "
+    <math>
+        <mrow>
+        <mn>62</mn>
+        <mfrac>
+        <mi intent=':unit'>mi</mi>
+        <mi intent=':unit'>hr</mi>
+        </mfrac>
+        </mrow>
+    </math>";
+    test("pt", "ClearSpeak", expr, "62 miles per hour")?;
+    return Ok(());
+
+}
+
+
+#[test]
+fn mixed_number() -> Result<()> {
+    let expr = "<math>
+                    <mn>3</mn>
+                    <mfrac> <mn>1</mn> <mn>2</mn> </mfrac>
+                </math>";
+    test("pt", "ClearSpeak", expr, "3 and 1 half")?;
+    return Ok(());
+
+}
+
+#[test]
+fn explicit_mixed_number() -> Result<()> {
+    let expr = "<math>
+                    <mn>3</mn>
+                    <mo>&#x2064;</mo>
+                    <mfrac> <mn>1</mn> <mn>8</mn> </mfrac>
+                </math>";
+    test("pt", "ClearSpeak", expr, "3 and 1 eighth")?;
+    return Ok(());
+
+}
+
+#[test]
+fn mixed_number_big() -> Result<()> {
+    let expr = "<math>
+                    <mn>3</mn>
+                    <mfrac> <mn>7</mn> <mn>83</mn> </mfrac>
+                </math>";
+    test("pt", "ClearSpeak", expr, "3 and 7 over 83")?;
+    return Ok(());
+
+}
+
+#[test]
+fn simple_text() -> Result<()> {
+    let expr = "<math>
+    <mfrac> <mi>rise</mi> <mi>run</mi> </mfrac>
+                </math>";
+    test("pt", "ClearSpeak", expr, "rise over run")?;
+    return Ok(());
+
+}
+
+#[test]
+fn number_and_text() -> Result<()> {
+    let expr = "<math>
+            <mfrac>
+            <mrow>
+                <mn>2</mn><mtext>miles</mtext></mrow>
+            <mrow>
+                <mn>3</mn><mtext>gallons</mtext></mrow>
+            </mfrac>
+        </math>";
+    test("pt", "ClearSpeak", expr, "2 miles over 3 gallons")?;
+    return Ok(());
+
+}
+
+
+#[test]
+fn nested_simple_fractions() -> Result<()> {
+    let expr = "<math>
+                <mrow>
+                <mfrac>
+                    <mrow>
+                    <mfrac>
+                        <mn>1</mn>
+                        <mn>2</mn>
+                    </mfrac>
+                    </mrow>
+                    <mrow>
+                    <mfrac>
+                        <mn>2</mn>
+                        <mn>3</mn>
+                    </mfrac>
+                    </mrow>
+                </mfrac>
+                </mrow>
+            </math>";
+    test_prefs("pt", "ClearSpeak", vec![("ClearSpeak_Fractions", "Auto")], expr, "1 half over 2 thirds")?;
+    test_prefs("pt", "ClearSpeak", vec![("ClearSpeak_Fractions", "Ordinal")], expr, "1 half over 2 thirds")?;
+    test_prefs("pt", "ClearSpeak", vec![("ClearSpeak_Fractions", "Over")], expr, "1 over 2 over 2 over 3")?;
+    test_prefs("pt", "ClearSpeak", vec![("ClearSpeak_Fractions", "FracOver")], expr,
+            "the fraction the fraction 1 over 2 over the fraction 2 over 3")?;
+    test_prefs("pt", "ClearSpeak", vec![("ClearSpeak_Fractions", "General")], expr,
+            "the fraction with numerator the fraction with numerator 1; and denominator 2; and denominator the fraction with numerator 2; and denominator 3")?;
+    test_prefs("pt", "ClearSpeak", vec![("ClearSpeak_Fractions", "EndFrac")], expr, "1 half over 2 thirds")?;
+    test_prefs("pt", "ClearSpeak", vec![("ClearSpeak_Fractions", "GeneralEndFrac")], expr,
+            "the fraction with numerator the fraction with numerator 1; and denominator 2; end fraction; and denominator the fraction with numerator 2; and denominator 3; end fraction; end fraction")?;
+    test_prefs("pt", "ClearSpeak", vec![("ClearSpeak_Fractions", "OverEndFrac")], expr,
+            "1 over 2, end fraction, over 2 over 3, end fraction; end fraction")?;
+            return Ok(());
+
+}
+
+
+#[test]
+fn semi_nested_fraction() -> Result<()> {
+    let expr = "<math>
+                <mrow>
+                        <mfrac>
+                        <mrow>
+                        <mfrac>
+                        <mn>2</mn>
+                        <mn>3</mn>
+                        </mfrac>
+                        <mi>x</mi>
+                    </mrow>
+                    <mn>6</mn>
+                    </mfrac>
+                </mrow>
+                </math>";
+    test("pt", "ClearSpeak", expr, "2 thirds x over 6")?;
+    return Ok(());
+
+}
+
+#[test]
+fn general_nested_fraction() -> Result<()> {
+    let expr = "
+    <math>
+    <mrow>
+        <mfrac>
+        <mrow>
+        <mfrac>
+            <mn>10</mn>
+            <mi>n</mi>
+        </mfrac>
+        </mrow>
+        <mrow>
+        <mfrac>
+        <mn>2</mn>
+        <mi>n</mi>
+        </mfrac>
+        </mrow>
+        </mfrac>
+        </mrow>
+    </math>
+                    ";
+    test("pt", "ClearSpeak", expr, "the fraction with numerator; 10 over n; and denominator 2 over n")?;
+    return Ok(());
+
+}
+
+#[test]
+fn complex_nested_fraction() -> Result<()> {
+    let expr = "
+    <math>
+    <mrow>
+        <mfrac>
+        <mrow>
+        <mfrac>
+            <mrow> <mi>n</mi> <mo>+</mo> <mn>10</mn> </mrow>
+            <mi>n</mi>
+        </mfrac>
+        </mrow>
+        <mrow>
+        <mfrac>
+        <mn>2</mn>
+        <mi>n</mi>
+        </mfrac>
+        </mrow>
+        </mfrac>
+        </mrow>
+    </math>
+                    ";
+    test("pt", "ClearSpeak", expr, "the fraction with numerator; the fraction with numerator; n plus 10; and denominator n; and denominator 2 over n")?;
+    return Ok(());
+
+}
+
+#[test]
+fn simple_function() -> Result<()> {
+    let expr = "<math><mfrac><mrow><mi>f</mi><mo>(</mo><mi>x</mi><mo>)</mo></mrow><mn>2</mn></mfrac></math>";
+    test_prefs("pt", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Fractions", "Auto")], expr, "f of x over 2")?;
+    test_prefs("pt", "ClearSpeak", vec![("Verbosity", "Verbose"), ("ClearSpeak_Fractions", "Auto")], expr, "f of x over 2, end fraction")?;
+    return Ok(());
+
+}
+
+#[test]
+fn function_over_function() -> Result<()> {
+    let expr = "<math><mfrac>
+            <mrow><mi>f</mi><mo>(</mo><mi>x</mi><mo>)</mo></mrow>
+            <mrow><mi>g</mi><mo>(</mo><mi>x</mi><mo>)</mo></mrow>
+        </mfrac></math>";
+    test_prefs("pt", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Fractions", "Auto")], expr, "f of x over g of x")?;
+    test_prefs("pt", "ClearSpeak", vec![("Verbosity", "Verbose"), ("ClearSpeak_Fractions", "Auto")], expr, "f of x over g of x, end fraction")?;
+    return Ok(());
+
+}
+
+#[test]
+fn non_simple_function_over_function() -> Result<()> {
+    let expr = "<math><mfrac>
+            <mrow><mi>f</mi><mo>(</mo><mi>x</mi><mo>+</mo><mn>1</mn><mo>)</mo></mrow>
+            <mrow><mi>g</mi><mo>(</mo><mi>x</mi><mo>)</mo></mrow>
+        </mfrac></math>";
+    test_prefs("pt", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Fractions", "Auto")], expr,
+             "the fraction with numerator; f of, open paren x plus 1, close paren; and denominator g of x")?;
+    test_prefs("pt", "ClearSpeak", vec![("Verbosity", "Verbose"), ("ClearSpeak_Fractions", "Auto")], expr,
+             "the fraction with numerator; f of, open paren x plus 1, close paren; and denominator g of x; end fraction")?;
+             return Ok(());
+
+}
+
+#[test]
+fn binomial() -> Result<()> {
+    let expr = "<math>
+                    <mn>2</mn>
+                    <mo>(</mo>
+                    <mfrac linethickness='0'> <mn>7</mn> <mn>3</mn> </mfrac>
+                    <mo>)</mo>
+                </math>";
+    test("pt", "ClearSpeak", expr, "2 times 7 choose 3")?;
+    return Ok(());
+
+}

--- a/tests/Languages/pt/ClearSpeak/mroot.rs
+++ b/tests/Languages/pt/ClearSpeak/mroot.rs
@@ -1,0 +1,171 @@
+﻿use crate::common::*;
+use anyhow::Result;
+
+#[test]
+fn msqrt_simple() -> Result<()> {
+    let expr = "<math>
+                    <msqrt> <mi>x</mi> </msqrt>
+                </math>";
+    test("pt", "ClearSpeak", expr, "the square root of x")?;
+    return Ok(());
+
+}
+
+#[test]
+fn msqrt_simple_end_root() -> Result<()> {
+    let expr = "<math>
+                    <msqrt> <mi>x</mi> </msqrt>
+                </math>";
+    test_ClearSpeak("pt", "ClearSpeak_Roots", "RootEnd", expr, "the square root of x, end root")?;
+    return Ok(());
+
+}
+
+#[test]
+fn msqrt_simple_positive() -> Result<()> {
+    let expr = "<math>
+                    <msqrt> <mi>x</mi> </msqrt>
+                </math>";
+    test_ClearSpeak("pt", "ClearSpeak_Roots", "PosNegSqRoot", expr, "the positive square root of x")?;
+    return Ok(());
+
+}
+
+#[test]
+fn msqrt_simple_pos_end_root() -> Result<()> {
+    let expr = "<math>
+                    <msqrt> <mi>x</mi> </msqrt>
+                </math>";
+    test_ClearSpeak("pt", "ClearSpeak_Roots", "PosNegSqRootEnd", expr, "the positive square root of x, end root")?;
+    return Ok(());
+
+}
+
+#[test]
+fn msqrt_simple_pos_end_with_neg_root() -> Result<()> {
+    let expr = "<math>
+                    <mo>-</mo> <msqrt> <mi>x</mi> </msqrt>
+                    <mo>-</mo> <mroot> <mi>x</mi> <mn>3</mn></mroot>
+                </math>";
+    test_ClearSpeak("pt", "ClearSpeak_Roots", "PosNegSqRootEnd", expr, 
+    "the negative square root of x, end root; minus, the positive cube root of x, end root")?;
+    return Ok(());
+
+}
+
+#[test]
+fn mroot_simple_pos_end_with_neg_root() -> Result<()> {
+    let expr = "<math>
+                    <mo>-</mo> <mroot> <mi>x</mi> <mn>3</mn></mroot>
+                    <mo>-</mo> <msqrt> <mi>x</mi> </msqrt>
+
+                </math>";
+    test_ClearSpeak("pt", "ClearSpeak_Roots", "PosNegSqRoot", expr, 
+    "the negative cube root of x; minus, the positive square root of x")?;
+    return Ok(());
+
+}
+
+#[test]
+fn neg_without_root() -> Result<()> {
+    let expr = "<math>
+                    <mo>-</mo> <mi>x</mi> <mo>-</mo> <mi>y</mi>
+                </math>";
+    test("pt", "ClearSpeak", expr, "negative x minus y")?;
+    return Ok(());
+
+}
+
+#[test]
+fn msqrt() -> Result<()> {
+    let expr = "<math>
+                    <msqrt>
+                        <mrow> <mi>x</mi> <mo>+</mo> <mi>y</mi> </mrow>
+                    </msqrt>
+                </math>";
+    test("pt", "ClearSpeak", expr, "the square root of x plus y")?;
+    return Ok(());
+
+}
+
+#[test]
+fn mroot_as_square_root() -> Result<()> {
+    let expr = "<math>
+                    <mroot> <mi>x</mi> <mn>2</mn> </mroot>
+                </math>";
+    test("pt", "ClearSpeak", expr, "the square root of x")?;
+    return Ok(());
+
+}
+
+#[test]
+fn cube_root() -> Result<()> {
+    let expr = "<math>
+                    <mroot> <mi>x</mi> <mn>3</mn> </mroot>
+                </math>";
+    test("pt", "ClearSpeak", expr, "the cube root of x")?;
+    return Ok(());
+
+}
+
+#[test]
+fn ordinal_root() -> Result<()> {
+    let expr = "<math>
+                    <mroot> <mi>x</mi> <mn>9</mn> </mroot>
+                </math>";
+    test("pt", "ClearSpeak", expr, "the ninth root of x")?;
+    return Ok(());
+
+}
+
+#[test]
+fn simple_mi_root() -> Result<()> {
+    let expr = "<math>
+                    <mroot> <mi>x</mi> <mi>n</mi> </mroot>
+                </math>";
+    test("pt", "ClearSpeak", expr, "the n-th root of x")?;
+    return Ok(());
+
+}
+
+#[test]
+fn mroot_simple_pos_end_root() -> Result<()> {
+    let expr = "<math>
+                <mroot> <mi>x</mi> <mi>t</mi> </mroot>
+                </math>";
+    test_ClearSpeak("pt", "ClearSpeak_Roots", "PosNegSqRootEnd", expr, "the positive t-th root of x, end root")?;
+    return Ok(());
+
+}
+
+#[test]
+fn mroot_simple_end_root() -> Result<()> {
+    let expr = "<math>
+                    <mroot> <mrow> <mi>x</mi> <mo>+</mo> <mi>y</mi> </mrow> 
+                    <mn>21</mn></mroot>
+                </math>";
+    test_ClearSpeak("pt", "ClearSpeak_Roots", "RootEnd", expr, "the twenty first root of x plus y, end root")?;
+    return Ok(());
+
+}
+
+#[test]
+fn simple_fraction_power() -> Result<()> {
+    let expr = "<math>
+                    <mroot>
+                        <mi>x</mi> 
+                        <mfrac><mn>1</mn><mn>3</mn></mfrac>
+                    </mroot>
+                </math>";
+    test("pt", "ClearSpeak", expr, "the 1 third root of x")?;
+    return Ok(());
+
+}
+
+#[test]
+fn no_double_the_532() -> Result<()> {
+    let expr = "<math><mroot><msqrt><mn>42</mn></msqrt><mn>3</mn></mroot></math>";
+    test("pt", "ClearSpeak", expr, "the cube root of the square root of 42")?;
+    return Ok(());
+
+}

--- a/tests/Languages/pt/ClearSpeak/msup.rs
+++ b/tests/Languages/pt/ClearSpeak/msup.rs
@@ -1,0 +1,382 @@
+﻿/// Tests for superscripts
+///   simple superscripts
+///   complex/nested superscripts
+use crate::common::*;
+use anyhow::Result;
+
+#[test]
+fn squared() -> Result<()> {
+    let expr = "<math>
+                    <msup> <mi>x</mi> <mn>2</mn> </msup>
+                </math>";
+    test_prefs("pt", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Exponents", "Auto")], expr, "x squared")?;
+    test_prefs("pt", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Exponents", "Ordinal")], expr, "x to the second")?;
+    test_prefs("pt", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Exponents", "OrdinalPower")], expr, "x to the second power")?;
+    test_prefs("pt", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Exponents", "AfterPower")], expr, "x raised to the power 2")?;
+
+    return Ok(());
+
+}
+
+#[test]
+fn cubed() -> Result<()> {
+  let expr = "<math>
+                  <msup> <mi>x</mi> <mn>3</mn> </msup>
+              </math>";
+  test_prefs("pt", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Exponents", "Auto")], expr, "x cubed")?;
+  test_prefs("pt", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Exponents", "Ordinal")], expr, "x to the third")?;
+  test_prefs("pt", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Exponents", "OrdinalPower")], expr, "x to the third power")?;
+  test_prefs("pt", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Exponents", "AfterPower")], expr, "x raised to the power 3")?;
+  return Ok(());
+
+}
+
+#[test]
+fn ordinal_power() -> Result<()> {
+  let expr = "<math>
+                  <msup> <mn>3</mn> <mn>5</mn> </msup>
+              </math>";
+  test_prefs("pt", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Exponents", "Auto")], expr, "3 to the fifth power")?;
+  test_prefs("pt", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Exponents", "Ordinal")], expr, "3 to the fifth")?;
+  test_prefs("pt", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Exponents", "OrdinalPower")], expr, "3 to the fifth power")?;
+  test_prefs("pt", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Exponents", "AfterPower")], expr, "3 raised to the power 5")?;
+  return Ok(());
+
+}
+
+
+#[test]
+fn zero_power() -> Result<()> {
+  let expr = "<math>
+                    <msup> <mn>3</mn> <mn>0</mn> </msup>
+                </math>";
+  test_prefs("pt", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Exponents", "Auto")], expr, "3 to the 0 power")?;
+  test_prefs("pt", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Exponents", "Ordinal")], expr, "3 to the 0")?;
+  test_prefs("pt", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Exponents", "OrdinalPower")], expr, "3 to the 0 power")?;
+  test_prefs("pt", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Exponents", "AfterPower")], expr, "3 raised to the power 0")?;
+  return Ok(());
+
+}
+
+#[test]
+fn simple_mi_power() -> Result<()> {
+  let expr = "<math>
+                    <msup> <mn>4</mn> <mi>x</mi> </msup>
+                </math>";
+  test_prefs("pt", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Exponents", "Auto")], expr, "4 to the x-th power")?;
+  test_prefs("pt", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Exponents", "Ordinal")], expr, "4 to the x-th")?;
+  test_prefs("pt", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Exponents", "OrdinalPower")], expr, "4 to the x-th power")?;
+  test_prefs("pt", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Exponents", "AfterPower")], expr, "4 raised to the power x")?;
+  return Ok(());
+
+}
+
+#[test]
+fn decimal_power() -> Result<()> {
+  let expr = "<math>
+                  <msup> <mn>3</mn> <mn>5.0</mn> </msup>
+              </math>";
+  test_prefs("pt", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Exponents", "Auto")], expr, "3 raised to the 5.0 power")?;
+  test_prefs("pt", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Exponents", "Ordinal")], expr, "3 raised to the 5.0 power")?;
+  test_prefs("pt", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Exponents", "OrdinalPower")], expr, "3 raised to the 5.0 power")?;
+  test_prefs("pt", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Exponents", "AfterPower")], expr, "3 raised to the power 5.0")?;
+  return Ok(());
+
+}
+
+#[test]
+fn non_simple_power() -> Result<()> {
+  let expr = "<math>
+        <msup> <mn>3</mn>  <mrow> <mi>y</mi><mo>+</mo><mn>2</mn></mrow>  </msup>
+    </math>";
+  test_prefs("pt", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Exponents", "Auto")], expr, "3 raised to the y plus 2 power")?;
+  test_prefs("pt", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Exponents", "Ordinal")], expr, "3 raised to the y plus 2 power")?;
+  test_prefs("pt", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Exponents", "OrdinalPower")], expr, "3 raised to the y plus 2 power")?;
+  test_prefs("pt", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Exponents", "AfterPower")], expr, "3 raised to the power y plus 2")?;
+  return Ok(());
+
+}
+
+#[test]
+fn negative_power() -> Result<()> {
+  let expr = "<math>
+                  <msup> <mn>3</mn> <mrow> <mo>-</mo> <mn>2</mn> </mrow> </msup>
+              </math>";
+  test_prefs("pt", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Exponents", "Auto")], expr, "3 to the negative 2 power")?;
+  test_prefs("pt", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Exponents", "Ordinal")], expr, "3 to the negative 2")?;
+  test_prefs("pt", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Exponents", "OrdinalPower")], expr, "3 to the negative 2 power")?;
+  test_prefs("pt", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Exponents", "AfterPower")], expr, "3 raised to the power negative 2")?;
+  return Ok(());
+
+}
+
+#[test]
+fn simple_fraction_power() -> Result<()> {
+  let expr = "<math>
+                    <msup>
+                        <mi>x</mi> 
+                        <mfrac><mn>1</mn><mn>3</mn></mfrac>
+                    </msup>
+                </math>";
+  test("pt", "ClearSpeak", expr, "x raised to the 1 third power")?;
+  return Ok(());
+
+}
+
+#[test]
+fn nested_squared_power_with_coef() -> Result<()> {
+  let expr = "<math>
+      <mrow>
+      <msup>
+        <mn>3</mn>
+        <mrow>
+        <mn>2</mn>
+        <msup>
+          <mi>x</mi>
+          <mn>2</mn>
+        </msup>
+        </mrow>
+      </msup>
+      </mrow>
+      </math>";
+  test_prefs("pt", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Exponents", "Auto")], expr, "3 raised to the 2 x squared power")?;
+  test_prefs("pt", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Exponents", "Ordinal")], expr, "3 raised to the exponent, 2 x to the second, end exponent")?;
+  test_prefs("pt", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Exponents", "OrdinalPower")], expr, "3 raised to the exponent, 2 x to the second power, end exponent")?;
+  test_prefs("pt", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Exponents", "AfterPower")], expr, "3 raised to the exponent, 2 x raised to the power 2; end exponent")?;
+
+  return Ok(());
+
+}
+
+#[test]
+fn nested_squared_power_with_neg_coef() -> Result<()> {
+    let expr = "<math>
+      <mrow>
+      <msup>
+        <mn>3</mn>
+        <mrow>
+        <mo>-</mo>
+        <mn>2</mn>
+        <msup>
+          <mi>x</mi>
+          <mn>2</mn>
+        </msup>
+        </mrow>
+      </msup>
+      </mrow>
+    </math>";
+  test("pt", "ClearSpeak", expr, "3 raised to the negative 2 x squared power")?;
+  return Ok(());
+
+}
+
+
+#[test]
+fn nested_cubed_power() -> Result<()> {
+    let expr = "<math>
+      <msup>
+      <mi>y</mi> 
+      <msup>
+          <mfrac><mn>4</mn><mn>5</mn></mfrac>
+          <mn>3</mn>
+      </msup>
+    </msup>
+  </math>";
+  test("pt", "ClearSpeak", expr, "y raised to the 4 fifths cubed power")?;
+  return Ok(());
+
+}
+
+#[test]
+fn nested_cubed_power_with_neg_base() -> Result<()> {
+    let expr = "<math>
+      <msup>
+      <mi>y</mi> 
+        <mrow>
+            <mo>-</mo>
+            <msup>
+                <mfrac><mn>4</mn><mn>5</mn></mfrac>
+                <mn>3</mn>
+            </msup>
+        </mrow>
+    </msup>
+    </math>";
+  test("pt", "ClearSpeak", expr, "y raised to the negative 4 fifths cubed power")?;
+  return Ok(());
+
+}
+
+#[test]
+fn nested_number_times_squared() -> Result<()> {
+  let expr = "<math>
+      <mrow>
+      <msup>
+        <mi>e</mi>
+        <mrow>
+        <mfrac>
+          <mn>1</mn>
+          <mn>2</mn>
+          </mfrac>
+          <msup>
+          <mi>x</mi>
+          <mn>2</mn>
+          </msup>
+        </mrow>
+      </msup>
+      </mrow>
+      </math>";
+  test_prefs("pt", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Exponents", "Auto")], expr, "e raised to the 1 half x squared power")?;
+  return Ok(());
+
+}
+
+#[test]
+fn nested_negative_number_times_squared() -> Result<()> {
+  let expr = "<math>
+      <mrow>
+      <msup>
+        <mi>e</mi>
+        <mrow>
+        <mo>&#x2212;</mo><mfrac>
+          <mn>1</mn>
+          <mn>2</mn>
+        </mfrac>
+        <msup>
+          <mi>x</mi>
+          <mn>2</mn>
+        </msup>
+        </mrow>
+      </msup>
+      </mrow>
+      </math>";
+  test_prefs("pt", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Exponents", "Auto")], expr, "e raised to the negative 1 half x squared power")?;
+  test_prefs("pt", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Exponents", "Ordinal")], expr, "e raised to the exponent, negative 1 half x to the second, end exponent")?;
+  test_prefs("pt", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Exponents", "OrdinalPower")], expr, "e raised to the exponent, negative 1 half x to the second power, end exponent")?;
+  test_prefs("pt", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Exponents", "AfterPower")], expr, "e raised to the exponent, negative 1 half x raised to the power 2; end exponent")?;
+  return Ok(());
+
+}
+
+#[test]
+fn nested_expr_to_tenth() -> Result<()> {
+  let expr = "<math>
+      <mrow>
+      <msup>
+        <mn>3</mn>
+        <mrow>
+        <msup>
+          <mn>3</mn>
+          <mrow>
+          <mn>10</mn></mrow>
+        </msup>
+        </mrow>
+      </msup>
+      </mrow>
+      </math>";
+  test_prefs("pt", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Exponents", "Auto")], expr, "3 raised to the exponent, 3 to the tenth power, end exponent")?;
+  test_prefs("pt", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Exponents", "Ordinal")], expr, "3 raised to the exponent, 3 to the tenth, end exponent")?;
+  test_prefs("pt", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Exponents", "OrdinalPower")], expr, "3 raised to the exponent, 3 to the tenth power, end exponent")?;
+  test_prefs("pt", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Exponents", "AfterPower")], expr, "3 raised to the exponent, 3 raised to the power 10; end exponent")?;
+
+  return Ok(());
+
+}
+
+#[test]
+fn nested_non_simple_squared_exp() -> Result<()> {
+  let expr = "<math>
+      <mrow>
+      <msup>
+        <mn>3</mn>
+        <mrow>
+        <msup>
+          <mrow>
+          <mrow><mo>(</mo>
+            <mrow>
+            <mi>x</mi><mo>+</mo><mn>1</mn></mrow>
+          <mo>)</mo></mrow></mrow>
+          <mn>2</mn>
+        </msup>
+        </mrow>
+      </msup>
+      </mrow>
+      </math>";
+  test_prefs("pt", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Exponents", "Auto")], expr, "3 raised to the exponent, open paren x plus 1, close paren squared, end exponent")?;
+  test_prefs("pt", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Exponents", "Ordinal")], expr, "3 raised to the exponent, open paren x plus 1, close paren to the second, end exponent")?;
+  test_prefs("pt", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Exponents", "OrdinalPower")], expr, "3 raised to the exponent, open paren x plus 1, close paren to the second power, end exponent")?;
+  test_prefs("pt", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Exponents", "AfterPower")], expr, "3 raised to the exponent, open paren x plus 1, close paren raised to the power 2; end exponent")?;
+  return Ok(());
+
+}
+
+#[test]
+fn nested_default_power() -> Result<()> {
+  let expr = "<math>
+    <msup>
+    <mi>t</mi> 
+    <msup>
+        <mfrac><mn>4</mn><mn>5</mn></mfrac>
+        <mi>n</mi>
+    </msup>
+  </msup>
+</math>";
+  test("pt", "ClearSpeak", expr, "t raised to the exponent, 4 fifths to the n-th power, end exponent")?;
+  return Ok(());
+
+}
+
+#[test]
+fn nested_complex_power() -> Result<()> {
+  let expr = "<math>
+      <mrow>
+      <msup>
+        <mi>e</mi>
+        <mrow>
+        <mo>&#x2212;</mo><mfrac>
+          <mn>1</mn>
+          <mn>2</mn>
+        </mfrac>
+        <msup>
+          <mrow>
+          <mrow><mo>(</mo>
+            <mrow>
+            <mfrac>
+              <mrow>
+              <mi>x</mi><mo>&#x2212;</mo><mi>&#x03BC;</mi></mrow>
+              <mi>&#x03C3;</mi>
+            </mfrac>
+            </mrow>
+          <mo>)</mo></mrow></mrow>
+          <mn>2</mn>
+        </msup>
+        </mrow>
+      </msup>
+      </mrow>
+      </math>";
+  test_prefs("pt", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Exponents", "Auto")], expr,
+       "e raised to the exponent, negative 1 half times; open paren; the fraction with numerator; x minus mu; and denominator sigma; close paren squared, end exponent")?;
+  test_prefs("pt", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Exponents", "Ordinal")], expr,
+       "e raised to the exponent, negative 1 half times; open paren; the fraction with numerator; x minus mu; and denominator sigma; close paren to the second, end exponent")?;
+  test_prefs("pt", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Exponents", "OrdinalPower")], expr,
+       "e raised to the exponent, negative 1 half times; open paren; the fraction with numerator; x minus mu; and denominator sigma; close paren to the second power, end exponent")?;
+  test_prefs("pt", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_Exponents", "AfterPower")], expr,
+       "e raised to the exponent, negative 1 half times; open paren; the fraction with numerator; x minus mu; and denominator sigma; close paren raised to the power 2; end exponent")?;
+       return Ok(());
+
+}
+
+#[test]
+fn default_power() -> Result<()> {
+    let expr = "<math>
+      <msup>
+      <mi>t</mi> 
+      <mfrac>
+          <mrow><mi>b</mi><mo>+</mo><mn>1</mn></mrow>
+          <mn>3</mn>
+      </mfrac>
+    </msup>
+  </math>";
+  test("pt", "ClearSpeak", expr, "t raised to the fraction with numerator; b plus 1; and denominator 3; power")?;
+  return Ok(());
+
+}

--- a/tests/Languages/pt/ClearSpeak/multiline.rs
+++ b/tests/Languages/pt/ClearSpeak/multiline.rs
@@ -1,0 +1,192 @@
+﻿use crate::common::*;
+use anyhow::Result;
+
+
+#[test]
+fn case_1() -> Result<()> {
+  let expr = "<math>
+    <mi>f</mi>
+    <mrow>
+      <mo>(</mo>
+      <mi>x</mi>
+      <mo>)</mo>
+    </mrow>
+    <mo>=</mo>
+    <mrow>
+      <mo stretchy='true'>{</mo>
+      <mtable>
+        <mtr><mtd><mo>-</mo><mn>1</mn></mtd><mtd><mtext>if</mtext></mtd><mtd><mi>x</mi><mo>&lt;</mo><mn>0</mn></mtd></mtr>
+        <mtr><mtd><mn>0</mn></mtd><mtd><mtext>if</mtext></mtd><mtd><mi>x</mi><mo>=</mo><mn>0</mn></mtd></mtr>
+        <mtr><mtd><mn>1</mn></mtd><mtd><mtext>if</mtext></mtd><mtd><mi>x</mi><mo>&gt;</mo><mn>0</mn></mtd></mtr>
+      </mtable>
+    </mrow>
+  </math>
+   ";
+  test_ClearSpeak("pt", "ClearSpeak_MultiLineLabel", "Auto", expr,
+    "f of x is equal to; 3 cases; \
+                case 1; negative 1 if x is less than 0; \
+                case 2; 0 if x is equal to 0; \
+                case 3; 1 if x is greater than 0"
+    )?;
+    return Ok(());
+}
+
+#[test]
+fn equation_auto() -> Result<()> {
+    let expr = "<math>
+     <mrow>
+      <mtable>
+       <mtr> <mtd> <mrow> <mi>x</mi><mo>+</mo><mi>y</mi></mrow> </mtd>  <mtd><mo>=</mo> </mtd>  <mtd><mn>7</mn></mtd>  </mtr>
+       <mtr> <mtd> <mrow> <mn>2</mn><mi>x</mi><mo>+</mo><mn>3</mn><mi>y</mi></mrow></mtd>  <mtd><mo>=</mo></mtd>  <mtd><mrow><mn>17</mn></mrow></mtd> </mtr>
+      </mtable></mrow>
+    </math>
+   ";
+   test_ClearSpeak("pt", "ClearSpeak_MultiLineLabel", "Auto", expr,
+                "2 lines; \
+                line 1; x plus y, is equal to 7; \
+                line 2; 2 x plus 3 y; is equal to 17")?;
+    return Ok(());
+}
+
+
+#[test]
+fn equation_plus_at_start() -> Result<()> {
+  let expr = "<math>
+     <mrow>
+      <mtable>
+       <mtr> <mtd> <mi>x</mi></mtd><mtd><mo>+</mo><mi>y</mi> </mtd>  <mtd><mo>=</mo> </mtd>  <mtd><mn>7</mn></mtd>  </mtr>
+       <mtr> <mtd> <mn>2</mn><mi>x</mi></mtd><mtd><mo>+</mo><mn>3</mn><mi>y</mi></mtd>  <mtd><mo>=</mo></mtd>  <mtd><mrow><mn>17</mn></mrow></mtd> </mtr>
+      </mtable></mrow>
+    </math>
+   ";
+   test_ClearSpeak("pt", "ClearSpeak_MultiLineLabel", "Auto", expr, "2 lines; \
+                line 1; x plus y is equal to 7; \
+                line 2; 2 x, plus 3 y, is equal to 17")?;
+    return Ok(());
+}
+
+#[test]
+fn equation_case() -> Result<()> {
+    let expr = "<math>
+     <mrow>
+      <mtable>
+       <mtr> <mtd> <mrow> <mi>x</mi><mo>+</mo><mi>y</mi></mrow> </mtd>  <mtd><mo>=</mo> </mtd>  <mtd><mn>7</mn></mtd>  </mtr>
+       <mtr> <mtd> <mrow> <mn>2</mn><mi>x</mi><mo>+</mo><mn>3</mn><mi>y</mi></mrow></mtd>  <mtd><mo>=</mo></mtd>  <mtd><mrow><mn>17</mn></mrow></mtd> </mtr>
+      </mtable></mrow>
+    </math>
+   ";
+   test_ClearSpeak("pt", "ClearSpeak_MultiLineLabel", "Case", expr, 
+   "2 cases; case 1; x plus y, is equal to 7; case 2; 2 x plus 3 y; is equal to 17")?;
+    return Ok(());
+}
+
+#[test]
+fn equation_constraint() -> Result<()> {
+  let expr = "<math>
+     <mrow>
+      <mtable>
+       <mtr> <mtd> <mrow> <mi>x</mi><mo>+</mo><mi>y</mi></mrow> </mtd>  <mtd><mo>=</mo> </mtd>  <mtd><mn>7</mn></mtd>  </mtr>
+       <mtr> <mtd> <mrow> <mn>2</mn><mi>x</mi><mo>+</mo><mn>3</mn><mi>y</mi></mrow></mtd>  <mtd><mo>=</mo></mtd>  <mtd><mrow><mn>17</mn></mrow></mtd> </mtr>
+      </mtable></mrow>
+    </math>
+   ";
+   test_ClearSpeak("pt", "ClearSpeak_MultiLineLabel", "Constraint", expr, "2 constraints; \
+                constraint 1; x plus y, is equal to 7; \
+                constraint 2; 2 x plus 3 y; is equal to 17")?;
+   return Ok(());
+}
+
+#[test]
+fn equation_equation() -> Result<()> {
+    let expr = "<math>
+     <mrow>
+      <mtable>
+       <mtr> <mtd> <mrow> <mi>x</mi><mo>+</mo><mi>y</mi></mrow> </mtd>  <mtd><mo>=</mo> </mtd>  <mtd><mn>7</mn></mtd>  </mtr>
+       <mtr> <mtd> <mrow> <mn>2</mn><mi>x</mi><mo>+</mo><mn>3</mn><mi>y</mi></mrow></mtd>  <mtd><mo>=</mo></mtd>  <mtd><mrow><mn>17</mn></mrow></mtd> </mtr>
+      </mtable></mrow>
+    </math>
+   ";
+   test_ClearSpeak("pt", "ClearSpeak_MultiLineLabel", "Equation", expr, "2 equations; \
+                equation 1; x plus y, is equal to 7; \
+                equation 2; 2 x plus 3 y; is equal to 17")?;
+   return Ok(());
+}
+
+#[test]
+fn equation_line() -> Result<()> {
+    let expr = "<math>
+     <mrow>
+      <mtable>
+       <mtr> <mtd> <mrow> <mi>x</mi><mo>+</mo><mi>y</mi></mrow> </mtd>  <mtd><mo>=</mo> </mtd>  <mtd><mn>7</mn></mtd>  </mtr>
+       <mtr> <mtd> <mrow> <mn>2</mn><mi>x</mi><mo>+</mo><mn>3</mn><mi>y</mi></mrow></mtd>  <mtd><mo>=</mo></mtd>  <mtd><mrow><mn>17</mn></mrow></mtd> </mtr>
+      </mtable></mrow>
+    </math>
+   ";
+   test_ClearSpeak("pt", "ClearSpeak_MultiLineLabel", "Line", expr, "2 lines; \
+                line 1; x plus y, is equal to 7; \
+                line 2; 2 x plus 3 y; is equal to 17")?;
+    return Ok(());
+}
+
+#[test]
+fn equation_none() -> Result<()> {
+    let expr = "<math>
+     <mrow>
+      <mtable>
+       <mtr> <mtd> <mrow> <mi>x</mi><mo>+</mo><mi>y</mi></mrow> </mtd>  <mtd><mo>=</mo> </mtd>  <mtd><mn>7</mn></mtd>  </mtr>
+       <mtr> <mtd> <mrow> <mn>2</mn><mi>x</mi><mo>+</mo><mn>3</mn><mi>y</mi></mrow></mtd>  <mtd><mo>=</mo></mtd>  <mtd><mrow><mn>17</mn></mrow></mtd> </mtr>
+      </mtable></mrow>
+    </math>
+   ";
+   test_ClearSpeak("pt", "ClearSpeak_MultiLineLabel", "None", expr,
+        "2 lines; \
+                x plus y, is equal to 7; \
+                2 x plus 3 y; is equal to 17")?;
+   return Ok(());
+}
+
+#[test]
+fn equation_row() -> Result<()> {
+    let expr = "<math>
+     <mrow>
+      <mtable>
+       <mtr> <mtd> <mrow> <mi>x</mi><mo>+</mo><mi>y</mi></mrow> </mtd>  <mtd><mo>=</mo> </mtd>  <mtd><mn>7</mn></mtd>  </mtr>
+       <mtr> <mtd> <mrow> <mn>2</mn><mi>x</mi><mo>+</mo><mn>3</mn><mi>y</mi></mrow></mtd>  <mtd><mo>=</mo></mtd>  <mtd><mrow><mn>17</mn></mrow></mtd> </mtr>
+      </mtable></mrow>
+    </math>
+   ";
+   test_ClearSpeak("pt", "ClearSpeak_MultiLineLabel", "Row", expr, "2 rows; \
+                row 1; x plus y, is equal to 7; \
+                row 2; 2 x plus 3 y; is equal to 17")?;
+   return Ok(());
+}
+
+#[test]
+fn equation_step() -> Result<()> {
+    let expr = "<math>
+     <mrow>
+      <mtable>
+       <mtr> <mtd> <mrow> <mi>x</mi><mo>+</mo><mi>y</mi></mrow> </mtd>  <mtd><mo>=</mo> </mtd>  <mtd><mn>7</mn></mtd>  </mtr>
+       <mtr> <mtd> <mrow> <mn>2</mn><mi>x</mi><mo>+</mo><mn>3</mn><mi>y</mi></mrow></mtd>  <mtd><mo>=</mo></mtd>  <mtd><mrow><mn>17</mn></mrow></mtd> </mtr>
+      </mtable></mrow>
+    </math>
+   ";
+   test_ClearSpeak("pt", "ClearSpeak_MultiLineLabel", "Step", expr, "2 steps; \
+                step 1; x plus y, is equal to 7; \
+                step 2; 2 x plus 3 y; is equal to 17")?;
+   return Ok(());
+}
+
+#[test]
+fn continued_row() -> Result<()> {
+  let expr = "<math>
+  <mtable intent=':system-of-equations'>
+   <mtr><mtd><mi>x</mi></mtd><mtd><mo>=</mo></mtd><mtd><mi>y</mi></mtd></mtr>
+   <mtr intent=':continued-row'><mtd/><mtd/><mtd><mrow><mo>+</mo><mn>1</mn></mrow></mtd></mtr>
+   <mtr><mtd><mi>y</mi></mtd><mtd><mo>=</mo></mtd><mtd><mn>1</mn></mtd></mtr>
+  </mtable>
+</math>";
+test("pt", "SimpleSpeak", expr,
+     "2 equations; equation 1; x is equal to y plus 1; equation 2; y is equal to 1")?;
+    return Ok(());
+}

--- a/tests/Languages/pt/ClearSpeak/sets.rs
+++ b/tests/Languages/pt/ClearSpeak/sets.rs
@@ -1,0 +1,531 @@
+﻿use crate::common::*;
+use anyhow::Result;
+
+#[test]
+fn complex() -> Result<()> {
+    let expr = "<math>
+                    <mi>â„‚</mi>
+                </math>";
+    test("pt", "ClearSpeak", expr, "the complex numbers")?;
+    return Ok(());
+
+}
+
+#[test]
+fn natural() -> Result<()> {
+    let expr = "<math>
+                    <mi>â„•</mi>
+                </math>";
+    test("pt", "ClearSpeak", expr, "the natural numbers")?;
+    return Ok(());
+
+}
+
+#[test]
+fn rationals() -> Result<()> {
+    let expr = "<math>
+                    <mi>â„š</mi>
+                </math>";
+    test("pt", "ClearSpeak", expr, "the rational numbers")?;
+    return Ok(());
+
+}
+
+#[test]
+fn reals() -> Result<()> {
+    let expr = "<math>
+                    <mi>â„</mi>
+                </math>";
+    test("pt", "ClearSpeak", expr, "the real numbers")?;
+    return Ok(());
+
+}
+
+#[test]
+fn integers() -> Result<()> {
+    let expr = "<math>
+                    <mi>â„¤</mi>
+                </math>";
+    test("pt", "ClearSpeak", expr, "the integers")?;
+    return Ok(());
+
+}
+
+
+
+#[test]
+fn msup_complex() -> Result<()> {
+    let expr = "<math>
+                <msup>
+                    <mi>â„‚</mi>
+                    <mn>2</mn>
+                </msup>
+                </math>";
+    test("pt", "ClearSpeak", expr, "C 2")?;
+    return Ok(());
+
+}
+
+#[test]
+fn msup_natural() -> Result<()> {
+    let expr = "<math>
+                <msup>
+                    <mi>â„•</mi>
+                    <mn>2</mn>
+                </msup>
+            </math>";
+    test("pt", "ClearSpeak", expr, "N 2")?;
+    return Ok(());
+
+}
+
+#[test]
+fn msup_rationals() -> Result<()> {
+    let expr = "<math>
+                <msup>
+                    <mi>â„š</mi>
+                    <mn>2</mn>
+                </msup>
+            </math>";
+    test("pt", "ClearSpeak", expr, "Q 2")?;
+    return Ok(());
+
+}
+
+#[test]
+fn msup_reals() -> Result<()> {
+    let expr = "<math>
+                <msup>
+                    <mi>â„</mi>
+                    <mn>3</mn>
+                </msup>
+            </math>";
+    test("pt", "ClearSpeak", expr, "R 3")?;
+    return Ok(());
+
+}
+
+#[test]
+fn msup_integers() -> Result<()> {
+    let expr = "<math>
+                <msup>
+                    <mi>â„¤</mi>
+                    <mn>4</mn>
+                </msup>
+            </math>";
+    test("pt", "ClearSpeak", expr, "Z 4")?;
+    return Ok(());
+
+}
+
+#[test]
+fn msup_positive_integers() -> Result<()> {
+    let expr = "<math>
+                <msup>
+                    <mi>â„¤</mi>
+                    <mo>+</mo>
+                </msup>
+            </math>";
+    test("pt", "ClearSpeak", expr, "the positive integers")?;
+    return Ok(());
+
+}
+
+#[test]
+fn msup_negative_integers() -> Result<()> {
+    let expr = "<math>
+                <msup>
+                    <mi>â„¤</mi>
+                    <mo>-</mo>
+                </msup>
+            </math>";
+    test("pt", "ClearSpeak", expr, "the negative integers")?;
+    return Ok(());
+
+}
+
+#[test]
+fn msup_positive_rationals() -> Result<()> {
+    let expr = "<math>
+                <msup>
+                    <mi>â„š</mi>
+                    <mo>+</mo>
+                </msup>
+            </math>";
+    test("pt", "ClearSpeak", expr, "the positive rational numbers")?;
+    return Ok(());
+
+}
+
+#[test]
+fn msup_negative_rationals() -> Result<()> {
+    let expr = "<math>
+                <msup>
+                    <mi>â„š</mi>
+                    <mo>-</mo>
+                </msup>
+            </math>";
+    test("pt", "ClearSpeak", expr, "the negative rational numbers")?;
+    return Ok(());
+
+}
+
+#[test]
+fn empty_set() -> Result<()> {
+    let expr = "<math>
+                <mo>{</mo> <mo>}</mo>
+            </math>";
+    test("pt", "ClearSpeak", expr, "the empty set")?;
+    return Ok(());
+
+}
+
+#[test]
+fn single_element_set() -> Result<()> {
+    let expr = "<math>
+                <mo>{</mo> <mn>12</mn><mo>}</mo>
+            </math>";
+    test("pt", "ClearSpeak", expr, "the set 12")?;
+    return Ok(());
+
+}
+
+#[test]
+fn multiple_element_set() -> Result<()> {
+    let expr = "<math>
+                <mo>{</mo> <mn>5</mn> <mo>,</mo> <mn>10</mn>  <mo>,</mo> <mn>15</mn> <mo>}</mo>
+            </math>";
+    test("pt", "ClearSpeak", expr, "the set 5 comma, 10 comma, 15")?;
+    return Ok(());
+
+}
+
+#[test]
+fn set_with_colon() -> Result<()> {
+    let expr = "<math>
+                    <mo>{</mo> <mrow><mi>x</mi><mo>:</mo><mi>x</mi><mo>&#x003E;</mo><mn>2</mn></mrow> <mo>}</mo>
+            </math>";
+    test("pt", "ClearSpeak", expr, "the set of all x such that x is greater than 2")?;
+    return Ok(());
+
+}
+
+#[test]
+fn set_with_bar() -> Result<()> {
+    let expr = "<math>
+                    <mo>{</mo> <mrow><mi>x</mi><mo>|</mo><mi>x</mi><mo>&#x003E;</mo><mn>2</mn></mrow> <mo>}</mo>
+            </math>";
+    test("pt", "ClearSpeak", expr, "the set of all x such that x is greater than 2")?;
+    return Ok(());
+
+}
+
+#[test]
+fn element_alone() -> Result<()> {
+    let expr = "<math>
+            <mn>3</mn><mo>+</mo><mn>2</mn><mi>i</mi><mo>âˆ‰</mo><mi>â„</mi>
+        </math>";
+    test("pt", "ClearSpeak", expr, "3 plus 2 i, is not a member of, the real numbers")?;
+    return Ok(());
+
+}
+
+#[test]
+fn element_under_sum() -> Result<()> {
+    let expr = "<math>
+            <munder>
+                <mo>âˆ‘</mo>
+                <mrow> <mi>i</mi> <mo>âˆˆ</mo> <mi>â„¤</mi> </mrow>
+            </munder>
+            <mfrac>
+                <mn>1</mn>
+                <mrow> <msup>  <mi>i</mi> <mn>2</mn> </msup> </mrow>
+            </mfrac>
+        </math>";
+    test("pt", "ClearSpeak", expr,
+                    "the sum over i is a member of the integers of; the fraction with numerator 1; and denominator i squared")?;
+                    return Ok(());
+
+}
+
+#[test]
+fn complicated_set_with_colon() -> Result<()> {
+    let expr = "<math>
+            <mo>{</mo>
+            <mi>x</mi>
+            <mo>âˆˆ</mo>
+            <mi>â„¤</mi>
+            <mo>:</mo>
+            <mn>2</mn>
+            <mo>&#x003C;</mo>
+            <mi>x</mi>
+            <mo>&#x003C;</mo>
+            <mn>7</mn>
+            <mo>}</mo>
+        </math>";
+    test("pt", "ClearSpeak", expr, "the set of all x in the integers such that 2 is less than x is less than 7")?;
+    return Ok(());
+
+}
+
+#[test]
+fn complicated_set_with_mtext() -> Result<()> {
+    // as of 8/5/21, parsing of "|" is problematic in the example, so <mrows> are needed for this test
+    let expr = "<math>
+        <mo>{</mo>
+        <mrow> <mi>x</mi><mo>âˆˆ</mo><mi>â„•</mi></mrow>
+        <mo>|</mo>
+        <mrow><mi>x</mi> <mtext>is an even number</mtext> </mrow>
+        <mo>}</mo>
+        </math>";
+    test("pt", "ClearSpeak", expr, 
+            "the set of all x in the natural numbers such that x is an even number")?;
+            return Ok(());
+
+}
+
+
+#[test]
+fn set_with_bar_member() -> Result<()> {
+    let expr = "<math>
+            <mo>{</mo>
+            <mi>x</mi>
+            <mo>âˆˆ</mo>
+            <mi>â„¤</mi>
+            <mo>:</mo>
+            <mi>x</mi>
+            <mo>&#x003E;</mo>
+            <mn>5</mn>
+            <mo>}</mo>
+            </math>";
+    test_ClearSpeak("pt", "ClearSpeak_SetMemberSymbol", "Member",
+                expr, "the set of all x member of the integers such that x is greater than 5")?;
+                return Ok(());
+
+}
+
+#[test]
+fn element_alone_member() -> Result<()> {
+    let expr = "<math>
+            <mn>3</mn><mo>+</mo><mn>2</mn><mi>i</mi><mo>âˆ‰</mo><mi>â„</mi>
+        </math>";
+    test_ClearSpeak("pt", "ClearSpeak_SetMemberSymbol", "Member",
+                expr, "3 plus 2 i, is not a member of, the real numbers")?;
+                return Ok(());
+
+}
+
+#[test]
+fn element_under_sum_member() -> Result<()> {
+    let expr = "<math>
+            <munder>
+                <mo>âˆ‘</mo>
+                <mrow> <mi>i</mi> <mo>âˆˆ</mo> <mi>â„¤</mi> </mrow>
+            </munder>
+            <mfrac>
+                <mn>1</mn>
+                <mrow> <msup>  <mi>i</mi> <mn>2</mn> </msup> </mrow>
+            </mfrac>
+        </math>";
+    test_ClearSpeak("pt", "ClearSpeak_SetMemberSymbol", "Member",
+                expr, "the sum over i is a member of the integers of; the fraction with numerator 1; and denominator i squared")?;
+                return Ok(());
+
+}
+
+
+#[test]
+fn set_with_bar_element() -> Result<()> {
+    let expr = "<math>
+            <mo>{</mo>
+            <mi>x</mi>
+            <mo>âˆˆ</mo>
+            <mi>â„¤</mi>
+            <mo>:</mo>
+            <mi>x</mi>
+            <mo>&#x003E;</mo>
+            <mn>5</mn>
+            <mo>}</mo>
+            </math>";
+    test_ClearSpeak("pt", "ClearSpeak_SetMemberSymbol", "Element",
+                expr, "the set of all x element of the integers such that x is greater than 5")?;
+                return Ok(());
+
+}
+
+#[test]
+fn element_alone_element() -> Result<()> {
+    let expr = "<math>
+            <mn>3</mn><mo>+</mo><mn>2</mn><mi>i</mi><mo>âˆ‰</mo><mi>â„</mi>
+        </math>";
+    test_ClearSpeak("pt", "ClearSpeak_SetMemberSymbol", "Element",
+                expr, "3 plus 2 i, is not an element of, the real numbers")?;
+                return Ok(());
+
+}
+
+#[test]
+fn element_under_sum_element() -> Result<()> {
+    let expr = "<math>
+            <munder>
+                <mo>âˆ‘</mo>
+                <mrow> <mi>i</mi> <mo>âˆˆ</mo> <mi>â„¤</mi> </mrow>
+            </munder>
+            <mfrac>
+                <mn>1</mn>
+                <mrow> <msup>  <mi>i</mi> <mn>2</mn> </msup> </mrow>
+            </mfrac>
+        </math>";
+    test_ClearSpeak("pt", "ClearSpeak_SetMemberSymbol", "Element",
+                expr, "the sum over i is an element of the integers of; the fraction with numerator 1; and denominator i squared")?;
+                return Ok(());
+
+}
+
+#[test]
+fn set_with_bar_in() -> Result<()> {
+    let expr = "<math>
+            <mo>{</mo>
+            <mi>x</mi>
+            <mo>âˆˆ</mo>
+            <mi>â„¤</mi>
+            <mo>:</mo>
+            <mi>x</mi>
+            <mo>&#x003E;</mo>
+            <mn>5</mn>
+            <mo>}</mo>
+            </math>";
+    test_ClearSpeak("pt", "ClearSpeak_SetMemberSymbol", "In",
+                expr, "the set of all x in the integers such that x is greater than 5")?;
+                return Ok(());
+
+}
+
+#[test]
+fn element_alone_in() -> Result<()> {
+    let expr = "<math>
+            <mn>3</mn><mo>+</mo><mn>2</mn><mi>i</mi><mo>âˆ‰</mo><mi>â„</mi>
+        </math>";
+    test_ClearSpeak("pt", "ClearSpeak_SetMemberSymbol", "In",
+                expr, "3 plus 2 i, is not in the real numbers")?;
+                return Ok(());
+
+}
+
+#[test]
+fn element_under_sum_in() -> Result<()> {
+    let expr = "<math>
+            <munder>
+                <mo>âˆ‘</mo>
+                <mrow> <mi>i</mi> <mo>âˆˆ</mo> <mi>â„¤</mi> </mrow>
+            </munder>
+            <mfrac>
+                <mn>1</mn>
+                <mrow> <msup>  <mi>i</mi> <mn>2</mn> </msup> </mrow>
+            </mfrac>
+        </math>";
+    test_ClearSpeak("pt", "ClearSpeak_SetMemberSymbol", "In",
+                expr, "the sum over i is in the integers of; the fraction with numerator 1; and denominator i squared")?;
+                return Ok(());
+
+}
+
+#[test]
+fn set_with_bar_belongs() -> Result<()> {
+    let expr = "<math>
+            <mo>{</mo>
+            <mi>x</mi>
+            <mo>âˆˆ</mo>
+            <mi>â„¤</mi>
+            <mo>:</mo>
+            <mi>x</mi>
+            <mo>&#x003E;</mo>
+            <mn>5</mn>
+            <mo>}</mo>
+            </math>";
+    test_ClearSpeak("pt", "ClearSpeak_SetMemberSymbol", "Belongs",
+                expr, "the set of all x belonging to the integers such that x is greater than 5")?;
+                return Ok(());
+
+}
+
+#[test]
+fn element_alone_belongs() -> Result<()> {
+    let expr = "<math>
+            <mn>3</mn><mo>+</mo><mn>2</mn><mi>i</mi><mo>âˆ‰</mo><mi>â„</mi>
+        </math>";
+    test_ClearSpeak("pt", "ClearSpeak_SetMemberSymbol", "Belongs",
+                expr, "3 plus 2 i, does not belong to, the real numbers")?;
+                return Ok(());
+
+}
+
+#[test]
+fn element_under_sum_belongs() -> Result<()> {
+    let expr = "<math>
+            <munder>
+                <mo>âˆ‘</mo>
+                <mrow> <mi>i</mi> <mo>âˆˆ</mo> <mi>â„¤</mi> </mrow>
+            </munder>
+            <mfrac>
+                <mn>1</mn>
+                <mrow> <msup>  <mi>i</mi> <mn>2</mn> </msup> </mrow>
+            </mfrac>
+        </math>";
+    test_ClearSpeak("pt", "ClearSpeak_SetMemberSymbol", "Belongs",
+                expr, "the sum over i belongs to the integers of; the fraction with numerator 1; and denominator i squared")?;
+                return Ok(());
+
+}
+
+
+#[test]
+fn set_member_woall() -> Result<()> {
+    let expr = "<math>
+            <mo>{</mo>
+            <mi>x</mi>
+            <mo>âˆˆ</mo>
+            <mi>â„¤</mi>
+            <mo>:</mo>
+            <mi>x</mi>
+            <mo>&#x003E;</mo>
+            <mn>5</mn>
+            <mo>}</mo>
+            </math>";
+            test_ClearSpeak_prefs("pt", vec![("ClearSpeak_SetMemberSymbol", "Member"), ("ClearSpeak_Sets", "woAll")],
+                expr, "the set of x member of the integers such that x is greater than 5")?;
+                return Ok(());
+
+}
+
+#[test]
+fn multiple_element_set_woall() -> Result<()> {
+    let expr = "<math>
+                <mo>{</mo> <mn>5</mn> <mo>,</mo> <mn>10</mn>  <mo>,</mo> <mn>15</mn> <mo>}</mo>
+            </math>";
+    test_ClearSpeak("pt", "ClearSpeak_Sets", "woAll", expr, "the set 5 comma, 10 comma, 15")?;
+    return Ok(());
+
+}
+
+#[test]
+fn multiple_element_set_silent_bracket() -> Result<()> {
+    let expr = "<math>
+                <mo>{</mo> <mn>5</mn> <mo>,</mo> <mn>10</mn>  <mo>,</mo> <mn>15</mn> <mo>}</mo>
+            </math>";
+            test_ClearSpeak("pt", "ClearSpeak_Sets", "SilentBracket", expr, "5 comma, 10 comma, 15")?;
+            return Ok(());
+
+        }
+
+#[test]
+fn silent_bracket() -> Result<()> {
+    let expr = "<math>
+                <mo>{</mo><mrow><mi>x</mi><mo>|</mo><mi>x</mi><mo>&#x003E;</mo><mn>2</mn></mrow><mo>}</mo>
+            </math>";
+            test_ClearSpeak("pt", "ClearSpeak_Sets", "SilentBracket", expr,
+                    "the set of all x such that x is greater than 2")?;
+                    return Ok(());
+
+        }
+

--- a/tests/Languages/pt/ClearSpeak/symbols_and_adornments.rs
+++ b/tests/Languages/pt/ClearSpeak/symbols_and_adornments.rs
@@ -1,0 +1,377 @@
+﻿use crate::common::*;
+use anyhow::Result;
+
+#[test]
+fn multiplication() -> Result<()> {
+    let expr = "<math>
+                    <mn>2</mn><mo>Ã—</mo><mn>3</mn>
+                </math>";
+    test("pt", "ClearSpeak", expr, "2 times 3")?;
+    return Ok(());
+
+}
+
+#[test]
+fn multiplication_by() -> Result<()> {
+    let expr = "<math>
+                    <mn>2</mn><mo>Ã—</mo><mn>3</mn>
+                </math>";
+    test_ClearSpeak("pt", "ClearSpeak_MultSymbolX", "By", expr, "2 by 3")?;
+    return Ok(());
+
+}
+
+#[test]
+fn multiplication_cross() -> Result<()> {
+    let expr = "<math>
+                    <mi>u</mi><mo>Ã—</mo><mi>v</mi>
+                </math>";
+    test_ClearSpeak("pt", "ClearSpeak_MultSymbolX", "Cross", expr, "u cross v")?;
+    return Ok(());
+
+}
+
+#[test]
+fn ellipses_auto_start() -> Result<()> {
+    let expr = "<math>
+            <mi>â€¦</mi><mo>,</mo>
+            <mo>-</mo><mn>2</mn><mo>,</mo><mo>-</mo><mn>1</mn><mo>,</mo><mn>0</mn>
+        </math>";
+    test("pt", "ClearSpeak", expr, "dot dot dot comma, negative 2 comma, negative 1 comma, 0")?;
+    return Ok(());
+
+}
+
+#[test]
+fn ellipses_auto_end() -> Result<()> {
+    let expr = "<math>
+            <mn>1</mn>
+            <mo>,</mo>
+            <mn>2</mn>
+            <mo>,</mo>
+            <mn>3</mn>
+            <mo>,</mo>
+            <mi>â€¦</mi>
+        </math>";
+    test_ClearSpeak("pt", "ClearSpeak_Ellipses", "Auto", expr, "1 comma, 2 comma, 3 comma, dot dot dot")?;
+    return Ok(());
+
+}
+
+#[test]
+fn ellipses_auto_middle() -> Result<()> {
+    let expr = "<math>
+            <mrow>
+                <mn>1</mn>
+                <mo>,</mo>
+                <mn>2</mn>
+                <mo>,</mo>
+                <mn>3</mn>
+                <mo>,</mo>
+                <mi>â€¦</mi>
+                <mo>,</mo>
+                <mn>20</mn>
+            </mrow>
+        </math>";
+    test_ClearSpeak("pt", "ClearSpeak_Ellipses", "Auto", expr,
+            "1 comma, 2 comma, 3 comma, dot dot dot comma, 20")?;
+            return Ok(());
+
+}
+
+#[test]
+fn ellipses_auto_both() -> Result<()> {
+    let expr = "<math>
+            <mi>â€¦</mi><mo>,</mo>
+            <mo>-</mo><mn>2</mn><mo>,</mo><mo>-</mo><mn>1</mn><mo>,</mo><mn>0</mn><mo>,</mo><mn>1</mn><mo>,</mo><mn>2</mn>
+            <mo>,</mo><mi>â€¦</mi>
+       </math>";
+    test_ClearSpeak("pt", "ClearSpeak_Ellipses", "Auto", expr,
+            "dot dot dot comma, negative 2 comma, negative 1 comma, 0 comma, 1 comma, 2 comma, dot dot dot")?;
+            return Ok(());
+
+}
+
+#[test]
+fn ellipses_and_so_on_start() -> Result<()> {
+    let expr = "<math>
+            <mi>â€¦</mi><mo>,</mo>
+            <mo>-</mo><mn>2</mn><mo>,</mo><mo>-</mo><mn>1</mn><mo>,</mo><mn>0</mn>
+        </math>";
+        test_ClearSpeak("pt", "ClearSpeak_Ellipses", "AndSoOn", expr, "dot dot dot comma, negative 2 comma, negative 1 comma, 0")?;
+        return Ok(());
+
+}
+
+#[test]
+fn ellipses_and_so_on_end() -> Result<()> {
+    let expr = "<math>
+            <mn>1</mn>
+            <mo>,</mo>
+            <mn>2</mn>
+            <mo>,</mo>
+            <mn>3</mn>
+            <mo>,</mo>
+            <mi>â€¦</mi>
+        </math>";
+    test_ClearSpeak("pt", "ClearSpeak_Ellipses", "AndSoOn", expr, "1 comma, 2 comma, 3 and so on")?;
+    return Ok(());
+
+}
+
+#[test]
+fn ellipses_and_so_on_middle() -> Result<()> {
+    let expr = "<math>
+            <mrow>
+                <mn>1</mn>
+                <mo>,</mo>
+                <mn>2</mn>
+                <mo>,</mo>
+                <mn>3</mn>
+                <mo>,</mo>
+                <mi>â€¦</mi>
+                <mo>,</mo>
+                <mn>20</mn>
+            </mrow>
+        </math>";
+    test_ClearSpeak("pt", "ClearSpeak_Ellipses", "AndSoOn", expr,
+            "1 comma, 2 comma, 3 and so on up to 20")?;
+            return Ok(());
+
+}
+
+#[test]
+fn ellipses_and_so_on_both() -> Result<()> {
+    let expr = "<math>
+            <mi>â€¦</mi><mo>,</mo>
+            <mo>-</mo><mn>2</mn><mo>,</mo><mo>-</mo><mn>1</mn><mo>,</mo><mn>0</mn><mo>,</mo><mn>1</mn><mo>,</mo><mn>2</mn>
+            <mo>,</mo><mi>â€¦</mi>
+       </math>";
+    test_ClearSpeak("pt", "ClearSpeak_Ellipses", "AndSoOn", expr,
+            "dot dot dot comma, negative 2 comma, negative 1 comma, 0 comma, 1 comma, 2 comma, dot dot dot")?;
+            return Ok(());
+
+}
+
+#[test]
+fn vertical_line_auto() -> Result<()> {
+    let expr = "<math>
+        <mn>3</mn><mo>|</mo><mn>6</mn>
+    </math>";
+    test_ClearSpeak("pt", "ClearSpeak_VerticalLine", "Auto", expr,
+            "3 divides 6")?;
+            return Ok(());
+
+}
+
+#[test]
+fn vertical_line_divides() -> Result<()> {
+    let expr = "<math>
+        <mn>3</mn><mo>|</mo><mn>6</mn>
+    </math>";
+    test_ClearSpeak("pt", "ClearSpeak_VerticalLine", "Divides", expr,
+            "3 divides 6")?;
+            return Ok(());
+
+}
+
+    #[test]
+    fn vertical_line_given() -> Result<()> {
+        let expr = "<math>
+            <mn>3</mn><mo>|</mo><mn>6</mn>
+        </math>";
+        test_ClearSpeak("pt", "ClearSpeak_VerticalLine", "Given", expr,
+                "3 given 6")?;
+                return Ok(());
+
+    }
+
+    #[test]
+    fn vertical_line_probability_given() -> Result<()> {
+        let expr = "<math>
+                <mi>P</mi>
+                <mrow>
+                    <mo>(</mo>
+                    <mrow>
+                        <mi>A</mi>
+                        <mo>|</mo>
+                        <mi>B</mi>
+                    </mrow>
+                    <mo>)</mo>
+                </mrow>
+            </math>";
+        test_ClearSpeak_prefs("pt", vec![("ClearSpeak_VerticalLine", "Given"), ("ClearSpeak_ImpliedTimes", "None")]
+                        , expr, "cap p, open paren, cap eigh given cap b, close paren")?;
+                        return Ok(());
+    }
+
+#[test]
+fn vertical_line_set() -> Result<()> {
+    let expr = "<math>
+        <mo>{</mo>
+        <mrow>
+            <mi>x</mi>
+            <mo>|</mo>
+            <mi>x</mi>
+            <mo>&gt;</mo>
+            <mn>0</mn>
+        </mrow>
+        <mo>}</mo>    
+    </math>";
+    test_ClearSpeak("pt", "ClearSpeak_VerticalLine", "Auto", expr,
+            "the set of all x such that x is greater than 0")?;
+            return Ok(());
+
+}
+
+
+#[test]
+fn vertical_line_set_such_that() -> Result<()> {
+    let expr = "<math>
+        <mo>{</mo>
+        <mrow>
+            <mi>x</mi>
+            <mo>|</mo>
+            <mi>x</mi>
+            <mo>&gt;</mo>
+            <mn>0</mn>
+        </mrow>
+        <mo>}</mo>    
+    </math>";
+    test_ClearSpeak("pt", "ClearSpeak_VerticalLine", "SuchThat", expr,
+            "the set of all x such that x is greater than 0")?;
+            return Ok(());
+
+}
+
+#[test]
+fn vertical_line_set_given() -> Result<()> {
+    let expr = "<math>
+        <mo>{</mo>
+        <mrow>
+            <mi>x</mi>
+            <mo>|</mo>
+            <mi>x</mi>
+            <mo>&gt;</mo>
+            <mn>0</mn>
+        </mrow>
+        <mo>}</mo>    
+    </math>";
+    // the rules for set will override all the options -- ClearSpeak spec should be clarified
+    test_ClearSpeak("pt", "ClearSpeak_VerticalLine", "Given", expr,
+            "the set of all x such that x is greater than 0")?;
+            return Ok(());
+
+}
+
+#[test]
+fn vertical_line_set_and_abs() -> Result<()> {
+    let expr = "<math>
+            <mo>{</mo>
+            <mrow>
+                <mi>x</mi>
+                <mo>&#x007C;</mo>
+                <mrow>
+                    <mo>|</mo>
+                    <mi>x</mi>
+                    <mo>|</mo>
+                </mrow>
+                <mo>&gt;</mo>
+                <mn>2</mn>
+            </mrow>
+            <mo>}</mo>
+        </math>";
+    test_ClearSpeak("pt", "ClearSpeak_VerticalLine", "Auto", expr,
+        "the set of all x such that the absolute value of x; is greater than 2")?;
+        return Ok(());
+
+}
+
+#[test]
+fn vertical_line_evaluated_at() -> Result<()> {
+    let expr = "<math>
+            <mi>f</mi>
+            <mrow>
+                <mo>(</mo>
+                <mi>x</mi>
+                <mo>)</mo>
+            </mrow>
+            <msub>
+                <mo>&#x007C;</mo>
+                <mrow>
+                    <mi>x</mi>
+                    <mo>=</mo>
+                    <mn>5</mn>
+                </mrow>
+            </msub>
+        </math>";
+    test_ClearSpeak("pt", "ClearSpeak_VerticalLine", "Auto", expr,
+        "f of x evaluated at, x is equal to 5")?;
+        return Ok(());
+
+}
+
+#[test]
+fn vertical_line_evaluated_at_both() -> Result<()> {
+    let expr = "<math>
+            <msup>
+            <mi>x</mi>
+            <mn>2</mn>
+            </msup>
+            <mo>+</mo>
+            <mi>x</mi>
+            <msubsup>
+                <mstyle mathsize='140%' displaystyle='true'> <mo>&#x007C;</mo> </mstyle>
+                <mn>0</mn>
+                <mn>1</mn>
+            </msubsup>
+        </math>";
+    test_ClearSpeak("pt", "ClearSpeak_VerticalLine", "Auto", expr,
+        "x squared plus x, evaluated at 1 minus the same expression evaluated at 0")?;
+        return Ok(());
+
+}
+#[test]
+fn vertical_line_evaluated_at_divides() -> Result<()> {
+    let expr = "<math>
+            <mi>f</mi>
+            <mrow>
+                <mo>(</mo>
+                <mi>x</mi>
+                <mo>)</mo>
+            </mrow>
+            <msub>
+                <mo>&#x007C;</mo>
+                <mrow>
+                    <mi>x</mi>
+                    <mo>=</mo>
+                    <mn>5</mn>
+                </mrow>
+            </msub>
+        </math>";
+    test_ClearSpeak("pt", "ClearSpeak_VerticalLine", "Divides", expr,
+        "f of x evaluated at, x is equal to 5")?;
+        return Ok(());
+
+}
+
+#[test]
+fn vertical_line_evaluated_at_both_given() -> Result<()> {
+    let expr = "<math>
+            <msup>
+            <mi>x</mi>
+            <mn>2</mn>
+            </msup>
+            <mo>+</mo>
+            <mi>x</mi>
+            <msubsup>
+                <mstyle mathsize='140%' displaystyle='true'> <mo>&#x007C;</mo> </mstyle>
+                <mn>0</mn>
+                <mn>1</mn>
+            </msubsup>
+        </math>";
+    test_ClearSpeak("pt", "ClearSpeak_VerticalLine", "Given", expr,
+        "x squared plus x, evaluated at 1 minus the same expression evaluated at 0")?;
+        return Ok(());
+
+}

--- a/tests/Languages/pt/SimpleSpeak/functions.rs
+++ b/tests/Languages/pt/SimpleSpeak/functions.rs
@@ -1,0 +1,417 @@
+﻿/// Tests for:
+/// *  functions including trig functions, logs, and functions to powers
+/// *  implied times/functional call and explicit times/function call
+/// *  parens
+/// These are all intertwined, so they are in one file
+use crate::common::*;
+use anyhow::Result;
+
+#[test]
+fn trig_names() -> Result<()> {
+    let expr = "<math><mrow>
+    <mi>sin</mi><mi>x</mi><mo>+</mo>
+    <mi>cos</mi><mi>y</mi><mo>+</mo>
+    <mi>tan</mi><mi>z</mi><mo>+</mo>
+    <mi>sec</mi><mi>&#x03B1;</mi><mo>+</mo>
+    <mi>csc</mi><mi>&#x03D5;</mi><mo>+</mo>
+    <mi>cot</mi><mi>&#x03C6;</mi>
+    </mrow></math>";
+    test("pt", "SimpleSpeak", expr, "sine of x plus cosine of y plus tangent of z plus secant of alpha, plus cosecant of phi, plus cotangent of phi")?;
+    return Ok(());
+
+}
+
+#[test]
+fn hyperbolic_trig_names() -> Result<()> {
+    let expr = "<math><mrow>
+    <mi>sinh</mi><mi>x</mi><mo>+</mo>
+    <mi>cosh</mi><mi>y</mi><mo>+</mo>
+    <mi>tanh</mi><mi>z</mi><mo>+</mo>
+    <mi>sech</mi><mi>&#x03B1;</mi><mo>+</mo>
+    <mi>csch</mi><mi>&#x03D5;</mi><mo>+</mo>
+    <mi>coth</mi><mi>&#x03C6;</mi>
+    </mrow></math>";
+    test("pt", "SimpleSpeak", expr, "hyperbolic sine of x, plus \
+                                hyperbolic cosine of y, plus \
+                                hyperbolic tangent of z, plus \
+                                hyperbolic secant of alpha, plus \
+                                hyperbolic cosecant of phi, plus \
+                                hyperbolic cotangent of phi")?;
+                                return Ok(());
+
+}
+
+
+#[test]
+fn inverse_trig() -> Result<()> {
+    let expr = "<math><msup><mi>sin</mi><mrow><mo>-</mo><mn>1</mn></mrow></msup><mi>x</mi></math>";
+    test("pt", "SimpleSpeak", expr, "inverse sine of x")?;
+    return Ok(());
+
+}
+
+#[test]
+fn trig_squared() -> Result<()> {
+    let expr = "<math><msup><mi>sin</mi><mn>2</mn></msup><mi>x</mi></math>";
+    test("pt", "SimpleSpeak", expr, "sine squared of x")?;
+    return Ok(());
+
+}
+
+#[test]
+fn trig_cubed() -> Result<()> {
+    let expr = "<math><msup><mi>tan</mi><mn>3</mn></msup><mi>x</mi></math>";
+    test("pt", "SimpleSpeak", expr, "tangent cubed of x")?;
+    return Ok(());
+
+}
+
+#[test]
+fn trig_fourth() -> Result<()> {
+    let expr = "<math><msup><mi>sec</mi><mn>4</mn></msup><mi>x</mi></math>";
+    test("pt", "SimpleSpeak", expr, "the fourth power of, secant of x")?;
+    return Ok(());
+
+}
+
+
+#[test]
+fn trig_power_other() -> Result<()> {
+    let expr = "<math><msup><mi>sinh</mi><mrow>><mi>n</mi><mo>-</mo><mn>1</mn></mrow></msup><mi>x</mi></math>";
+    test("pt", "SimpleSpeak", expr, "the n minus 1 power of, hyperbolic sine of x")?;
+    return Ok(());
+
+}
+
+#[test]
+fn simple_log() -> Result<()> {
+    let expr = "<math> <mrow>  <mi>log</mi><mi>x</mi></mrow> </math>";
+    test("pt", "SimpleSpeak", expr, "the log of x")?;
+    return Ok(());
+
+}
+
+#[test]
+fn principal_value_log() -> Result<()> {
+    let expr = "<math><mrow><mi>Log</mi><mi>z</mi></mrow></math>";
+    test("pt", "SimpleSpeak", expr, "the principal value log of z")?;
+    return Ok(());
+
+}
+
+#[test]
+fn normal_log() -> Result<()> {
+    let expr = "<math><mrow><mi>log</mi><mrow><mo>(</mo><mrow><mi>x</mi><mo>+</mo><mi>y</mi></mrow><mo>)</mo></mrow></mrow></math>";
+    test("pt", "SimpleSpeak", expr, "the log of, open paren x plus y, close paren")?;
+    return Ok(());
+
+}
+
+#[test]
+fn simple_log_with_base() -> Result<()> {
+    let expr = "<math> <mrow>  <msub><mi>log</mi><mi>b</mi></msub><mi>x</mi></mrow> </math>";
+    test("pt", "SimpleSpeak", expr, "the log base b, of x")?;
+    return Ok(());
+
+}
+
+#[test]
+fn normal_log_with_base() -> Result<()> {
+    let expr = "<math><mrow><msub><mi>log</mi><mi>b</mi></msub><mrow><mo>(</mo><mrow><mi>x</mi><mo>+</mo><mi>y</mi></mrow><mo>)</mo></mrow></mrow></math>";
+    test("pt", "SimpleSpeak", expr, "the log base b, of, open paren x plus y, close paren")?;
+    return Ok(());
+
+}
+
+#[test]
+fn normal_ln() -> Result<()> {
+    let expr = "<math><mrow><mi>ln</mi><mrow><mo>(</mo><mrow><mi>x</mi><mo>+</mo><mi>y</mi></mrow><mo>)</mo></mrow></mrow></math>";
+    test_prefs("pt", "SimpleSpeak", vec![("Verbosity", "Terse")],
+                expr, "l n, open x plus y close")?;
+    test_prefs("pt", "SimpleSpeak", vec![("Verbosity", "Medium")],
+                expr, "the natural log of, open paren x plus y, close paren")?;
+    test_prefs("pt", "SimpleSpeak", vec![("Verbosity", "Verbose")],
+                expr, "the natural log of, open paren x plus y, close paren")?;
+                return Ok(());
+
+}
+
+#[test]
+fn simple_ln() -> Result<()> {
+    let expr = "<math> <mrow>  <mi>ln</mi><mi>x</mi></mrow> </math>";
+    test_prefs("pt", "SimpleSpeak", vec![("Verbosity", "Terse")],
+                expr, "l n x")?;
+    test_prefs("pt", "SimpleSpeak", vec![("Verbosity", "Medium")],
+                expr, "the natural log of x")?;
+    test_prefs("pt", "SimpleSpeak", vec![("Verbosity", "Verbose")],
+                expr, "the natural log of x")?;
+                return Ok(());
+
+}
+
+#[test]
+fn other_names() -> Result<()> {
+    let expr = "<math> <mrow><mi>Cov</mi><mi>x</mi></mrow> </math>";
+    test_prefs("pt", "SimpleSpeak", vec![("Verbosity", "Terse")],
+                expr, "Cov x")?;
+    test_prefs("pt", "SimpleSpeak", vec![("Verbosity", "Medium")],
+                expr, "covariance x")?;
+    let expr = "<math> <mrow><mi>exp</mi><mo>(</mo><mi>x</mi><mo>)</mo></mrow> </math>";
+    test_prefs("pt", "SimpleSpeak", vec![("Verbosity", "Terse")],
+                expr, "exp x")?;
+    test_prefs("pt", "SimpleSpeak", vec![("Verbosity", "Medium")],
+                expr, "exponential of x")?;
+                return Ok(());
+
+}
+
+#[test]
+fn explicit_function_call_with_parens() -> Result<()> {
+    let expr = "<math><mrow><mi>t</mi><mo>&#x2061;</mo><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>";
+    test("pt", "SimpleSpeak", expr, "t of x")?;
+    return Ok(());
+
+}
+
+
+#[test]
+fn explicit_times_with_parens() -> Result<()> {
+    let expr = "<math><mrow><mi>t</mi><mo>&#x2062;</mo><mrow><mo>(</mo><mi>x</mi><mo>)</mo></mrow></mrow></math>";
+    test("pt", "SimpleSpeak", expr, "t times x")?;
+    return Ok(());
+
+}
+
+#[test]
+fn explicit_function_call() -> Result<()> {
+    let expr = "<math><mrow><mi>t</mi><mo>&#x2061;</mo><mrow><mi>x</mi></mrow></mrow></math>";
+    test("pt", "SimpleSpeak", expr, "t of x")?;
+    return Ok(());
+
+}
+
+#[test]
+fn explicit_times() -> Result<()> {
+    let expr = "<math><mrow><mi>t</mi><mo>&#x2062;</mo><mrow><mi>x</mi></mrow></mrow></math>";
+    test("pt", "SimpleSpeak", expr, "t x")?;
+    return Ok(());
+
+}
+
+
+/*
+    * Tests for times
+    */
+#[test]
+fn no_times_binomial() -> Result<()> {
+    let expr = "<math><mrow><mi>x</mi> <mo>&#x2062;</mo> <mi>y</mi></mrow></math>";
+    test("pt", "SimpleSpeak", expr, "x y")?;
+    return Ok(());
+
+}
+
+#[test]
+fn times_following_paren() -> Result<()> {
+    let expr = "<math><mrow>
+        <mn>2</mn>
+        <mrow>  <mo>(</mo> <mn>3</mn>  <mo>)</mo> </mrow>
+        </mrow></math>";
+    test("pt", "SimpleSpeak", expr, "2 times 3")?;
+    return Ok(());
+
+}
+
+#[test]
+fn times_preceding_paren() -> Result<()> {
+    let expr = "<math><mrow>
+        <mrow>  <mo>(</mo> <mn>2</mn>  <mo>)</mo> </mrow>
+        <mn>3</mn>
+        </mrow></math>";
+    test("pt", "SimpleSpeak", expr, "2 times 3")?;
+    return Ok(());
+
+}
+
+#[test]
+fn no_times_sqrt() -> Result<()> {
+    let expr = "<math><mrow>
+        <msqrt> <mi>a</mi>  </msqrt>
+        <msqrt> <mi>b</mi>  </msqrt>
+        <mo>=</mo>
+        <msqrt> <mrow>  <mi>a</mi><mi>b</mi></mrow> </msqrt>
+        </mrow></math>";
+    test("pt", "SimpleSpeak", expr, 
+            "the square root of eigh; times the square root of b; is equal to, the square root of eigh b, end root")?;
+    test_prefs("pt", "SimpleSpeak", vec![("Impairment", "LearningDisability")], expr,
+            "the square root of eigh; times the square root of b; is equal to, the square root of eigh b")?;
+            return Ok(());
+
+}
+
+/*
+    * Tests for parens
+    */
+    #[test]
+    fn no_parens_number() -> Result<()> {
+        let expr = "<math><mrow>
+        <mrow><mo>(</mo>
+        <mn>25</mn>
+        <mo>)</mo></mrow>
+        <mi>x</mi>
+        </mrow></math>";
+        test("pt", "SimpleSpeak", expr, "25 times x")?;
+        return Ok(());
+
+    }
+
+    #[test]
+    fn no_parens_monomial() -> Result<()> {
+        let expr = "<math><mrow>
+        <mi>b</mi>
+        <mrow><mo>(</mo>
+        <mrow><mi>x</mi><mi>y</mi></mrow>
+        <mo>)</mo></mrow>
+        </mrow></math>";
+        test("pt", "SimpleSpeak", expr, "b, open paren x y close paren")?;
+        return Ok(());
+
+    }
+
+    #[test]
+    fn no_parens_negative_number() -> Result<()> {
+        let expr = "<math><mrow>
+        <mn>2</mn><mo>+</mo>
+        <mrow><mo>(</mo>
+        <mrow><mo>&#x2212;</mo><mn>2</mn></mrow>
+        <mo>)</mo></mrow>
+        </mrow></math>";
+        test("pt", "SimpleSpeak", expr, "2 plus negative 2")?;
+        return Ok(());
+
+    }
+
+
+    #[test]
+    fn no_parens_negative_number_with_var() -> Result<()> {
+        let expr = "<math><mrow>
+        <mrow><mo>(</mo>
+        <mrow><mo>&#x2212;</mo><mn>2</mn></mrow><mi>x</mi>
+        <mo>)</mo></mrow>
+        <mo>+</mo><mn>1</mn>
+        </mrow></math>";
+        test("pt", "SimpleSpeak", expr, "negative 2 x, plus 1")?;
+        return Ok(());
+
+    }
+
+    #[test]
+    fn parens_superscript() -> Result<()> {
+        let expr = "<math><mrow>
+        <mrow>
+        <msup>
+        <mrow>
+            <mrow><mo>(</mo>
+            <mrow> <mn>2</mn><mi>x</mi></mrow>
+            <mo>)</mo></mrow></mrow>
+        <mn>2</mn>
+        </msup>
+        </mrow>
+    </mrow></math>";
+        test("pt", "SimpleSpeak", expr, "open paren 2 x close paren squared")?;
+        return Ok(());
+
+    }
+
+    #[test]
+    fn no_parens_fraction() -> Result<()> {
+        let expr = "<math><mrow>
+        <mn>2</mn>
+        <mo>+</mo>
+        <mrow>
+            <mrow><mo>(</mo>
+            <mfrac> <mn>1</mn><mn>2</mn></mfrac>
+            <mo>)</mo></mrow></mrow>
+    </mrow></math>";
+        test("pt", "SimpleSpeak", expr, "2 plus 1 half")?;
+        return Ok(());
+
+    }
+
+
+    // Tests for the four types of intervals in SimpleSpeak
+    #[test]
+    fn parens_interval_open_open() -> Result<()> {
+        let expr = "<math> 
+        <mrow intent='open-interval($start, $end)'><mo>(</mo>
+        <mrow> <mo arg='open'>(</mo><mi arg='start'>c</mi><mo>,</mo><mi arg='end'>d</mi></mrow><mo arg='close'>)</mo>
+        <mo>)</mo></mrow>
+    </math>";
+    test("pt", "SimpleSpeak",expr, "the open interval from c to d")?;
+    return Ok(());
+
+}
+
+#[test]
+    fn parens_interval_closed_open() -> Result<()> {
+        let expr = "<math> 
+        <mrow intent='closed-open-interval($start, $end)'><mo>[</mo>
+            <mrow> <mo arg='open'>[(]</mo><mi arg='start'>c</mi><mo>,</mo><mi arg='end'>d</mi></mrow><mo arg='close'>)</mo>
+            <mo>)</mo></mrow>
+        </math>";
+    test("pt", "SimpleSpeak",expr, "the closed open interval from c to d")?;
+    return Ok(());
+
+}
+
+
+#[test]
+fn parens_interval_open_closed() -> Result<()> {
+    let expr = "<math> 
+    <mrow intent='open-closed-interval($start, $end)'><mo>(</mo>
+        <mrow> <mo arg='open'>(</mo><mi arg='start'>c</mi><mo>,</mo><mi arg='end'>d</mi></mrow><mo arg='close'>]</mo>
+        <mo>]</mo></mrow>
+    </math>";
+    test("pt", "SimpleSpeak",expr,"the open closed interval from c to d")?;
+    return Ok(());
+
+}
+
+
+#[test]
+fn parens_interval_closed_closed() -> Result<()> {
+    let expr = "<math> 
+        <mrow intent='closed-interval($start, $end)'><mo>[</mo>
+            <mrow> <mo arg='open'>[(]</mo><mi arg='start'>c</mi><mo>,</mo><mi arg='end'>d</mi></mrow><mo arg='close'>]</mo>
+            <mo>]</mo></mrow>
+    </math>";
+    test("pt", "SimpleSpeak",expr, "the closed interval from c to d")?;
+    return Ok(());
+
+}
+
+    #[test]
+    fn parens_interval_neg_infinity_open_open() -> Result<()> {
+        let expr = "<math> 
+        <mrow intent='open-interval($start, $end)'><mo arg='open'>(</mo>
+        <mrow><mrow arg='start'><mo>-</mo> <mi>âˆž</mi></mrow><mo>,</mo><mi arg='end'>d</mi></mrow><mo arg='close'>)</mo>
+        <mo>)</mo></mrow>
+    </math>";
+    test("pt", "SimpleSpeak",expr,
+    "the open interval from negative infinity to d")?;
+    return Ok(());
+
+}
+
+    #[test]
+    fn parens_interval_neg_infinity_open_closed() -> Result<()> {
+        let expr = "<math> 
+        <mrow intent='open-closed-interval($start, $end)'><mo arg='open'>(</mo>
+        <mrow><mrow arg='start'><mo>-</mo> <mi>âˆž</mi></mrow><mo>,</mo><mi arg='end'>d</mi></mrow><mo arg='close'>]</mo>
+        <mo>]</mo></mrow>
+    </math>";
+    test("pt", "SimpleSpeak",expr,
+    "the open closed interval from negative infinity to d")?;
+    return Ok(());
+
+}
+

--- a/tests/Languages/pt/SimpleSpeak/geometry.rs
+++ b/tests/Languages/pt/SimpleSpeak/geometry.rs
@@ -1,0 +1,36 @@
+﻿/// Tests for geometry listed in intent
+///   ABC as mtext and as separated letters
+use crate::common::*;
+use anyhow::Result;
+
+#[test]
+fn arc() -> Result<()> {
+  let expr = "<math>  <mover><mrow><mi>B</mi><mi>C</mi></mrow><mo>âŒ’</mo></mover> </math>";
+  test("pt", "SimpleSpeak", expr, "arc cap b cap c")?;
+  return Ok(());
+
+}
+
+#[test]
+fn ray() -> Result<()> {
+  let expr = "<math> <mover><mrow><mi>X</mi><mi>Y</mi></mrow><mo>&#xAF;</mo></mover> </math>";
+  test("pt", "SimpleSpeak", expr, "line segment cap x cap y")?;
+  return Ok(());
+
+}
+
+#[test]
+fn arc_mtext() -> Result<()> {
+  let expr = "<math> <mover><mtext>BC</mtext><mo>âŒ’</mo></mover> </math>";
+  test("pt", "SimpleSpeak", expr, "arc cap b cap c")?;
+  return Ok(());
+
+}
+
+#[test]
+fn ray_mtext() -> Result<()> {
+  let expr = "<math> <mover><mtext>XY</mtext><mo>â†’</mo></mover> </math>";
+  test("pt", "SimpleSpeak", expr, "ray cap x cap y")?;
+  return Ok(());
+
+}

--- a/tests/Languages/pt/SimpleSpeak/large_ops.rs
+++ b/tests/Languages/pt/SimpleSpeak/large_ops.rs
@@ -1,0 +1,235 @@
+﻿use crate::common::*;
+use anyhow::Result;
+
+#[test]
+fn sum_both() -> Result<()> {
+    let expr = "<math>
+        <munderover>
+            <mo>âˆ‘</mo>
+            <mrow><mi>n</mi><mo>=</mo><mn>1</mn></mrow>
+            <mrow><mn>10</mn></mrow>
+        </munderover>
+        <mi>n</mi>
+    </math>";
+    test("pt", "SimpleSpeak", expr, "the sum from n is equal to 1, to 10 of n")?;
+    return Ok(());
+
+}
+
+#[test]
+fn sum_under() -> Result<()> {
+    let expr = "<math>
+        <munder>
+            <mo>âˆ‘</mo>
+            <mi>S</mi>
+        </munder>
+        <mi>i</mi>
+    </math>";
+    test("pt", "SimpleSpeak", expr, "the sum over cap s of i")?;
+    return Ok(());
+
+}
+#[test]
+fn sum_both_msubsup() -> Result<()> {
+    let expr = "<math>
+        <msubsup>
+            <mo>âˆ‘</mo>
+            <mrow><mi>n</mi><mo>=</mo><mn>1</mn></mrow>
+            <mrow><mn>10</mn></mrow>
+        </msubsup>
+        <mi>n</mi>
+    </math>";
+    test("pt", "SimpleSpeak", expr, "the sum from n is equal to 1, to 10 of n")?;
+    return Ok(());
+
+}
+
+#[test]
+fn sum_sub() -> Result<()> {
+    let expr = "<math>
+        <msub>
+            <mo>âˆ‘</mo>
+            <mi>S</mi>
+        </msub>
+        <mi>i</mi>
+    </math>";
+    test("pt", "SimpleSpeak", expr, "the sum over cap s of i")?;
+    return Ok(());
+
+}
+
+#[test]
+fn sum() -> Result<()> {
+    let expr = "<math>
+            <mo>âˆ‘</mo>
+            <msub><mi>a</mi><mi>i</mi></msub>
+    </math>";
+    test("pt", "SimpleSpeak", expr, "the sum of eigh sub i")?;
+    return Ok(());
+
+}
+
+#[test]
+fn product_both() -> Result<()> {
+    let expr = "<math>
+        <munderover>
+            <mo>âˆ</mo>
+            <mrow><mi>n</mi><mo>=</mo><mn>1</mn></mrow>
+            <mrow><mn>10</mn></mrow>
+        </munderover>
+        <mi>n</mi>
+    </math>";
+    test("pt", "SimpleSpeak", expr, "the product from n is equal to 1, to 10 of n")?;
+    return Ok(());
+
+}
+
+#[test]
+fn product_under() -> Result<()> {
+    let expr = "<math>
+        <munder>
+            <mo>âˆ</mo>
+            <mi>S</mi>
+        </munder>
+        <mi>i</mi>
+    </math>";
+    test("pt", "SimpleSpeak", expr, "the product over cap s of i")?;
+    return Ok(());
+
+}
+
+#[test]
+fn product() -> Result<()> {
+    let expr = "<math>
+            <mo>âˆ</mo>
+            <msub><mi>a</mi><mi>i</mi></msub>
+    </math>";
+    test("pt", "SimpleSpeak", expr, "the product of eigh sub i")?;
+    return Ok(());
+
+}
+
+#[test]
+fn intersection_both() -> Result<()> {
+    let expr = "<math>
+        <munderover>
+            <mo>â‹‚</mo>
+            <mrow><mi>i</mi><mo>=</mo><mn>1</mn> </mrow>
+            <mn>10</mn>
+        </munderover>
+        <msub><mi>S</mi><mi>i</mi></msub>
+    </math>";
+    test("pt", "SimpleSpeak", expr, "the intersection from i is equal to 1, to 10 of; cap s sub i")?;
+    return Ok(());
+
+}
+
+#[test]
+fn intersection_under() -> Result<()> {
+    let expr = "<math>
+        <munder>
+            <mo>â‹‚</mo>
+            <mi>C</mi>
+        </munder>
+        <msub><mi>S</mi><mi>i</mi></msub>
+    </math>";
+    test("pt", "SimpleSpeak", expr, "the intersection over cap c of, cap s sub i")?;
+    return Ok(());
+
+}
+
+#[test]
+fn intersection() -> Result<()> {
+    let expr = "<math>
+            <mo>â‹‚</mo>
+            <msub><mi>S</mi><mi>i</mi></msub>
+            </math>";
+    test("pt", "SimpleSpeak", expr, "the intersection of cap s sub i")?;
+    return Ok(());
+
+}
+
+#[test]
+fn union_both() -> Result<()> {
+    let expr = "<math>
+        <munderover>
+            <mo>â‹ƒ</mo>
+            <mrow><mi>i</mi><mo>=</mo><mn>1</mn> </mrow>
+            <mn>10</mn>
+        </munderover>
+        <msub><mi>S</mi><mi>i</mi></msub>
+    </math>";
+    test("pt", "SimpleSpeak", expr, "the union from i is equal to 1, to 10 of; cap s sub i")?;
+    return Ok(());
+
+}
+
+#[test]
+fn union_under() -> Result<()> {
+    let expr = "<math>
+        <munder>
+            <mo>â‹ƒ</mo>
+            <mi>C</mi>
+        </munder>
+        <msub><mi>S</mi><mi>i</mi></msub>
+    </math>";
+    test("pt", "SimpleSpeak", expr, "the union over cap c of, cap s sub i")?;
+    return Ok(());
+
+}
+
+#[test]
+fn union() -> Result<()> {
+    let expr = "<math>
+            <mo>â‹ƒ</mo>
+            <msub><mi>S</mi><mi>i</mi></msub>
+            </math>";
+    test("pt", "SimpleSpeak", expr, "the union of cap s sub i")?;
+    return Ok(());
+
+}
+
+#[test]
+fn integral_both() -> Result<()> {
+    let expr = "<math>
+            <mrow>
+                <msubsup>
+                    <mo>âˆ«</mo>
+                    <mn>0</mn>
+                    <mn>1</mn>
+                </msubsup>
+                <mrow><mi>f</mi><mrow><mo>(</mo><mi>x</mi> <mo>)</mo></mrow></mrow>
+            </mrow>
+            <mtext>&#x2009;</mtext><mi>d</mi><mi>x</mi>
+        </math>";
+    test("pt", "SimpleSpeak", expr, "the integral from 0, to 1 of, f of x; d x")?;
+    return Ok(());
+
+}
+
+#[test]
+fn integral_under() -> Result<()> {
+    let expr = "<math>
+        <munder>
+            <mo>âˆ«</mo>
+            <mi>â„</mi>
+        </munder>
+        <mrow><mi>f</mi><mrow><mo>(</mo><mi>x</mi> <mo>)</mo></mrow></mrow>
+        <mi>d</mi><mi>x</mi>
+        </math>";
+    test("pt", "SimpleSpeak", expr, "the integral over the real numbers of; f of x d x")?;
+    return Ok(());
+
+}
+
+#[test]
+fn integral() -> Result<()> {
+    let expr = "<math>
+            <mo>âˆ«</mo>
+            <mrow><mi>f</mi><mrow><mo>(</mo><mi>x</mi> <mo>)</mo></mrow></mrow>
+            <mi>d</mi><mi>x</mi>
+            </math>";
+    test("pt", "SimpleSpeak", expr, "the integral of f of x d x")?;
+    return Ok(());
+
+}

--- a/tests/Languages/pt/SimpleSpeak/linear_algebra.rs
+++ b/tests/Languages/pt/SimpleSpeak/linear_algebra.rs
@@ -1,0 +1,111 @@
+﻿use crate::common::*;
+use anyhow::Result;
+
+#[test]
+fn transpose() -> Result<()> {
+  let expr = "<math> <msup><mi>M</mi><mi>T</mi></msup> </math>";
+  test("pt", "SimpleSpeak", expr, "cap m transpose")?;
+  return Ok(());
+
+}
+
+#[test]
+fn trace() -> Result<()> {
+  let expr = "<math> <mi>Tr</mi><mi>M</mi> </math>";
+  test("pt", "SimpleSpeak", expr, "trace of cap m")?;
+  return Ok(());
+
+}
+
+#[test]
+fn dimension() -> Result<()> {
+  let expr = "<math> <mi>Dim</mi><mi>M</mi> </math>";
+  test("pt", "SimpleSpeak", expr, "dimension of cap m")?;
+  return Ok(());
+
+}
+
+#[test]
+fn homomorphism() -> Result<()> {
+  let expr = "<math> <mi>Hom</mi><mo>(</mo><mi>M</mi><mo>)</mo> </math>";
+  test("pt", "SimpleSpeak", expr, "homomorphism of cap m")?;
+  return Ok(());
+
+}
+
+#[test]
+fn kernel() -> Result<()> {
+  let expr = "<math> <mi>ker</mi><mrow><mo>(</mo><mi>L</mi><mo>)</mo></mrow> </math>";
+  test("pt", "SimpleSpeak", expr, "kernel of cap l")?;
+  return Ok(());
+
+}
+
+#[test]
+fn norm() -> Result<()> {
+  let expr = "  <math>
+    <mrow>
+      <mo>âˆ¥</mo>
+      <mi>f</mi>
+      <mo>âˆ¥</mo>
+    </mrow>
+</math>
+";
+  test("pt", "SimpleSpeak", expr, "norm of f")?;
+  return Ok(());
+
+}
+
+#[test]
+fn norm_non_simple() -> Result<()> {
+  let expr = "  <math>
+    <mrow>
+      <mo>âˆ¥</mo>
+      <mi>x</mi>
+      <mo>+</mo>
+      <mi>y</mi>
+      <mo>âˆ¥</mo>
+    </mrow>
+</math>
+";
+  test("pt", "SimpleSpeak", expr, "norm of x plus y end norm")?;
+  return Ok(());
+
+}
+
+#[test]
+fn norm_subscripted() -> Result<()> {
+  let expr = "  <math>
+    <msub>
+      <mrow>
+        <mo>âˆ¥</mo>
+        <mi>f</mi>
+        <mo>âˆ¥</mo>
+      </mrow>
+      <mi>p</mi>
+    </msub>
+</math>
+";
+  test("pt", "SimpleSpeak", expr, "p norm of f")?;
+  return Ok(());
+
+}
+
+#[test]
+fn not_gradient() -> Result<()> {
+  // the nabla is at the end, so it can't be gradient because it doesn't operate on anything
+  let expr = r#"<math>
+  <mo>(</mo>
+  <mi>b</mi>
+  <mo>&#x22C5;</mo>
+  <mrow>
+    <mo>&#x2207;</mo>
+  </mrow>
+  <mo>)</mo>
+  <mi>a</mi>
+</math>
+"#;
+  test("pt", "SimpleSpeak", expr, "open paren, b times nahblah, close paren; times eigh")?;
+  return Ok(());
+
+}

--- a/tests/Languages/pt/SimpleSpeak/mfrac.rs
+++ b/tests/Languages/pt/SimpleSpeak/mfrac.rs
@@ -1,0 +1,356 @@
+﻿/// Tests for fractions
+///   includes simple fractions and more complex fractions
+///   also tests mixed fractions (implicit and explicit)
+use crate::common::*;
+use anyhow::Result;
+
+#[test]
+fn common_fraction_half() -> Result<()> {
+    let expr = "<math>
+                    <mfrac> <mn>1</mn> <mn>2</mn> </mfrac>
+                </math>";
+    test("pt", "SimpleSpeak", expr, "1 half")?;
+    return Ok(());
+
+}
+
+#[test]
+fn common_fraction_thirds() -> Result<()> {
+    let expr = "<math>
+                    <mfrac> <mn>2</mn> <mn>3</mn> </mfrac>
+                </math>";
+    test("pt", "SimpleSpeak", expr, "2 thirds")?;
+    return Ok(());
+
+}
+
+#[test]
+fn common_fraction_tenths() -> Result<()> {
+    let expr = "<math>
+                    <mfrac> <mn>17</mn> <mn>10</mn> </mfrac>
+                </math>";
+    test("pt", "SimpleSpeak", expr, "17 tenths")?;
+    return Ok(());
+
+}
+
+#[test]
+#[allow(non_snake_case)]
+fn not_SimpleSpeak_common_fraction_tenths() -> Result<()> {
+    let expr = "<math>
+                    <mfrac> <mn>89</mn> <mn>10</mn> </mfrac>
+                </math>";
+    test("pt", "SimpleSpeak", expr, "89 over 10")?;
+    return Ok(());
+
+}
+
+#[test]
+fn non_simple_fraction() -> Result<()> {
+    let expr = "
+    <math>
+        <mrow>
+        <mfrac>
+        <mrow> <mi>x</mi><mo>+</mo><mi>y</mi> </mrow>
+        <mrow>
+        <mi>x</mi><mo>-</mo><mi>y</mi></mrow>
+        </mfrac>
+        </mrow>
+    </math>
+                            ";
+    test("pt", "SimpleSpeak", expr, "fraction, x plus y, over, x minus y, end fraction")?;
+    return Ok(());
+
+}
+
+#[test]
+fn nested_fraction() -> Result<()> {
+    let expr = "
+    <math>
+        <mrow>
+        <mfrac>
+        <mrow> <mi>x</mi><mo>+</mo>  <mfrac><mn>1</mn><mi>y</mi></mfrac>  </mrow>
+        <mrow>
+        <mi>x</mi><mo>-</mo><mi>y</mi></mrow>
+        </mfrac>
+        </mrow>
+    </math>
+                            ";
+    test("pt", "SimpleSpeak", expr, "fraction, x plus, fraction, 1 over y, end fraction; over, x minus y, end fraction")?;
+    return Ok(());
+
+}
+
+
+#[test]
+fn deeply_nested_fraction_msqrt() -> Result<()> {
+    let expr = "
+    <math>
+        <mrow>
+        <mfrac>
+        <mrow> <mi>x</mi><mo>+</mo>  <msqrt><mrow><mfrac><mn>1</mn><mi>y</mi></mfrac></mrow> </msqrt> </mrow>
+        <mrow>
+        <mi>x</mi><mo>-</mo><mi>y</mi></mrow>
+        </mfrac>
+        </mrow>
+    </math>
+                            ";
+    test("pt", "SimpleSpeak", expr, "fraction, x plus, the square root of 1 over y; end root; over, x minus y, end fraction")?;
+    return Ok(());
+
+}
+
+#[test]
+fn deeply_nested_fraction_mrow_msqrt() -> Result<()> {
+    let expr = "
+    <math>
+        <mrow>
+        <mfrac>
+        <mrow> <mi>x</mi><mo>+</mo>  <msqrt><mrow><mn>2</mn><mo>+</mo><mfrac><mn>1</mn><mi>y</mi></mfrac></mrow> </msqrt> </mrow>
+        <mrow>
+        <mi>x</mi><mo>-</mo><mi>y</mi></mrow>
+        </mfrac>
+        </mrow>
+    </math>
+                            ";
+    test("pt", "SimpleSpeak", expr, "fraction, x plus, the square root of 2 plus 1 over y; end root; over, x minus y, end fraction")?;
+    return Ok(());
+
+}
+
+#[test]
+fn numerator_simple_fraction() -> Result<()> {
+    let expr = "
+    <math>
+        <mrow>
+        <mfrac>
+        <mrow> <mi>x</mi></mrow>
+        <mrow>
+            <mi>x</mi><mo>-</mo><mi>y</mi></mrow>
+        </mfrac>
+        </mrow>
+    </math>
+                            ";
+    test("pt", "SimpleSpeak", expr, "fraction, x over, x minus y, end fraction")?;
+    return Ok(());
+
+}
+
+#[test]
+fn denominator_simple_fraction() -> Result<()> {
+    let expr = "
+    <math>
+        <mfrac>
+            <mrow> <mi>x</mi><mo>-</mo><mi>y</mi></mrow>
+            <mrow> <mi>x</mi></mrow>
+        </mfrac>
+    </math>
+                            ";
+    test("pt", "SimpleSpeak", expr, "fraction, x minus y, over x, end fraction")?;
+    return Ok(());
+
+}
+
+
+#[test]
+fn frac_with_units() -> Result<()> {
+    let expr = "
+    <math>
+        <mrow>
+        <mn>62</mn>
+        <mfrac>
+        <mi intent=':unit'>mi</mi>
+        <mi intent=':unit'>hr</mi>
+        </mfrac>
+        </mrow>
+    </math>";
+    test("pt", "SimpleSpeak", expr, "62 miles per hour")?;
+    return Ok(());
+
+}
+
+#[test]
+fn singular_frac_with_units() -> Result<()> {
+    let expr = "
+    <math>
+        <mrow>
+        <mn>1</mn>
+        <mfrac>
+        <mi intent=':unit'>gal</mi>
+        <mi intent=':unit'>mi</mi>
+        </mfrac>
+        </mrow>
+    </math>";
+    test("pt", "SimpleSpeak", expr, "1 gallon per mile")?;
+    return Ok(());
+
+}
+
+#[test]
+fn number_in_numerator_with_units() -> Result<()> {
+    let expr = "
+    <math>
+        <mfrac>
+            <mrow>
+                <mn>3</mn>
+                <mi intent=':unit'>gal</mi>
+            </mrow>
+            <mi intent=':unit'>mi</mi>
+        </mfrac>
+    </math>";
+    test("pt", "SimpleSpeak", expr, "3 gallons per mile")?;
+    return Ok(());
+
+}
+
+#[test]
+fn units_with_powers() -> Result<()> {
+    let expr = "
+    <math>
+        <mfrac>
+            <mrow> <mn>3</mn> <mi intent=':unit'>m</mi> </mrow>
+            <msup> <mi intent=':unit'>s</mi><mn>2</mn> </msup>
+        </mfrac>
+    </math>";
+    test("pt", "SimpleSpeak", expr, "3 metres per second squared")?;
+    return Ok(());
+
+}
+
+
+#[test]
+fn mixed_number() -> Result<()> {
+    let expr = "<math>
+                    <mn>3</mn>
+                    <mfrac> <mn>1</mn> <mn>2</mn> </mfrac>
+                </math>";
+    test("pt", "SimpleSpeak", expr, "3 and 1 half")?;
+    return Ok(());
+
+}
+
+#[test]
+fn explicit_mixed_number() -> Result<()> {
+    let expr = "<math>
+                    <mn>3</mn>
+                    <mo>&#x2064;</mo>
+                    <mfrac> <mn>1</mn> <mn>8</mn> </mfrac>
+                </math>";
+    test("pt", "SimpleSpeak", expr, "3 and 1 eighth")?;
+    return Ok(());
+
+}
+
+#[test]
+fn mixed_number_big() -> Result<()> {
+    let expr = "<math>
+                    <mn>3</mn>
+                    <mfrac> <mn>7</mn> <mn>83</mn> </mfrac>
+                </math>";
+    test("pt", "SimpleSpeak", expr, "3 and 7 eighty thirds")?;
+    return Ok(());
+
+}
+
+#[test]
+fn simple_text() -> Result<()> {
+    let expr = "<math>
+    <mfrac> <mi>rise</mi> <mi>run</mi> </mfrac>
+                </math>";
+    test("pt", "SimpleSpeak", expr, "rise over run")?;
+    return Ok(());
+
+}
+
+#[test]
+fn number_and_text() -> Result<()> {
+    let expr = "<math>
+            <mfrac>
+            <mrow>
+                <mn>2</mn><mtext>miles</mtext></mrow>
+            <mrow>
+                <mn>3</mn><mtext>gallons</mtext></mrow>
+            </mfrac>
+        </math>";
+    test("pt", "SimpleSpeak", expr, "fraction, 2 miles, over, 3 gallons, end fraction")?;
+    return Ok(());
+
+}
+
+
+#[test]
+fn nested_simple_fractions() -> Result<()> {
+    let expr = "<math>
+                <mrow>
+                <mfrac>
+                    <mrow>
+                    <mfrac>
+                        <mn>1</mn>
+                        <mn>2</mn>
+                    </mfrac>
+                    </mrow>
+                    <mrow>
+                    <mfrac>
+                        <mn>2</mn>
+                        <mn>3</mn>
+                    </mfrac>
+                    </mrow>
+                </mfrac>
+                </mrow>
+            </math>";
+    test("pt", "SimpleSpeak", expr, "fraction, 1 half, over, 2 thirds, end fraction")?;
+    return Ok(());
+
+}
+
+#[test]
+fn binomial() -> Result<()> {
+    let expr = "<math>
+                    <mn>2</mn>
+                    <mo>(</mo>
+                    <mfrac linethickness='0'> <mn>7</mn> <mn>3</mn> </mfrac>
+                    <mo>)</mo>
+                </math>";
+    test("pt", "SimpleSpeak", expr, "2 times 7 choose 3")?;
+    return Ok(());
+
+}
+
+#[test]
+fn binomial_non_simple_top() -> Result<()> {
+    let expr = "<math>
+                    <mn>2</mn>
+                    <mo>(</mo>
+                    <mfrac linethickness='0'> <mrow><mi>n</mi><mo>+</mo><mn>7</mn></mrow> <mn>3</mn> </mfrac>
+                    <mo>)</mo>
+                </math>";
+    test("pt", "SimpleSpeak", expr, "2 times, binomial n plus 7 choose 3")?;
+    return Ok(());
+
+}
+
+#[test]
+fn binomial_non_simple_bottom() -> Result<()> {
+    let expr = "<math>
+                    <mn>2</mn>
+                    <mo>(</mo>
+                    <mfrac linethickness='0'> <mn>7</mn> <mrow><mi>k</mi><mo>+</mo><mn>3</mn></mrow> </mfrac>
+                    <mo>)</mo>
+                </math>";
+    test("pt", "SimpleSpeak", expr, "2 times, 7 choose k plus 3 end binomial")?;
+    return Ok(());
+
+}
+
+#[test]
+fn binomial_non_simple_top_and_bottom() -> Result<()> {
+    let expr = "<math>
+                    <mn>2</mn>
+                    <mo>(</mo>
+                    <mfrac linethickness='0'> <mrow><mi>n</mi><mo>+</mo><mn>7</mn></mrow> <mrow><mi>k</mi><mo>+</mo><mn>3</mn></mrow> </mfrac>
+                    <mo>)</mo>
+                </math>";
+    test("pt", "SimpleSpeak", expr, "2 times, binomial n plus 7 choose k plus 3 end binomial")?;
+    return Ok(());
+
+}

--- a/tests/Languages/pt/SimpleSpeak/msup.rs
+++ b/tests/Languages/pt/SimpleSpeak/msup.rs
@@ -1,0 +1,379 @@
+﻿/// Tests for superscripts
+///   simple superscripts
+///   complex/nested superscripts
+use crate::common::*;
+use anyhow::Result;
+
+#[test]
+fn squared() -> Result<()> {
+    let expr = "<math>
+                    <msup> <mi>x</mi> <mn>2</mn> </msup>
+                </math>";
+    test("pt", "SimpleSpeak", expr, "x squared")?;
+    return Ok(());
+
+}
+
+#[test]
+fn cubed() -> Result<()> {
+    let expr = "<math>
+                    <msup> <mi>x</mi> <mn>3</mn> </msup>
+                </math>";
+    test("pt", "SimpleSpeak", expr, "x cubed")?;
+    return Ok(());
+
+}
+
+#[test]
+    fn ordinal_power() -> Result<()> {
+        let expr = "<math>
+                        <msup> <mi>x</mi> <mn>4</mn> </msup>
+                    </math>";
+        test("pt", "SimpleSpeak", expr, "x to the fourth")?;
+        return Ok(());
+
+    }
+
+#[test]
+fn simple_mi_power() -> Result<()> {
+    let expr = "<math>
+                    <msup> <mi>x</mi> <mi>n</mi> </msup>
+                </math>";
+  test("pt", "SimpleSpeak", expr, "x to the n-th")?;
+  return Ok(());
+
+}
+
+#[test]
+fn zero_power() -> Result<()> {
+    let expr = "<math>
+                    <msup> <mi>x</mi> <mn>0</mn> </msup>
+                </math>";
+    test("pt", "SimpleSpeak", expr, "x to the 0")?;
+    return Ok(());
+
+}
+
+
+#[test]
+fn decimal_power() -> Result<()> {
+    let expr = "<math>
+                    <msup> <mi>x</mi> <mn>2.0</mn> </msup>
+                </math>";
+    test("pt", "SimpleSpeak", expr, "x to the 2.0")?;
+    return Ok(());
+
+}
+
+#[test]
+fn non_simple_power() -> Result<()> {
+    let expr = "<math>
+      <mrow>
+      <msup>
+        <mn>3</mn>
+        <mrow>
+        <mi>y</mi><mo>+</mo><mn>2</mn></mrow>
+      </msup>
+      </mrow>
+                </math>";
+    test("pt", "SimpleSpeak", expr, "3 raised to the y plus 2 power")?;
+    return Ok(());
+
+}
+
+#[test]
+fn negative_power() -> Result<()> {
+    let expr = "<math>
+                    <msup>
+                        <mi>x</mi>
+                        <mrow> <mo>-</mo> <mn>2</mn> </mrow>
+                    </msup>
+                </math>";
+    test("pt", "SimpleSpeak", expr, "x to the negative 2")?;
+    return Ok(());
+
+}
+
+#[test]
+fn simple_fraction_power() -> Result<()> {
+  let expr = "<math>
+                  <msup>
+                      <mi>x</mi> 
+                      <mfrac><mn>1</mn><mn>3</mn></mfrac>
+                  </msup>
+              </math>";
+  test("pt", "SimpleSpeak", expr, "x raised to the 1 third power")?;
+  return Ok(());
+
+}
+
+#[test]
+fn nested_squared_power_with_coef() -> Result<()> {
+    let expr = "<math>
+      <mrow>
+      <msup>
+        <mn>3</mn>
+        <mrow>
+        <mn>2</mn>
+        <msup>
+          <mi>x</mi>
+          <mn>2</mn>
+        </msup>
+        </mrow>
+      </msup>
+      </mrow>
+      </math>";
+  test("pt", "SimpleSpeak", expr, "3 raised to the 2 x squared power")?;
+  return Ok(());
+
+}
+
+#[test]
+fn nested_squared_power_with_neg_coef() -> Result<()> {
+    let expr = "<math>
+    <mrow>
+    <msup>
+      <mn>3</mn>
+      <mrow>
+      <mo>-</mo>
+      <mn>2</mn>
+      <msup>
+        <mi>x</mi>
+        <mn>2</mn>
+      </msup>
+      </mrow>
+    </msup>
+    </mrow>
+  </math>";
+  test("pt", "SimpleSpeak", expr, "3 raised to the negative 2 x squared power")?;
+  return Ok(());
+
+}
+
+
+#[test]
+fn nested_cubed_power() -> Result<()> {
+    let expr = "<math>
+      <msup>
+      <mi>y</mi> 
+      <msup>
+          <mfrac><mn>4</mn><mn>5</mn></mfrac>
+          <mn>3</mn>
+      </msup>
+    </msup>
+  </math>";
+  test("pt", "SimpleSpeak", expr, "y raised to the 4 fifths cubed power")?;
+  return Ok(());
+
+}
+
+#[test]
+fn nested_cubed_power_with_neg_base() -> Result<()> {
+    let expr = "<math>
+      <msup>
+      <mi>y</mi> 
+        <mrow>
+            <mo>-</mo>
+            <msup>
+                <mfrac><mn>4</mn><mn>5</mn></mfrac>
+                <mn>3</mn>
+            </msup>
+        </mrow>
+    </msup>
+    </math>";
+  test("pt", "SimpleSpeak", expr, "y raised to the negative 4 fifths cubed power")?;
+  return Ok(());
+
+}
+
+#[test]
+fn nested_number_times_squared() -> Result<()> {
+    let expr = "<math>
+        <mrow>
+        <msup>
+          <mi>e</mi>
+          <mrow>
+          <mfrac>
+            <mn>1</mn>
+            <mn>2</mn>
+            </mfrac>
+            <msup>
+            <mi>x</mi>
+            <mn>2</mn>
+            </msup>
+          </mrow>
+        </msup>
+        </mrow>
+        </math>";
+  test("pt", "SimpleSpeak", expr, "e raised to the 1 half x squared power")?;
+  return Ok(());
+
+}
+
+#[test]
+fn nested_negative_number_times_squared() -> Result<()> {
+  let expr = "<math>
+    <mrow>
+    <msup>
+      <mi>e</mi>
+      <mrow>
+      <mo>&#x2212;</mo><mfrac>
+        <mn>1</mn>
+        <mn>2</mn>
+      </mfrac>
+      <msup>
+        <mi>x</mi>
+        <mn>2</mn>
+      </msup>
+      </mrow>
+    </msup>
+    </mrow>
+    </math>";
+  test("pt", "SimpleSpeak", expr, "e raised to the negative 1 half x squared power")?;
+  return Ok(());
+
+}
+
+#[test]
+fn nested_expr_to_tenth() -> Result<()> {
+    let expr = "<math>
+      <mrow>
+      <msup>
+        <mn>3</mn>
+        <mrow>
+        <msup>
+          <mn>3</mn>
+          <mrow>
+          <mn>10</mn></mrow>
+        </msup>
+        </mrow>
+      </msup>
+      </mrow>
+      </math>";
+  test("pt", "SimpleSpeak", expr, "3 raised to the 3 to the tenth power")?;
+  return Ok(());
+
+}
+
+#[test]
+fn nested_non_simple_squared_exp() -> Result<()> {
+    let expr = "<math>
+      <mrow>
+      <msup>
+        <mn>3</mn>
+        <mrow>
+        <msup>
+          <mrow>
+          <mrow><mo>(</mo>
+            <mrow>
+            <mi>x</mi><mo>+</mo><mn>1</mn></mrow>
+          <mo>)</mo></mrow></mrow>
+          <mn>2</mn>
+        </msup>
+        </mrow>
+      </msup>
+      </mrow>
+      </math>";
+  test("pt", "SimpleSpeak", expr, "3 raised to the open paren x plus 1, close paren squared power")?;
+  return Ok(());
+
+}
+
+#[test]
+fn nested_simple_power() -> Result<()> {
+    let expr = "<math>
+      <msup>
+      <mi>t</mi> 
+      <msup>
+          <mfrac><mn>4</mn><mn>5</mn></mfrac>
+          <mi>n</mi>
+      </msup>
+    </msup>
+  </math>";
+  test("pt", "SimpleSpeak", expr, "t raised to the 4 fifths to the n-th power")?;
+  return Ok(());
+
+}
+
+#[test]
+fn nested_end_exponent_power() -> Result<()> {
+    let expr = "<math>
+      <msup>
+      <mi>t</mi> 
+      <msup>
+          <mfrac><mn>4</mn><mn>5</mn></mfrac>
+          <mrow><mi>n</mi><mo>+</mo><mn>1</mn></mrow>
+      </msup>
+    </msup>
+  </math>";
+  test("pt", "SimpleSpeak", expr, "t raised to the 4 fifths raised to the n plus 1 power; end exponent")?;
+  test_prefs("pt", "SimpleSpeak", vec![("Impairment", "LearningDisability")], expr,
+  "t raised to the 4 fifths raised to the n plus 1 power")?;
+  return Ok(());
+
+}
+
+#[test]
+fn nested_end_exponent_neg_power() -> Result<()> {
+    let expr = "<math>
+      <msup>
+      <mi>t</mi> 
+      <msup>
+          <mfrac><mn>4</mn><mn>5</mn></mfrac>
+          <mrow><mo>-</mo><mn>3</mn></mrow>
+      </msup>
+    </msup>
+  </math>";
+  test("pt", "SimpleSpeak", expr, "t raised to the 4 fifths to the negative 3, end exponent")?;
+  return Ok(());
+
+}
+
+#[test]
+fn nested_complex_power() -> Result<()> {
+    let expr = "<math>
+      <mrow>
+      <msup>
+        <mi>e</mi>
+        <mrow>
+        <mo>&#x2212;</mo><mfrac>
+          <mn>1</mn>
+          <mn>2</mn>
+        </mfrac>
+        <msup>
+          <mrow>
+          <mrow><mo>(</mo>
+            <mrow>
+            <mfrac>
+              <mrow>
+              <mi>x</mi><mo>&#x2212;</mo><mi>&#x03BC;</mi></mrow>
+              <mi>&#x03C3;</mi>
+            </mfrac>
+            </mrow>
+          <mo>)</mo></mrow></mrow>
+          <mn>2</mn>
+        </msup>
+        </mrow>
+      </msup>
+      </mrow>
+      </math>";
+  test("pt", "SimpleSpeak", expr, "e raised to the negative 1 half times; open paren, fraction, x minus mu, over sigma, end fraction; close paren squared power")?;
+  return Ok(());
+
+}
+
+#[test]
+fn default_power() -> Result<()> {
+    let expr = "<math>
+      <msup>
+      <mi>t</mi> 
+      <mfrac>
+          <mrow><mi>b</mi><mo>+</mo><mn>1</mn></mrow>
+          <mn>3</mn>
+      </mfrac>
+    </msup>
+  </math>";
+  test("pt", "SimpleSpeak", expr, "t raised to the fraction, b plus 1, over 3, end fraction; power")?;
+  return Ok(());
+
+}

--- a/tests/Languages/pt/SimpleSpeak/multiline.rs
+++ b/tests/Languages/pt/SimpleSpeak/multiline.rs
@@ -1,0 +1,78 @@
+﻿use crate::common::*;
+use anyhow::Result;
+
+#[test]
+fn case_1() -> Result<()> {
+    let expr = "<math>
+            <mrow>
+            <mi>f</mi><mrow><mo>(</mo>
+            <mi>x</mi>
+            <mo>)</mo></mrow><mo>=</mo><mrow><mo>{</mo> <mrow>
+            <mtable>
+            <mtr>
+                <mtd>
+                <mrow>
+                <mo>&#x2212;</mo><mn>1</mn><mtext>&#x00A0;if&#x00A0;</mtext><mi>x</mi><mo>&#x003C;</mo><mn>0</mn></mrow>
+                </mtd>
+            </mtr>
+            <mtr>
+                <mtd>
+                <mrow>
+                <mn>0</mn><mtext>&#x00A0;if&#x00A0;</mtext><mi>x</mi><mo>=</mo><mn>0</mn></mrow>
+                </mtd>
+            </mtr>
+            <mtr>
+                <mtd>
+                <mrow>
+                <mn>1</mn><mtext>&#x00A0;if&#x00A0;</mtext><mi>x</mi><mo>&#x003E;</mo><mn>0</mn></mrow>
+                </mtd>
+            </mtr>
+            </mtable></mrow> </mrow></mrow>
+        </math>
+   ";
+    test("pt", "SimpleSpeak", expr, "f of x is equal to; 3 cases; \
+                case 1; negative 1 if x; is less than 0; \
+                case 2; 0 if x, is equal to 0; \
+                case 3; 1 if x, is greater than 0")?;
+    return Ok(());
+}
+
+#[test]
+fn equation_1() -> Result<()> {
+    let expr = "<math>
+     <mrow>
+      <mtable>
+       <mtr>
+        <mtd>
+         <mrow>
+          <mi>x</mi><mo>+</mo><mi>y</mi></mrow>
+        </mtd>
+        <mtd>
+         <mo>=</mo>
+        </mtd>
+        <mtd>
+         <mn>7</mn>
+        </mtd>
+       </mtr>
+       <mtr>
+        <mtd>
+         <mrow>
+          <mn>2</mn><mi>x</mi><mo>+</mo><mn>3</mn><mi>y</mi></mrow>
+        </mtd>
+        <mtd>
+         <mo>=</mo>
+        </mtd>
+        <mtd>
+         <mrow>
+          <mn>17</mn></mrow>
+        </mtd>
+       </mtr>
+       
+      </mtable></mrow>
+    </math>
+   ";
+    test("pt", "SimpleSpeak", expr, "2 equations; \
+                equation 1; x plus y, is equal to 7; \
+                equation 2; 2 x plus 3 y; is equal to 17")?;
+    return Ok(());
+}

--- a/tests/Languages/pt/SimpleSpeak/sets.rs
+++ b/tests/Languages/pt/SimpleSpeak/sets.rs
@@ -1,0 +1,285 @@
+﻿use crate::common::*;
+use anyhow::Result;
+
+#[test]
+fn complex() -> Result<()> {
+    let expr = "<math>
+                    <mi>â„‚</mi>
+                </math>";
+    test("pt", "SimpleSpeak", expr, "the complex numbers")?;
+    return Ok(());
+
+}
+
+#[test]
+fn natural() -> Result<()> {
+    let expr = "<math>
+                    <mi>â„•</mi>
+                </math>";
+    test("pt", "SimpleSpeak", expr, "the natural numbers")?;
+    return Ok(());
+
+}
+
+#[test]
+fn rationals() -> Result<()> {
+    let expr = "<math>
+                    <mi>â„š</mi>
+                </math>";
+    test("pt", "SimpleSpeak", expr, "the rational numbers")?;
+    return Ok(());
+
+}
+
+#[test]
+fn reals() -> Result<()> {
+    let expr = "<math>
+                    <mi>â„</mi>
+                </math>";
+    test("pt", "SimpleSpeak", expr, "the real numbers")?;
+    return Ok(());
+
+}
+
+#[test]
+fn integers() -> Result<()> {
+    let expr = "<math>
+                    <mi>â„¤</mi>
+                </math>";
+    test("pt", "SimpleSpeak", expr, "the integers")?;
+    return Ok(());
+
+}
+
+
+
+#[test]
+fn msup_complex() -> Result<()> {
+    let expr = "<math>
+                <msup>
+                    <mi>â„‚</mi>
+                    <mn>2</mn>
+                </msup>
+                </math>";
+    test("pt", "SimpleSpeak", expr, "C 2")?;
+    return Ok(());
+
+}
+
+#[test]
+fn msup_natural() -> Result<()> {
+    let expr = "<math>
+                <msup>
+                    <mi>â„•</mi>
+                    <mn>2</mn>
+                </msup>
+            </math>";
+    test("pt", "SimpleSpeak", expr, "N 2")?;
+    return Ok(());
+
+}
+
+#[test]
+fn msup_rationals() -> Result<()> {
+    let expr = "<math>
+                <msup>
+                    <mi>â„š</mi>
+                    <mn>2</mn>
+                </msup>
+            </math>";
+    test("pt", "SimpleSpeak", expr, "Q 2")?;
+    return Ok(());
+
+}
+
+#[test]
+fn msup_reals() -> Result<()> {
+    let expr = "<math>
+                <msup>
+                    <mi>â„</mi>
+                    <mn>3</mn>
+                </msup>
+            </math>";
+    test("pt", "SimpleSpeak", expr, "R 3")?;
+    return Ok(());
+
+}
+
+#[test]
+fn msup_integers() -> Result<()> {
+    let expr = "<math>
+                <msup>
+                    <mi>â„¤</mi>
+                    <mn>4</mn>
+                </msup>
+            </math>";
+    test("pt", "SimpleSpeak", expr, "Z 4")?;
+    return Ok(());
+
+}
+
+#[test]
+fn msup_positive_integers() -> Result<()> {
+    let expr = "<math>
+                <msup>
+                    <mi>â„¤</mi>
+                    <mo>+</mo>
+                </msup>
+            </math>";
+    test("pt", "SimpleSpeak", expr, "the positive integers")?;
+    return Ok(());
+
+}
+
+#[test]
+fn msup_negative_integers() -> Result<()> {
+    let expr = "<math>
+                <msup>
+                    <mi>â„¤</mi>
+                    <mo>-</mo>
+                </msup>
+            </math>";
+    test("pt", "SimpleSpeak", expr, "the negative integers")?;
+    return Ok(());
+
+}
+
+#[test]
+fn msup_positive_rationals() -> Result<()> {
+    let expr = "<math>
+                <msup>
+                    <mi>â„š</mi>
+                    <mo>+</mo>
+                </msup>
+            </math>";
+    test("pt", "SimpleSpeak", expr, "the positive rational numbers")?;
+    return Ok(());
+
+}
+
+#[test]
+fn msup_negative_rationals() -> Result<()> {
+    let expr = "<math>
+                <msup>
+                    <mi>â„š</mi>
+                    <mo>-</mo>
+                </msup>
+            </math>";
+    test("pt", "SimpleSpeak", expr, "the negative rational numbers")?;
+    return Ok(());
+
+}
+
+#[test]
+fn empty_set() -> Result<()> {
+    let expr = "<math>
+                <mo>{</mo> <mo>}</mo>
+            </math>";
+    test("pt", "SimpleSpeak", expr, "the empty set")?;
+    return Ok(());
+
+}
+
+#[test]
+fn single_element_set() -> Result<()> {
+    let expr = "<math>
+                <mo>{</mo> <mn>12</mn><mo>}</mo>
+            </math>";
+    test("pt", "SimpleSpeak", expr, "the set 12")?;
+    return Ok(());
+
+}
+
+#[test]
+fn multiple_element_set() -> Result<()> {
+    let expr = "<math>
+                <mo>{</mo> <mn>5</mn> <mo>,</mo> <mn>10</mn>  <mo>,</mo> <mn>15</mn> <mo>}</mo>
+            </math>";
+    test("pt", "SimpleSpeak", expr, "the set 5 comma, 10 comma, 15")?;
+    return Ok(());
+
+}
+
+#[test]
+fn set_with_colon() -> Result<()> {
+    let expr = "<math>
+                    <mo>{</mo> <mrow><mi>x</mi><mo>:</mo><mi>x</mi><mo>&#x003E;</mo><mn>2</mn></mrow> <mo>}</mo>
+            </math>";
+    test("pt", "SimpleSpeak", expr, "the set of all x such that x is greater than 2")?;
+    return Ok(());
+
+}
+
+#[test]
+fn set_with_bar() -> Result<()> {
+    let expr = "<math>
+                    <mo>{</mo> <mrow><mi>x</mi><mo>|</mo><mi>x</mi><mo>&#x003E;</mo><mn>2</mn></mrow> <mo>}</mo>
+            </math>";
+    test("pt", "SimpleSpeak", expr, "the set of all x such that x is greater than 2")?;
+    return Ok(());
+
+}
+
+#[test]
+fn element_alone() -> Result<()> {
+    let expr = "<math>
+            <mn>3</mn><mo>+</mo><mn>2</mn><mi>i</mi><mo>âˆ‰</mo><mi>â„</mi>
+        </math>";
+    test("pt", "SimpleSpeak", expr, "3 plus 2 i, is not an element of, the real numbers")?;
+    return Ok(());
+
+}
+
+#[test]
+fn element_under_sum() -> Result<()> {
+    let expr = "<math>
+            <munder>
+                <mo>âˆ‘</mo>
+                <mrow> <mi>i</mi> <mo>âˆˆ</mo> <mi>â„¤</mi> </mrow>
+            </munder>
+            <mfrac>
+                <mn>1</mn>
+                <mrow> <msup>  <mi>i</mi> <mn>2</mn> </msup> </mrow>
+            </mfrac>
+        </math>";
+    test("pt", "SimpleSpeak", expr,
+                    "the sum over i is an element of the integers of; fraction, 1 over, i squared, end fraction")?;
+                    return Ok(());
+
+}
+
+#[test]
+fn complicated_set_with_colon() -> Result<()> {
+    let expr = "<math>
+            <mo>{</mo>
+            <mi>x</mi>
+            <mo>âˆˆ</mo>
+            <mi>â„¤</mi>
+            <mo>:</mo>
+            <mn>2</mn>
+            <mo>&#x003C;</mo>
+            <mi>x</mi>
+            <mo>&#x003C;</mo>
+            <mn>7</mn>
+            <mo>}</mo>
+        </math>";
+    test("pt", "SimpleSpeak", expr, "the set of all x an element of the integers such that 2 is less than x is less than 7")?;
+    return Ok(());
+
+}
+
+#[test]
+fn complicated_set_with_mtext() -> Result<()> {
+    // as of 8/5/21, parsing of "|" is problematic an element of the example, so <mrows> are needed for this test
+    let expr = "<math>
+        <mo>{</mo>
+        <mrow> <mi>x</mi><mo>âˆˆ</mo><mi>â„•</mi></mrow>
+        <mo>|</mo>
+        <mrow><mi>x</mi> <mtext>&#x00A0;is&#x00A0;an&#x00A0;even&#x00A0;number</mtext> </mrow>
+        <mo>}</mo>
+        </math>";
+    test("pt", "SimpleSpeak", expr, 
+            "the set of all x an element of the natural numbers such that x is an even number")?;
+            return Ok(());
+
+}

--- a/tests/Languages/pt/SimpleSpeak/subscripts.rs
+++ b/tests/Languages/pt/SimpleSpeak/subscripts.rs
@@ -1,0 +1,64 @@
+﻿use crate::common::*;
+use anyhow::Result;
+
+#[test]
+fn msub_simple() -> Result<()> {
+    let expr = "<math> <msub> <mi>x</mi> <mn>1</mn> </msub> </math>";
+    test_prefs("pt", "SimpleSpeak", vec![("Verbosity", "Terse")], expr, "x 1")?;
+    test_prefs("pt", "SimpleSpeak", vec![("Verbosity", "Medium")], expr, "x sub 1")?;
+    test_prefs("pt", "SimpleSpeak", vec![("Verbosity", "Verbose")], expr, "x sub 1")?;
+    return Ok(());
+
+  }
+
+#[test]
+fn msub_not_simple() -> Result<()> {
+    let expr = "<math> <msub> <mi>x</mi> <mn>1.2</mn> </msub> </math>";
+    test_prefs("pt", "SimpleSpeak", vec![("Verbosity", "Terse")], expr, "x sub 1.2")?;
+    return Ok(());
+
+  }
+
+#[test]
+fn msubsup_not_simple() -> Result<()> {
+    let expr = "<math> <msubsup> <mi>x</mi> <mn>1.2</mn> <mn>3</mn></msubsup> </math>";
+    test_prefs("pt", "SimpleSpeak", vec![("Verbosity", "Terse")], expr, "x sub 1.2, cubed")?;
+    return Ok(());
+
+  }
+
+#[test]
+fn msub_simple_mi() -> Result<()> {
+    let expr = "<math> <msub> <mi>x</mi> <mi>i</mi> </msub> </math>";
+    test_prefs("pt", "SimpleSpeak", vec![("Verbosity", "Terse")], expr, "x sub i")?;
+    test_prefs("pt", "SimpleSpeak", vec![("Verbosity", "Verbose")], expr, "x sub i")?;
+    return Ok(());
+
+}
+
+#[test]
+fn msub_simple_number_follows() -> Result<()> {
+    let expr = "<math> <msub> <mi>x</mi> <mn>1</mn> </msub> <msup><mn>10</mn><mn>2</mn></msup> </math>";
+    test_prefs("pt", "SimpleSpeak", vec![("Verbosity", "Terse")], expr, "x 1, 10 squared")?;
+    test_prefs("pt", "SimpleSpeak", vec![("Verbosity", "Verbose")], expr, "x sub 1, 10 squared")?;
+    return Ok(());
+
+}
+
+#[test]
+fn msub_simple_non_number_follows() -> Result<()> {
+    let expr = "<math> <msubsup> <mi>x</mi> <mn>1</mn> <mn>2</mn> </msubsup> </math>";
+    test_prefs("pt", "SimpleSpeak", vec![("Verbosity", "Terse")], expr, "x 1, squared")?;
+    test_prefs("pt", "SimpleSpeak", vec![("Verbosity", "Verbose")], expr, "x sub 1, squared")?;
+    return Ok(());
+
+}
+
+#[test]
+fn msubsup_simple() -> Result<()> {
+    let expr = "<math> <msub> <mi>x</mi> <mn>1</mn> </msub> <msup><mi>x</mi>,<mn>2</mn></msup> </math>";
+    test_prefs("pt", "SimpleSpeak", vec![("Verbosity", "Terse")], expr, "x 1, x squared")?;
+    test_prefs("pt", "SimpleSpeak", vec![("Verbosity", "Verbose")], expr, "x sub 1, x squared")?;
+    return Ok(());
+
+}

--- a/tests/Languages/pt/alphabets.rs
+++ b/tests/Languages/pt/alphabets.rs
@@ -1,0 +1,427 @@
+﻿/// Tests for rules shared between various speech styles:
+/// *  this has tests focused on the various alphabets
+use crate::common::*;
+use anyhow::Result;
+
+
+#[test]
+fn special_alphabet_chars() -> Result<()> {
+  let expr = "<math> <mi>â„Œ</mi><mo>,</mo><mi>â„­</mi></math>";
+  test("pt", "SimpleSpeak", expr, "fraktur cap h comma, fraktur cap c")?;
+  let expr = "<math> <mi>â„</mi><mo>,</mo><mi>â„¿</mi></math>";
+  test("pt", "SimpleSpeak", expr, "double struck cap h, comma, double struck cap pi")?;
+  let expr = "<math> <mi>â„</mi><mo>,</mo><mi>â„³</mi></math>";
+  test("pt", "SimpleSpeak", expr, "script cap i comma, script cap m")?;
+  return Ok(());
+
+}
+
+#[test]
+fn greek() -> Result<()> {
+    let expr = "<math> <mi>Î‘</mi><mo>,</mo><mi>Î©</mi></math>";
+    test("pt", "SimpleSpeak", expr, "cap alpha comma, cap omega")?;
+    let expr = "<math> <mi>Î±</mi><mo>,</mo><mi>Ï‰</mi></math>";
+    test("pt", "SimpleSpeak", expr, "alpha comma, omega")?;
+    // MathType private space versions
+    let expr = "<math> <mi>ïˆ</mi><mo>,</mo><mi>ïˆ‰</mi></math>";
+    test("pt", "SimpleSpeak", expr, "double struck cap delta, comma, double struck cap upsilon")?;
+    let expr = "<math> <mi>Î±</mi><mo>,</mo><mi>Ï‰</mi></math>";
+    test("pt", "SimpleSpeak", expr, "alpha comma, omega")?;
+    return Ok(());
+
+}
+
+#[test]
+fn cap_cyrillic() -> Result<()> {
+    let expr = "<math> <mi>Ð</mi><mo>,</mo><mi>Ð¯</mi></math>";
+    test("pt", "SimpleSpeak", expr, "cap a comma, cap ya")?;
+    return Ok(());
+
+}
+
+#[test]
+fn parenthesized() -> Result<()> {
+    let expr = "<math> <mi>â’œ</mi><mo>,</mo><mi>â’µ</mi></math>";
+    test("pt", "SimpleSpeak", expr, "parenthesized eigh comma, parenthesized z")?;
+    return Ok(());
+
+}
+
+#[test]
+fn circled() -> Result<()> {
+    let expr = "<math> <mi>â’¶</mi><mo>,</mo><mi>â“</mi></math>";
+    test("pt", "SimpleSpeak", expr, "circled cap eigh comma, circled cap z")?;
+    let expr = "<math> <mi>ðŸ…</mi><mo>,</mo><mi>ðŸ…©</mi></math>";
+    test("pt", "SimpleSpeak", expr, "black circled cap eigh, comma, black circled cap z")?;
+    let expr = "<math> <mi>â“</mi><mo>,</mo><mi>â“©</mi></math>";
+    test("pt", "SimpleSpeak", expr, "circled eigh comma, circled z")?;
+    return Ok(());
+
+}
+
+#[test]
+fn fraktur() -> Result<()> {
+    let expr = "<math> <mi>ð”„</mi><mo>,</mo><mi>ð”œ</mi></math>";
+    test("pt", "SimpleSpeak", expr, "fraktur cap eigh comma, fraktur cap y")?;
+    let expr = "<math> <mi>ð”ž</mi><mo>,</mo><mi>ð”·</mi></math>";
+    test("pt", "SimpleSpeak", expr, "fraktur eigh comma, fraktur z")?;
+    // MathType private space versions
+    let expr = "<math> <mi>ï€€</mi><mo>,</mo><mi>ï€˜</mi></math>";
+    test("pt", "SimpleSpeak", expr, "fraktur cap eigh comma, fraktur cap y")?;
+    let expr = "<math> <mi>ï€š</mi><mo>,</mo><mi>ï€³</mi></math>";
+    test("pt", "SimpleSpeak", expr, "fraktur eigh comma, fraktur z")?;
+    return Ok(());
+
+}
+
+#[test]
+fn bold_fraktur() -> Result<()> {
+    let expr = "<math> <mi>ð•¬</mi><mo>,</mo><mi>ð–…</mi></math>";
+    test("pt", "SimpleSpeak", expr, "fraktur bold cap eigh, comma, fraktur bold cap z")?;
+    let expr = "<math> <mi>ð–†</mi><mo>,</mo><mi>ð–Ÿ</mi></math>";
+    test("pt", "SimpleSpeak", expr, "fraktur bold eigh comma, fraktur bold z")?;
+    // MathType private space versions
+    let expr = "<math> <mi>ï€</mi><mo>,</mo><mi>ï™</mi></math>";
+    test("pt", "SimpleSpeak", expr, "fraktur bold cap eigh, comma, fraktur bold cap z")?;
+    let expr = "<math> <mi>ïš</mi><mo>,</mo><mi>ï³</mi></math>";
+    test("pt", "SimpleSpeak", expr, "fraktur bold eigh comma, fraktur bold z")?;
+    return Ok(());
+
+}
+
+#[test]
+fn double_struck() -> Result<()> {
+    let expr = "<math> <mi>ð”¸</mi><mo>,</mo><mi>ð•</mi></math>";
+    test("pt", "SimpleSpeak", expr, "double struck cap eigh, comma, double struck cap y")?;
+    let expr = "<math> <mi>ð•’</mi><mo>,</mo><mi>ð•«</mi></math>";
+    test("pt", "SimpleSpeak", expr, "double struck eigh comma, double struck z")?;
+    let expr = "<math> <mi>ðŸ˜</mi><mo>,</mo><mi>ðŸ¡</mi></math>";
+    test("pt", "SimpleSpeak", expr, "double struck 0 comma, double struck 9")?;
+    // MathType private space versions
+    let expr = "<math> <mi>ï‚€</mi><mo>,</mo><mi>ï‚˜</mi></math>";
+    test("pt", "SimpleSpeak", expr, "double struck cap eigh, comma, double struck cap y")?;
+    let expr = "<math> <mi>ï‚š</mi><mo>,</mo><mi>ï‚³</mi></math>";
+    test("pt", "SimpleSpeak", expr, "double struck eigh comma, double struck z")?;
+    let expr = "<math> <mi>ïƒ€</mi><mo>,</mo><mi>ïƒ‰</mi></math>";
+    test("pt", "SimpleSpeak", expr, "double struck 0 comma, double struck 9")?;
+    return Ok(());
+
+}
+
+#[test]
+fn script() -> Result<()> {
+    let expr = "<math> <mi>ð’œ</mi><mo>,</mo><mi>ð’µ</mi></math>";
+    test("pt", "SimpleSpeak", expr, "script cap eigh comma, script cap z")?;
+    let expr = "<math> <mi>ð’¶</mi><mo>,</mo><mi>ð“</mi></math>";
+    test("pt", "SimpleSpeak", expr, "script eigh comma, script z")?;
+    // MathType private space versions
+    let expr = "<math> <mi>ï„€</mi><mo>,</mo><mi>ï„™</mi></math>";
+    test("pt", "SimpleSpeak", expr, "script cap eigh comma, script cap z")?;
+    let expr = "<math> <mi>ï„š</mi><mo>,</mo><mi>ï„³</mi></math>";
+    test("pt", "SimpleSpeak", expr, "script eigh comma, script z")?;
+    return Ok(());
+
+}
+
+#[test]
+fn bold_script() -> Result<()> {
+    let expr = "<math> <mi>ð“</mi><mo>,</mo><mi>ð“©</mi></math>";
+    test("pt", "SimpleSpeak", expr, "script bold cap eigh, comma, script bold cap z")?;
+    let expr = "<math> <mi>ð“ª</mi><mo>,</mo><mi>ð”ƒ</mi></math>";
+    test("pt", "SimpleSpeak", expr, "script bold eigh comma, script bold z")?;
+    // MathType private space versions
+    let expr = "<math> <mi>ï…€</mi><mo>,</mo><mi>ï…™</mi></math>";
+    test("pt", "SimpleSpeak", expr, "script bold cap eigh, comma, script bold cap z")?;
+    let expr = "<math> <mi>ï…š</mi><mo>,</mo><mi>ï…³</mi></math>";
+    test("pt", "SimpleSpeak", expr, "script bold eigh comma, script bold z")?;
+    return Ok(());
+
+}
+
+#[test]
+fn bold() -> Result<()> {
+    let expr = "<math> <mi>ð€</mi><mo>,</mo><mi>ð™</mi></math>";
+    test("pt", "SimpleSpeak", expr, "bold cap eigh comma, bold cap z")?;
+    let expr = "<math> <mi>ðš</mi><mo>,</mo><mi>ð³</mi></math>";
+    test("pt", "SimpleSpeak", expr, "bold eigh comma, bold z")?;
+    // MathType private space versions
+    let expr = "<math> <mi>ï‰ </mi><mo>,</mo><mi>ï‰¹</mi></math>";
+    test("pt", "SimpleSpeak", expr, "bold cap eigh comma, bold cap z")?;
+    let expr = "<math> <mi>ï‰º</mi><mo>,</mo><mi>ïŠ“</mi></math>";
+    test("pt", "SimpleSpeak", expr, "bold eigh comma, bold z")?;
+    return Ok(());
+
+}
+
+#[test]
+fn italic() -> Result<()> {
+    let expr = "<math> <mi>ð´</mi><mo>,</mo><mi>ð‘</mi></math>";
+    test("pt", "SimpleSpeak", expr, "cap eigh comma, cap z")?;
+    let expr = "<math> <mi>ð‘Ž</mi><mo>,</mo><mi>ð‘§</mi></math>";
+    test("pt", "SimpleSpeak", expr, "eigh comma, z")?;
+    // MathType private space versions
+    let expr = "<math> <mi>ïŠ”</mi><mo>,</mo><mi>ïŠ­</mi></math>";
+    test("pt", "SimpleSpeak", expr, "cap eigh comma, cap z")?;
+    let expr = "<math> <mi>ïŠ®</mi><mo>,</mo><mi>ï‹‡</mi></math>";
+    test("pt", "SimpleSpeak", expr, "eigh comma, z")?;
+    return Ok(());
+
+}
+
+#[test]
+fn sans_serif() -> Result<()> {
+  let expr = "<math> <mi>ð– </mi><mo>,</mo><mi>ð–¹</mi></math>";
+  test("pt", "SimpleSpeak", expr, "cap eigh comma, cap z")?;
+  let expr = "<math> <mi>ð–º</mi><mo>,</mo><mi>ð—“</mi></math>";
+  test("pt", "SimpleSpeak", expr, "eigh comma, z")?;
+  // MathType private space versions
+  let expr = "<math> <mi>ïŒ€</mi><mo>,</mo><mi>ïŒ™</mi></math>";
+  test("pt", "SimpleSpeak", expr, "cap eigh comma, cap z")?;
+  let expr = "<math> <mi>ïŒš</mi><mo>,</mo><mi>ïŒ³</mi></math>";
+  test("pt", "SimpleSpeak", expr, "eigh comma, z")?;
+  return Ok(());
+
+}
+
+#[test]
+fn sans_serif_bold() -> Result<()> {
+    let expr = "<math> <mi>ð—”</mi><mo>,</mo><mi>ð—­</mi></math>";
+    test("pt", "SimpleSpeak", expr, "bold cap eigh comma, bold cap z")?;
+    let expr = "<math> <mi>ð—®</mi><mo>,</mo><mi>ð˜‡</mi></math>";
+    test("pt", "SimpleSpeak", expr, "bold eigh comma, bold z")?;
+    // MathType private space versions
+    let expr = "<math> <mi>ïŒ´</mi><mo>,</mo><mi>ï</mi></math>";
+    test("pt", "SimpleSpeak", expr, "bold cap eigh comma, bold cap z")?;
+    let expr = "<math> <mi>ïŽ</mi><mo>,</mo><mi>ï§</mi></math>";
+    test("pt", "SimpleSpeak", expr, "bold eigh comma, bold z")?;
+    return Ok(());
+
+}
+
+#[test]
+fn sans_serif_italic() -> Result<()> {
+    let expr = "<math> <mi>ð˜ˆ</mi><mo>,</mo><mi>ð˜¡</mi></math>";
+    test("pt", "SimpleSpeak", expr, "cap eigh comma, cap z")?;
+    let expr = "<math> <mi>ð˜¢</mi><mo>,</mo><mi>ð˜»</mi></math>";
+    test("pt", "SimpleSpeak", expr, "eigh comma, z")?;
+    // MathType private space versions
+    let expr = "<math> <mi>ï¨</mi><mo>,</mo><mi>ïŽ</mi></math>";
+    test("pt", "SimpleSpeak", expr, "cap eigh comma, cap z")?;
+    let expr = "<math> <mi>ïŽ‚</mi><mo>,</mo><mi>ïŽ›</mi></math>";
+    test("pt", "SimpleSpeak", expr, "eigh comma, z")?;
+    return Ok(());
+
+}
+
+#[test]
+fn sans_serif_bold_italic() -> Result<()> {
+    let expr = "<math> <mi>ð˜¼</mi><mo>,</mo><mi>ð™•</mi></math>";
+    test("pt", "SimpleSpeak", expr, "bold cap eigh comma, bold cap z")?;
+    let expr = "<math> <mi>ð™–</mi><mo>,</mo><mi>ð™¯</mi></math>";
+    test("pt", "SimpleSpeak", expr, "bold eigh comma, bold z")?;
+    // MathType private space versions
+    let expr = "<math> <mi>ïŽœ</mi><mo>,</mo><mi>ïŽµ</mi></math>";
+    test("pt", "SimpleSpeak", expr, "bold cap eigh comma, bold cap z")?;
+    let expr = "<math> <mi>ïŽ¶</mi><mo>,</mo><mi>ï</mi></math>";
+    test("pt", "SimpleSpeak", expr, "bold eigh comma, bold z")?;
+    return Ok(());
+
+}
+
+#[test]
+fn monospace() -> Result<()> {
+    let expr = "<math> <mi>ð™°</mi><mo>,</mo><mi>ðš‰</mi></math>";
+    test("pt", "SimpleSpeak", expr, "cap eigh comma, cap z")?;
+    let expr = "<math> <mi>ðšŠ</mi><mo>,</mo><mi>ðš£</mi></math>";
+    test("pt", "SimpleSpeak", expr, "eigh comma, z")?;
+    // MathType private space versions
+    let expr = "<math> <mi>ï</mi><mo>,</mo><mi>ï©</mi></math>";
+    test("pt", "SimpleSpeak", expr, "cap eigh comma, cap z")?;
+    let expr = "<math> <mi>ïª</mi><mo>,</mo><mi>ïƒ</mi></math>";
+    test("pt", "SimpleSpeak", expr, "eigh comma, z")?;
+    return Ok(());
+
+}
+
+
+#[test]
+fn bold_greek() -> Result<()> {
+    let expr = "<math> <mi>ðš¨</mi><mo>,</mo><mi>ð›€</mi></math>";
+    test("pt", "SimpleSpeak", expr, "bold cap alpha comma, bold cap omega")?;
+    let expr = "<math> <mi>ð›‚</mi><mo>,</mo><mi>ð›š</mi></math>";
+    test("pt", "SimpleSpeak", expr, "bold alpha comma, bold omega")?;
+    // MathType private space versions
+    let expr = "<math> <mi>ïˆ</mi><mo>,</mo><mi>ï </mi></math>";
+    test("pt", "SimpleSpeak", expr, "bold cap alpha comma, bold cap omega")?;
+    let expr = "<math> <mi>ï¢</mi><mo>,</mo><mi>ïº</mi></math>";
+    test("pt", "SimpleSpeak", expr, "bold alpha comma, bold omega")?;
+    return Ok(());
+
+}
+
+#[test]
+fn bold_greek_others() -> Result<()> {
+    let expr = "<math> <mi>ð››</mi><mo>,</mo><mi>ð›¡</mi></math>";
+    test("pt", "SimpleSpeak", expr, "bold partial derivative, comma, bold pi")?;
+    // MathType private space versions
+    let expr = "<math> <mi>ï»</mi><mo>,</mo><mi>ï‘</mi></math>";
+    test("pt", "SimpleSpeak", expr, "bold partial derivative, comma, bold pi")?;
+    return Ok(());
+
+}
+
+
+#[test]
+fn italic_greek() -> Result<()> {
+    let expr = "<math> <mi>ð›¢</mi><mo>,</mo><mi>ð›º</mi></math>";
+    test("pt", "SimpleSpeak", expr, "cap alpha comma, cap omega")?;
+    let expr = "<math> <mi>ð›¼</mi><mo>,</mo><mi>ðœ”</mi></math>";
+    test("pt", "SimpleSpeak", expr, "alpha comma, omega")?;
+    // MathType private space versions
+    let expr = "<math> <mi>ï‘‚</mi><mo>,</mo><mi>ï‘š</mi></math>";
+    test("pt", "SimpleSpeak", expr, "cap alpha comma, cap omega")?;
+    let expr = "<math> <mi>ï‘œ</mi><mo>,</mo><mi>ï‘´</mi></math>";
+    test("pt", "SimpleSpeak", expr, "alpha comma, omega")?;
+    return Ok(());
+
+}
+
+#[test]
+fn italic_greek_others() -> Result<()> {
+    let expr = "<math> <mi>ðœ•</mi><mo>,</mo><mi>ðœ›</mi></math>";
+    test("pt", "SimpleSpeak", expr, "partial derivative comma, pi")?;
+    // MathType private space versions
+    let expr = "<math> <mi>ï‘µ</mi><mo>,</mo><mi>ï‘»</mi></math>";
+    test("pt", "SimpleSpeak", expr, "partial derivative comma, pi")?;
+    return Ok(());
+
+}
+
+#[test]
+fn bold_italic_greek() -> Result<()> {
+    let expr = "<math> <mi>ðœœ</mi><mo>,</mo><mi>ðœ´</mi></math>";
+    test("pt", "SimpleSpeak", expr, "bold cap alpha comma, bold cap omega")?;
+    let expr = "<math> <mi>ðœ¶</mi><mo>,</mo><mi>ðŽ</mi></math>";
+    test("pt", "SimpleSpeak", expr, "bold alpha comma, bold omega")?;
+    // MathType private space versions
+    let expr = "<math> <mi>ï‘¼</mi><mo>,</mo><mi>ï’”</mi></math>";
+    test("pt", "SimpleSpeak", expr, "bold cap alpha comma, bold cap omega")?;
+    let expr = "<math> <mi>ï’–</mi><mo>,</mo><mi>ï’®</mi></math>";
+    test("pt", "SimpleSpeak", expr, "bold alpha comma, bold omega")?;
+    return Ok(());
+
+}
+
+#[test]
+fn bold_italic_greek_others() -> Result<()> {
+    let expr = "<math> <mi>ð</mi><mo>,</mo><mi>ð•</mi></math>";
+    test("pt", "SimpleSpeak", expr, "bold partial derivative, comma, bold pi")?;
+    // MathType private space versions
+    let expr = "<math> <mi>ï’¯</mi><mo>,</mo><mi>ï’µ</mi></math>";
+    test("pt", "SimpleSpeak", expr, "bold partial derivative, comma, bold pi")?;
+    return Ok(());
+
+}
+
+#[test]
+fn sans_serif_bold_greek() -> Result<()> {
+    let expr = "<math> <mi>ð–</mi><mo>,</mo><mi>ð®</mi></math>";
+    test("pt", "SimpleSpeak", expr, "bold cap alpha comma, bold cap omega")?;
+    let expr = "<math> <mi>ð°</mi><mo>,</mo><mi>ðžˆ</mi></math>";
+    test("pt", "SimpleSpeak", expr, "bold alpha comma, bold omega")?;
+    // MathType private space versions
+    let expr = "<math> <mi>ï’¶</mi><mo>,</mo><mi>ï“Ž</mi></math>";
+    test("pt", "SimpleSpeak", expr, "bold cap alpha comma, bold cap omega")?;
+    let expr = "<math> <mi>ï“</mi><mo>,</mo><mi>ï“¨</mi></math>";
+    test("pt", "SimpleSpeak", expr, "bold alpha comma, bold omega")?;
+    return Ok(());
+
+}
+
+#[test]
+fn sans_serif_bold_greek_others() -> Result<()> {
+    let expr = "<math> <mi>ðž‰</mi><mo>,</mo><mi>ðž</mi></math>";
+    test("pt", "SimpleSpeak", expr, "bold partial derivative, comma, bold pi")?;
+    // MathType private space versions
+    let expr = "<math> <mi>ï“©</mi><mo>,</mo><mi>ï“¯</mi></math>";
+    test("pt", "SimpleSpeak", expr, "bold partial derivative, comma, bold pi")?;
+    return Ok(());
+
+}
+
+#[test]
+fn sans_serif_bold_italic_greek() -> Result<()> {
+    let expr = "<math> <mi>ðž</mi><mo>,</mo><mi>ðž¨</mi></math>";
+    test("pt", "SimpleSpeak", expr, "bold cap alpha comma, bold cap omega")?;
+    let expr = "<math> <mi>ðžª</mi><mo>,</mo><mi>ðŸ‚</mi></math>";
+    test("pt", "SimpleSpeak", expr, "bold alpha comma, bold omega")?;
+    // MathType private space versions
+    let expr = "<math> <mi>ï“°</mi><mo>,</mo><mi>ï”ˆ</mi></math>";
+    test("pt", "SimpleSpeak", expr, "bold cap alpha comma, bold cap omega")?;
+    let expr = "<math> <mi>ï”Š</mi><mo>,</mo><mi>ï”¢</mi></math>";
+    test("pt", "SimpleSpeak", expr, "bold alpha comma, bold omega")?;
+    return Ok(());
+
+}
+
+#[test]
+fn sans_serif_bold_italic_greek_others() -> Result<()> {
+    let expr = "<math> <mi>ðŸƒ</mi><mo>,</mo><mi>ðŸ‰</mi></math>";
+    test("pt", "SimpleSpeak", expr, "bold partial derivative, comma, bold pi")?;
+    // MathType private space versions
+    let expr = "<math> <mi>ï”£</mi><mo>,</mo><mi>ï”©</mi></math>";
+    test("pt", "SimpleSpeak", expr, "bold partial derivative, comma, bold pi")?;
+    return Ok(());
+
+}
+
+#[test]
+fn pua_regular() -> Result<()> {
+  let expr = "<math> <mi>ï†€</mi><mo>,</mo><mi>ï†™</mi></math>";
+  test("pt", "SimpleSpeak", expr, "cap eigh comma, cap z")?;
+  return Ok(());
+
+}
+
+#[test]
+fn turned() -> Result<()> {
+    let expr = "<math> <mi>â„²</mi><mo>,</mo><mi>â…„</mi></math>";
+    test("pt", "SimpleSpeak", expr, "turned cap f comma, turned sans-serif cap y")?;
+    return Ok(());
+
+  }
+
+#[test]
+fn up_tack_330() -> Result<()> {
+    // perpendicular and up tack look the same. I added a special LiteralSpeak rule for up tack not to say "perpendicular"
+    let perp = "<math><mi>a</mi><mo>âŸ‚</mo><mi>b</mi></math>"; // 0x27c2
+    test("pt", "SimpleSpeak", perp, "eigh is perpendicular to b")?;
+    test("pt", "LiteralSpeak", perp, "eigh is perpendicular to b")?;
+    let up_tack = "<math><mi>a</mi><mo>âŠ¥</mo><mi>b</mi></math>"; // 0x22a5
+    test("pt", "ClearSpeak", up_tack, "eigh is perpendicular to b")?;
+    test("pt", "LiteralSpeak", up_tack, "eigh up tack b")?;
+    return Ok(());
+  }
+
+#[test]
+fn unicode_typo_regressions() -> Result<()> {
+  test("pt", "SimpleSpeak", "<math><mi>â±</mi></math>", "to the i-th power")?;
+  test("pt", "SimpleSpeak", "<math><mi>â˜Œ</mi></math>", "conjunction")?;
+  Ok(())
+}
+
+#[test]
+fn enclosed_numbers() -> Result<()> {
+  let expr = "<math> <mi>â‘ </mi><mo>,</mo><mi>â‘¨</mi></math>";
+  test("pt", "SimpleSpeak", expr, "circled 1 comma, circled 9")?;
+  let expr = "<math> <mi>â¶</mi><mo>,</mo><mi>ãŠ¿</mi></math>";
+  test("pt", "SimpleSpeak", expr, "black circled one comma, circled number fifty")?;
+  let expr = "<math> <mi>â‘´</mi><mo>,</mo><mi>â‘¼</mi></math>";
+  test("pt", "SimpleSpeak", expr, "parenthesized 1 comma, parenthesized 9")?;
+  let expr = "<math> <mi>â’ˆ</mi><mo>,</mo><mi>â’</mi></math>";
+  test("pt", "SimpleSpeak", expr, "1 with period comma, 9 with period")?;
+  let expr = "<math> <mi>â“µ</mi><mo>,</mo><mi>â“½</mi></math>";
+  test("pt", "SimpleSpeak", expr, "double circled 1 comma, double circled 9")?;
+  return Ok(());
+
+}

--- a/tests/Languages/pt/chemistry.rs
+++ b/tests/Languages/pt/chemistry.rs
@@ -1,0 +1,769 @@
+﻿/// Tests for rules shared between various speech styles:
+/// *  modified var
+use crate::common::*;
+use anyhow::Result;
+
+#[test]
+fn salt() -> Result<()> {
+  let expr = "<math><mi>Na</mi><mi>Cl</mi></math>";
+  test_prefs("pt", "SimpleSpeak", vec![("Verbosity", "Terse")], expr, "cap n eigh, cap c l")?;
+  return Ok(());
+
+}
+
+#[test]
+fn water() -> Result<()> {
+  let expr = "<math><msub><mi>H</mi><mn>2</mn></msub><mi>O</mi></math>";
+  test_prefs("pt", "ClearSpeak", vec![("Verbosity", "Terse")], expr, "cap h, 2 cap o")?;
+  test_prefs("pt", "ClearSpeak", vec![("Verbosity", "Medium")], expr, "cap h, sub 2 cap o")?;
+  test_prefs("pt", "ClearSpeak", vec![("Verbosity", "Verbose")], expr, "cap h, subscript 2, cap o")?;
+  return Ok(());
+
+}
+
+#[test]
+fn carbon() -> Result<()> {
+  let expr = "<math><mi>C</mi></math>";     // not enough to trigger recognition
+  test_prefs("pt", "SimpleSpeak", vec![("Verbosity", "Terse")], expr, "cap c")?;
+  return Ok(());
+
+}
+
+#[test]
+fn sulfate() -> Result<()> {
+  let expr = "<math><mrow><msup>
+          <mrow><mo>[</mo><mi>S</mi><msub><mi>O</mi><mn>4</mn></msub><mo>]</mo></mrow>
+          <mrow><mn>2</mn><mo>&#x2212;</mo></mrow>
+      </msup></mrow></math>";
+  test_prefs("pt", "ClearSpeak", vec![("Verbosity", "Medium")], expr, "open bracket, cap s, cap o, sub 4; close bracket super 2 minus")?;
+  return Ok(());
+
+}
+
+#[test]
+fn aluminum_sulfate() -> Result<()> {
+  let expr = "<math><mrow><msub><mi>Al</mi><mn>2</mn></msub>
+          <msub><mrow><mo>(</mo><mi>S</mi><msub><mi>O</mi><mn>4</mn></msub><mo>)</mo></mrow><mn>3</mn></msub></mrow></math>";
+  test_prefs("pt", "ClearSpeak", vec![("Verbosity", "Terse")], expr, "cap eigh l, 2, open cap s, cap o, 4, close 3")?;
+  test_prefs("pt", "ClearSpeak", vec![("Verbosity", "Medium")], expr, "cap eigh l, sub 2; open paren, cap s, cap o, sub 4; close paren sub 3")?;
+  test_prefs("pt", "ClearSpeak", vec![("Verbosity", "Verbose")], expr, "cap eigh l, subscript 2; open paren, cap s, cap o, subscript 4; close paren subscript 3")?;
+  return Ok(());
+
+}
+
+#[test]
+fn ethanol_bonds() -> Result<()> {
+  let expr = "<math>
+          <mrow>
+              <mi>C</mi>
+              <msub>  <mi>H</mi> <mn>3</mn> </msub>
+              <mo>&#x2212;</mo>
+              <mi>C</mi>
+              <msub>  <mi>H</mi> <mn>2</mn> </msub>
+              <mo>&#x2212;</mo>
+              <mi>O</mi>
+              <mi>H</mi>
+          </mrow>
+      </math>";
+  test_prefs("pt", "ClearSpeak", vec![("Verbosity", "Terse")], expr, "cap c, cap h, 3 single bond cap c, cap h, 2 single bond cap o, cap h")?;
+
+  return Ok(());
+
+}
+
+#[test]
+fn dichlorine_hexoxide() -> Result<()> {
+  let expr = "<math><mrow>
+      <msup>
+        <mrow><mo>[</mo><mi>Cl</mi><msub><mi>O</mi><mn>2</mn></msub><mo>]</mo></mrow>
+        <mo>+</mo>
+      </msup>
+      <msup>
+        <mrow><mo>[</mo><mi>Cl</mi><msub><mi>O</mi><mn>4</mn></msub><mo>]</mo></mrow>
+        <mo>-</mo>
+      </msup>
+    </mrow></math>";
+  test_prefs("pt", "SimpleSpeak", vec![("Verbosity", "Terse")], 
+    expr, "open bracket, cap c l, cap o, 2, close bracket plus; \
+                          open bracket, cap c l, cap o, 4, close bracket minus")?;
+  test_prefs("pt", "SimpleSpeak", vec![("Verbosity", "Medium")], 
+    expr, "open bracket, cap c l, cap o, sub 2; close bracket super plus; \
+                          open bracket, cap c l, cap o, sub 4; close bracket super minus")?;
+  test_prefs("pt", "SimpleSpeak", vec![("Verbosity", "Verbose")], 
+    expr, "open bracket, cap c l, cap o, subscript 2; close bracket superscript plus; \
+                          open bracket, cap c l, cap o, subscript 4; close bracket superscript minus")?;
+                          return Ok(());
+
+}
+
+
+#[test]
+fn ethylene_with_bond() -> Result<()> {
+  let expr = "<math><mrow>
+          <msub><mi>H</mi><mn>2</mn></msub><mi>C</mi>
+          <mo>=</mo>
+          <mi>C</mi><msub><mi>H</mi><mn>2</mn></msub>
+      </mrow></math>";
+  test_prefs("pt", "SimpleSpeak", vec![("Verbosity", "Terse")], expr, "cap h, 2 cap c, double bond cap c, cap h, 2")?;
+  return Ok(());
+
+}
+
+#[test]
+fn ferric_chloride_aq() -> Result<()> {
+  let expr = "<math><mrow>
+        <mi>Fe</mi>
+        <msub><mi>Cl</mi><mn>3</mn></msub>
+        <mrow><mo>(</mo><mrow><mi>aq</mi></mrow><mo>)</mo></mrow>
+    </mrow></math>";
+  test_prefs("pt", "SimpleSpeak", vec![("Verbosity", "Terse")], expr, "cap f e, cap c l, 3 aqueous")?;
+  return Ok(());
+
+  }
+
+#[test]
+fn ethylene_with_colon_bond() -> Result<()> {
+  let expr = "<math><mrow>
+          <msub><mi>H</mi><mn>2</mn></msub><mi>C</mi>
+          <mo>::</mo>
+          <mi>C</mi><msub><mi>H</mi><mn>2</mn></msub>
+      </mrow></math>";
+  test_prefs("pt", "SimpleSpeak", vec![("Verbosity", "Terse")], expr, "cap h, 2 cap c, double bond cap c, cap h, 2")?;
+  return Ok(());
+
+}
+
+#[test]
+fn beta_decay() -> Result<()> {
+  let expr = "<math>
+      <mmultiscripts>
+        <mtext>C</mtext>
+        <mprescripts />
+        <mn>6</mn>
+        <mn>14</mn>
+      </mmultiscripts>
+      <mo>&#x2192;</mo>
+      <mmultiscripts>
+        <mtext>N</mtext>
+        <mprescripts />
+        <mn>7</mn>
+        <mn>14</mn>
+      </mmultiscripts>
+      <mo>+</mo>
+      <mmultiscripts>
+        <mtext>e</mtext>
+        <mprescripts />
+        <mrow>
+          <mo>&#x2212;</mo>
+          <mn>1</mn>
+        </mrow>
+        <mn>0</mn>
+      </mmultiscripts>
+    </math>";
+    test_prefs("pt", "ClearSpeak", vec![("Verbosity", "Terse")], expr,
+      "14, 6, cap c; forms, 14, 7, cap n; plus 0, negative 1, e")?;
+    test_prefs("pt", "ClearSpeak", vec![("Verbosity", "Medium")], expr,
+      "super 14, sub 6, cap c; reacts to form; super 14, sub 7, cap n; plus super 0, sub negative 1, e")?;
+    test_prefs("pt", "ClearSpeak", vec![("Verbosity", "Verbose")], expr,
+      "superscript 14, subscript 6, cap c; reacts to form; superscript 14, subscript 7, cap n; plus, superscript 0, subscript negative 1, e")?;
+      return Ok(());
+
+}
+
+#[test]
+fn mhchem_beta_decay() -> Result<()> {
+  let expr = "<math>
+      <mrow>
+        <msubsup>
+          <mrow>
+            <mrow>
+              <mpadded width='0'>
+                <mphantom>
+                  <mi>A</mi>
+                </mphantom>
+              </mpadded>
+            </mrow>
+          </mrow>
+          <mrow>
+            <mrow>
+              <mpadded height='0' depth='0'>
+                <mphantom>
+                  <mn>6</mn>
+                </mphantom>
+              </mpadded>
+            </mrow>
+          </mrow>
+          <mrow>
+            <mrow>
+              <mpadded height='0' depth='0'>
+                <mphantom>
+                  <mn>14</mn>
+                </mphantom>
+              </mpadded>
+            </mrow>
+          </mrow>
+        </msubsup>
+        <mspace width='-0.083em'></mspace>
+        <msubsup>
+          <mrow>
+            <mrow>
+              <mpadded width='0'>
+                <mphantom>
+                  <mi>A</mi>
+                </mphantom>
+              </mpadded>
+            </mrow>
+          </mrow>
+          <mrow>
+            <mrow>
+              <mpadded width='0'>
+                <mphantom>
+                  <mn>2</mn>
+                </mphantom>
+              </mpadded>
+            </mrow>
+            <mrow>
+              <mpadded width='0' lspace='-1width'>
+                <mrow>
+                  <mpadded height='0'>
+                    <mn>6</mn>
+                  </mpadded>
+                </mrow>
+              </mpadded>
+            </mrow>
+          </mrow>
+          <mrow>
+            <mrow>
+              <mpadded height='0'>
+                <mrow>
+                  <mpadded width='0'>
+                    <mphantom>
+                      <mn>2</mn>
+                    </mphantom>
+                  </mpadded>
+                </mrow>
+              </mpadded>
+            </mrow>
+            <mrow>
+              <mpadded width='0' lspace='-1width'>
+                <mn>14</mn>
+              </mpadded>
+            </mrow>
+          </mrow>
+        </msubsup>
+        <mrow>
+          <mi mathvariant='normal'>C</mi>
+        </mrow>
+        <mrow></mrow>
+        <mrow>
+          <mo stretchy='false'>&#x27F6;</mo>
+        </mrow>
+        <mrow></mrow>
+        <msubsup>
+          <mrow>
+            <mrow>
+              <mpadded width='0'>
+                <mphantom>
+                  <mi>A</mi>
+                </mphantom>
+              </mpadded>
+            </mrow>
+          </mrow>
+          <mrow>
+            <mrow>
+              <mpadded height='0' depth='0'>
+                <mphantom>
+                  <mn>7</mn>
+                </mphantom>
+              </mpadded>
+            </mrow>
+          </mrow>
+          <mrow>
+            <mrow>
+              <mpadded height='0' depth='0'>
+                <mphantom>
+                  <mn>14</mn>
+                </mphantom>
+              </mpadded>
+            </mrow>
+          </mrow>
+        </msubsup>
+        <mspace width='-0.083em'></mspace>
+        <msubsup>
+          <mrow>
+            <mrow>
+              <mpadded width='0'>
+                <mphantom>
+                  <mi>A</mi>
+                </mphantom>
+              </mpadded>
+            </mrow>
+          </mrow>
+          <mrow>
+            <mrow>
+              <mpadded width='0'>
+                <mphantom>
+                  <mn>2</mn>
+                </mphantom>
+              </mpadded>
+            </mrow>
+            <mrow>
+              <mpadded width='0' lspace='-1width'>
+                <mrow>
+                  <mpadded height='0'>
+                    <mn>7</mn>
+                  </mpadded>
+                </mrow>
+              </mpadded>
+            </mrow>
+          </mrow>
+          <mrow>
+            <mrow>
+              <mpadded height='0'>
+                <mrow>
+                  <mpadded width='0'>
+                    <mphantom>
+                      <mn>2</mn>
+                    </mphantom>
+                  </mpadded>
+                </mrow>
+              </mpadded>
+            </mrow>
+            <mrow>
+              <mpadded width='0' lspace='-1width'>
+                <mn>14</mn>
+              </mpadded>
+            </mrow>
+          </mrow>
+        </msubsup>
+        <mrow>
+          <mi mathvariant='normal'>N</mi>
+        </mrow>
+        <mrow></mrow>
+        <mo>+</mo>
+        <mrow></mrow>
+        <msubsup>
+          <mrow>
+            <mrow>
+              <mpadded width='0'>
+                <mphantom>
+                  <mi>A</mi>
+                </mphantom>
+              </mpadded>
+            </mrow>
+          </mrow>
+          <mrow>
+            <mrow>
+              <mpadded height='0' depth='0'>
+                <mphantom>
+                  <mo>&#x2212;</mo>
+                  <mn>1</mn>
+                </mphantom>
+              </mpadded>
+            </mrow>
+          </mrow>
+          <mrow>
+            <mrow>
+              <mpadded height='0' depth='0'>
+                <mphantom>
+                  <mn>0</mn>
+                </mphantom>
+              </mpadded>
+            </mrow>
+          </mrow>
+        </msubsup>
+        <mspace width='-0.083em'></mspace>
+        <msubsup>
+          <mrow>
+            <mrow>
+              <mpadded width='0'>
+                <mphantom>
+                  <mi>A</mi>
+                </mphantom>
+              </mpadded>
+            </mrow>
+          </mrow>
+          <mrow>
+            <mrow>
+              <mpadded width='0'>
+                <mphantom>
+                  <mn>2</mn>
+                </mphantom>
+              </mpadded>
+            </mrow>
+            <mrow>
+              <mpadded width='0' lspace='-1width'>
+                <mrow>
+                  <mpadded height='0'>
+                    <mo>&#x2212;</mo>
+                    <mn>1</mn>
+                  </mpadded>
+                </mrow>
+              </mpadded>
+            </mrow>
+          </mrow>
+          <mrow>
+            <mrow>
+              <mpadded height='0'>
+                <mrow>
+                  <mpadded width='0'>
+                    <mphantom>
+                      <mn>2</mn>
+                    </mphantom>
+                  </mpadded>
+                </mrow>
+              </mpadded>
+            </mrow>
+            <mrow>
+              <mpadded width='0' lspace='-1width'>
+                <mn>0</mn>
+              </mpadded>
+            </mrow>
+          </mrow>
+        </msubsup>
+        <mrow>
+          <mi mathvariant='normal'>e</mi>
+        </mrow>
+      </mrow>
+    </math>";
+    test_prefs("pt", "ClearSpeak", vec![("Verbosity", "Terse")], expr,
+      "14, 6, cap c; forms, 14, 7, cap n; plus 0, negative 1, e")?;
+    test_prefs("pt", "ClearSpeak", vec![("Verbosity", "Medium")], expr,
+      "super 14, sub 6, cap c; reacts to form; super 14, sub 7, cap n; plus super 0, sub negative 1, e")?;
+    test_prefs("pt", "ClearSpeak", vec![("Verbosity", "Verbose")], expr,
+      "superscript 14, subscript 6, cap c; reacts to form; superscript 14, subscript 7, cap n; plus, superscript 0, subscript negative 1, e")?;
+      return Ok(());
+
+}
+
+#[test]
+fn hcl_na_yields() -> Result<()> {
+    let expr = "<math> <mrow>
+      <mn>2</mn><mi>H</mi><mi>Cl</mi><mo>+</mo><mn>2</mn><mtext>Na</mtext>
+      <mo>&#x2192;</mo>
+      <mn>2</mn><mtext>Na</mtext><mi>Cl</mi><mo>+</mo>
+      <msub> <mi>H</mi> <mn>2</mn> </msub>
+      </mrow>
+    </math>";
+    test_prefs("pt", "SimpleSpeak", vec![("Verbosity", "Verbose")], expr,
+        "2, cap h, cap c l; plus 2 cap n eigh; reacts to form; 2, cap n eigh, cap c l; plus cap h, subscript 2")?;
+        return Ok(());
+
+}
+
+#[test]
+fn mhchem_so4_2plus() -> Result<()> {
+  let expr = "<math>
+    <mrow>
+      <mrow>
+        <mi>SO</mi>
+      </mrow>
+      <msub>
+        <mrow>
+          <mrow>
+            <mpadded width='0'>
+              <mphantom>
+                <mi>A</mi>
+              </mphantom>
+            </mpadded>
+          </mrow>
+        </mrow>
+        <mrow>
+          <mrow>
+            <mpadded height='0'>
+              <mn>4</mn>
+            </mpadded>
+          </mrow>
+        </mrow>
+      </msub>
+      <msup>
+        <mrow>
+          <mrow>
+            <mpadded width='0'>
+              <mphantom>
+                <mi>A</mi>
+              </mphantom>
+            </mpadded>
+          </mrow>
+        </mrow>
+        <mrow>
+          <mn>2</mn>
+          <mo>+</mo>
+        </mrow>
+      </msup>
+    </mrow>
+  </math>";
+  test_prefs("pt", "SimpleSpeak", vec![("Verbosity", "Terse")], expr, "cap s; cap o, 4, 2 plus")?;
+  test_prefs("pt", "SimpleSpeak", vec![("Verbosity", "Medium")], expr, "cap s; cap o, sub 4, super 2 plus")?;
+  test_prefs("pt", "SimpleSpeak", vec![("Verbosity", "Verbose")], expr, "cap s; cap o, subscript 4, superscript 2 plus")?;
+  return Ok(());
+
+}
+
+
+#[test]
+fn mhchem_hcl_aq_etc() -> Result<()> {
+  let expr = "<math>
+    <mrow>
+      <mn>2</mn>
+      <mstyle scriptlevel='0'>
+        <mspace width='0.167em'></mspace>
+      </mstyle>
+      <mrow>
+        <mi>HCl</mi>
+      </mrow>
+      <mspace width='0.111em'></mspace>
+      <mo stretchy='false'>(</mo>
+      <mrow>
+        <mi>aq</mi>
+      </mrow>
+      <mo stretchy='false'>)</mo>
+      <mrow></mrow>
+      <mo>+</mo>
+      <mrow></mrow>
+      <mn>2</mn>
+      <mstyle scriptlevel='0'>
+        <mspace width='0.167em'></mspace>
+      </mstyle>
+      <mrow>
+        <mi>Na</mi>
+      </mrow>
+      <mspace width='0.111em'></mspace>
+      <mo stretchy='false'>(</mo>
+      <mrow>
+        <mi mathvariant='normal'>s</mi>
+      </mrow>
+      <mo stretchy='false'>)</mo>
+      <mrow></mrow>
+      <mrow>
+        <mo stretchy='false'>&#x27F6;</mo>
+      </mrow>
+      <mrow></mrow>
+      <mn>2</mn>
+      <mstyle scriptlevel='0'>
+        <mspace width='0.167em'></mspace>
+      </mstyle>
+      <mrow>
+        <mi>NaCl</mi>
+      </mrow>
+      <mspace width='0.111em'></mspace>
+      <mo stretchy='false'>(</mo>
+      <mrow>
+        <mi>aq</mi>
+      </mrow>
+      <mo stretchy='false'>)</mo>
+      <mrow></mrow>
+      <mo>+</mo>
+      <mrow></mrow>
+      <mrow>
+        <mi mathvariant='normal'>H</mi>
+      </mrow>
+      <msub>
+        <mrow>
+          <mrow>
+            <mpadded width='0'>
+              <mphantom>
+                <mi>A</mi>
+              </mphantom>
+            </mpadded>
+          </mrow>
+        </mrow>
+        <mrow>
+          <mrow>
+            <mpadded height='0'>
+              <mn>2</mn>
+            </mpadded>
+          </mrow>
+        </mrow>
+      </msub>
+      <mspace width='0.111em'></mspace>
+      <mo stretchy='false'>(</mo>
+      <mrow>
+        <mi mathvariant='normal'>g</mi>
+      </mrow>
+      <mo stretchy='false'>)</mo>
+    </mrow>
+  </math>";
+  test_prefs("pt", "SimpleSpeak", vec![("Verbosity", "Terse")],
+      expr, "2, cap h, cap c l, aqueous; plus, 2, cap n eigh, solid; forms; 2, cap n eigh, cap c l, aqueous; plus, cap h, 2, gas")?;
+
+      return Ok(());
+
+}
+
+
+#[test]
+fn mhchem_barbed_equilibrium() -> Result<()> {
+  let expr = "<math>
+    <mrow data-mjx-texclass='ORD' data-chem-equation='14'>
+      <mrow data-changed='added' data-chem-equation='3'>
+        <mmultiscripts data-chem-formula='1'>
+          <mi data-mjx-texclass='ORD' mathvariant='normal' data-chem-element='1'>H</mi>
+          <mn data-mjx-texclass='ORD'>2</mn>
+          <none></none>
+        </mmultiscripts>
+        <mo data-changed='added' data-function-guess='true'>&#x2063;</mo>
+        <mrow data-changed='added' data-chem-equation='1'>
+          <mo stretchy='false'>(</mo>
+          <mi data-mjx-texclass='ORD' mathvariant='normal'>g</mi>
+          <mo stretchy='false'>)</mo>
+        </mrow>
+      </mrow>
+      <mo data-chem-equation-op='1'>+</mo>
+      <mrow data-changed='added' data-chem-equation='10'>
+        <mrow data-changed='added' data-chem-equation='3'>
+          <mmultiscripts data-chem-formula='1'>
+            <mi data-mjx-texclass='ORD' mathvariant='normal' data-chem-element='1'>I</mi>
+            <mn data-mjx-texclass='ORD'>2</mn>
+            <none></none>
+          </mmultiscripts>
+          <mo data-changed='added' data-function-guess='true'>&#x2063;</mo>
+          <mrow data-changed='added' data-chem-equation='1'>
+            <mo stretchy='false'>(</mo>
+            <mi data-mjx-texclass='ORD' mathvariant='normal'>g</mi>
+            <mo stretchy='false'>)</mo>
+          </mrow>
+        </mrow>
+        <mo data-changed='added'>&#x2062;</mo>
+        <mover data-mjx-texclass='REL'>
+          <mrow data-mjx-texclass='ORD' depth='0' height='0' data-changed='added'>
+            <mo data-mjx-texclass='ORD' stretchy='false'>â†½</mo>
+            <mo data-mjx-texclass='ORD'>-</mo>
+          </mrow>
+          <mrow data-mjx-texclass='ORD' displaystyle='false' scriptlevel='0' data-changed='added'>
+            <mo data-mjx-texclass='ORD'>-</mo>
+            <mo data-mjx-texclass='ORD' stretchy='false'>â‡€</mo>
+          </mrow>
+        </mover>
+        <mo data-changed='added'>&#x2062;</mo>
+        <mn>2</mn>
+        <mo data-changed='added'>&#x2062;</mo>
+        <mrow data-changed='added' data-chem-equation='5'>
+          <mi mathvariant='normal' data-chem-element='1'>H</mi>
+          <mo data-changed='added'>&#x2063;</mo>
+          <mi mathvariant='normal' data-chem-element='1'>I</mi>
+          <mo data-changed='added' data-function-guess='true'>&#x2063;</mo>
+          <mrow data-changed='added' data-chem-equation='1'>
+            <mo stretchy='false'>(</mo>
+            <mi data-mjx-texclass='ORD' mathvariant='normal'>g</mi>
+            <mo stretchy='false'>)</mo>
+          </mrow>
+        </mrow>
+      </mrow>
+    </mrow>
+  </math>";
+  test_prefs("pt", "SimpleSpeak", vec![("Verbosity", "Terse")],
+      expr, "cap h, 2, gas; plus; cap i, 2, gas; is in equilibrium with, 2, cap h, cap i, gas")?;
+      return Ok(());
+
+}
+
+
+
+#[test]
+fn mhchem_roman_in_superscript() -> Result<()> {
+      let expr = "<math>
+      <mrow>
+        <mmultiscripts>
+          <mi>Fe</mi>
+          <none></none>
+          <mi>II</mi>
+        </mmultiscripts>
+        <mo>&#x2063;</mo>
+        <mmultiscripts>
+          <mi>Fe</mi>
+          <none></none>
+          <mi>III</mi>
+        </mmultiscripts>
+        <mo>&#x2063;</mo>
+        <mmultiscripts>
+          <mi mathvariant='normal' >O</mi>
+          <mn>4</mn>
+          <none></none>
+        </mmultiscripts>
+      </mrow>
+    </math>";
+  test_prefs("pt", "SimpleSpeak", vec![("Verbosity", "Terse")],
+      expr, "cap f e, 2; cap f e, 3; cap o, 4")?;
+      return Ok(());
+
+}
+
+
+#[test]
+fn dropped_msubsup_bug_358() -> Result<()> {
+      let expr = r#"<math>
+          <mrow class="MJX-TeXAtom-ORD">
+              <mrow class="MJX-TeXAtom-ORD">
+                <mn>2</mn>
+                <mspace width="thinmathspace"></mspace>
+                <msubsup>
+                  <mtext>SO</mtext>
+                  <mrow class="MJX-TeXAtom-ORD">
+                    <mn>2</mn>
+                  </mrow>
+                  <mrow class="MJX-TeXAtom-ORD">
+                    <mspace width="0pt" height="0pt" depth=".2em"></mspace>
+                  </mrow>
+                </msubsup>
+                <mo>+</mo>
+                <msubsup>
+                  <mtext>O</mtext>
+                  <mrow class="MJX-TeXAtom-ORD">
+                    <mn>2</mn>
+                  </mrow>
+                  <mrow class="MJX-TeXAtom-ORD">
+                    <mspace width="0pt" height="0pt" depth=".2em"></mspace>
+                  </mrow>
+                </msubsup>
+                <mrow class="MJX-TeXAtom-REL">
+                  <mover>
+                    <mrow class="MJX-TeXAtom-OP MJX-fixedlimits">
+                      <mrow class="MJX-TeXAtom-ORD">
+                        <mpadded height="0" depth="0">
+                          <mrow class="MJX-TeXAtom-ORD">
+                            <mo stretchy="false">â†½<!-- â†½ --></mo>
+                          </mrow>
+                          <mspace width="negativethinmathspace"></mspace>
+                          <mspace width="negativethinmathspace"></mspace>
+                          <mrow class="MJX-TeXAtom-ORD">
+                            <mo>âˆ’<!-- âˆ’ --></mo>
+                          </mrow>
+                        </mpadded>
+                      </mrow>
+                    </mrow>
+                    <mrow class="MJX-TeXAtom-ORD">
+                        <mrow class="MJX-TeXAtom-ORD">
+                          <mrow class="MJX-TeXAtom-ORD">
+                            <mo>âˆ’<!-- âˆ’ --></mo>
+                          </mrow>
+                          <mspace width="negativethinmathspace"></mspace>
+                          <mspace width="negativethinmathspace"></mspace>
+                          <mrow class="MJX-TeXAtom-ORD">
+                            <mo stretchy="false">â‡€<!-- â‡€ --></mo>
+                          </mrow>
+                        </mrow>
+                    </mrow>
+                  </mover>
+                </mrow>
+                <mn>2</mn>
+                <mspace width="thinmathspace"></mspace>
+                <msubsup>
+                  <mtext>SO</mtext>
+                  <mrow class="MJX-TeXAtom-ORD">
+                    <mn>3</mn>
+                  </mrow>
+                  <mrow class="MJX-TeXAtom-ORD">
+                    <mspace width="0pt" height="0pt" depth=".2em"></mspace>
+                  </mrow>
+                </msubsup>
+              </mrow>
+          </mrow>
+      </math>"#;
+  test_prefs("pt", "SimpleSpeak", vec![("Verbosity", "Terse")],
+      expr, "2, cap s, cap o, 2; plus; cap o, 2 is in equilibrium with, 2, cap s, cap o, 3")?;
+      return Ok(());
+
+}
+
+

--- a/tests/Languages/pt/definitions.rs
+++ b/tests/Languages/pt/definitions.rs
@@ -1,0 +1,1026 @@
+﻿/// Tests for rules in definitions:
+/// *  modified var
+use crate::common::*;
+use anyhow::Result;
+
+#[test]
+fn tuple_basic() -> Result<()> {
+    // function 
+    let expr = r#"
+      <math>
+        <mrow intent="tuple($x,$y)">
+          <mi arg="x">x</mi>
+          <mi arg="y">y</mi>
+        </mrow>
+      </math>
+    "#;
+
+    test("pt", "ClearSpeak", expr, "the tuple of x comma, y")?;
+    test("pt", "SimpleSpeak", expr, "the tuple of x comma, y")?;
+
+    return Ok(());
+}
+
+#[test]
+fn my_set_basic() -> Result<()> {
+    let expr = r#"
+      <math>
+        <mrow intent="set($x,$y)">
+          <mi arg="x">x</mi>
+          <mi arg="y">y</mi>
+        </mrow>
+      </math>
+    "#;
+
+    test("pt", "ClearSpeak", expr, "the set of x comma, y")?;
+
+    Ok(())
+}
+
+#[test]
+fn fixed_test() -> Result<()> {
+    let expr = r#"
+      <math>
+        <mi intent="set-of-reals">R
+        </mi>
+      </math>
+    "#;
+
+    test("pt", "ClearSpeak", expr, "set of all real numbers")?;
+    Ok(())
+}
+
+#[test]
+fn i_test() -> Result<()> {
+    let expr = r#"
+      <math>
+        <mi intent="imaginary-i">i
+        </mi>
+      </math>
+    "#;
+
+    test("pt", "ClearSpeak", expr, "i")?;
+    Ok(())
+}
+
+
+#[test]
+fn floor_basic() -> Result<()> {
+    let expr = r#"
+      <math>
+        <mrow intent="floor($x)">
+          <mi arg="x">x</mi>
+        </mrow>
+      </math>
+    "#;
+
+    test("pt", "ClearSpeak", expr, "floor of x")?;
+
+    Ok(())
+}
+
+#[test]
+fn set_difference_basic() -> Result<()> {
+    let expr = r#"
+      <math>
+        <mrow intent="set-difference($A,$B)">
+          <mi arg="A">A</mi>
+          <mo>&#x2216;</mo>
+          <mi arg="B">B</mi>
+        </mrow>
+      </math>
+    "#;
+
+    test( "pt", "ClearSpeak", expr, "set difference of cap eigh and cap b")?;
+
+    Ok(())
+}
+
+#[test]
+fn postfix_test() -> Result<()> {
+    let tests = [
+        (
+            "transpose",
+            r#"
+            <msup intent="transpose($x)">
+                <mi arg="x">x</mi>
+                <mo>T</mo>
+            </msup>
+            "#,
+            "x transpose",
+        ),
+        (
+            "highlight",
+            r#"
+            <menclose intent="highlight($x)">
+                <mi arg="x">x</mi>
+            </menclose>
+            "#,
+            "x highlighted",
+        ),
+    ];
+
+    // Loop through all test cases, name _, body, and expected result
+    for (_, body, expected) in tests {
+        let expr = format!(
+            r#"
+            <math>
+                {}
+            </math>
+            "#,
+            body
+        );
+
+        test("pt", "ClearSpeak", &expr, expected)?;
+    }
+
+    Ok(())
+}
+
+#[test]
+fn prefix_test() -> Result<()> {
+    // Prefix test limit, unit-vector, line-segment
+    // Directed-line-segment, line, ray, arc
+    let tests = [
+        (
+            "limit",
+            r#"
+            <mrow intent="limit($x)">
+                <mi arg="x">x</mi>
+            </mrow>
+            "#,
+            "limit as x",
+        ),
+        (
+            "unit-vector",
+            r#"
+            <mover intent="unit-vector($x)">
+                <mi arg="x">x</mi>
+                <mo>^</mo>
+            </mover>
+            "#,
+            "unit vector x",
+        ),
+        (
+            "line-segment",
+            r#"
+            <mover intent="line-segment($x)">
+                <mi arg="x">x</mi>
+                <mo>Â¯</mo>
+            </mover>
+            "#,
+            "line segment x",
+        ),
+    ];
+
+    for (_, body, expected) in tests {
+        let expr = format!(
+            r#"
+            <math>
+                {}
+            </math>
+            "#,
+            body
+        );
+
+        test("pt", "ClearSpeak", &expr, expected)?;
+    }
+
+    Ok(())
+}
+
+
+#[test]
+fn functions_and_inverses_tests() -> Result<()> {
+    let tests = vec![
+        //("closed-interval", "closed interval between x and y"),
+        //("closed-open-interval", "interval between x included and y"),
+        //("open-closed-interval", "interval between x and y included"),
+        //("open-interval", "open interval between x and y"),
+
+        ("inverse", "inverse of x"),
+        ("domain", "domain of x"),
+        ("codomain", "codomain of x"),
+        ("image", "image of x"),
+
+        //("fraction", "fraction x over y end fraction"),
+        ("mixed-fraction", "x and y"),
+        ("quotient", "integer part of x divided by y"),
+        ("evaluated-at", "x evaluated at y"),
+        ("remainder", "the remainder x divided by y"),
+
+        ("max", "max x"),
+        ("min", "min x"),
+
+        ("power", "x to the power y"),
+
+        ("root", "root x"),
+
+        ("greatest-common-divisor", "gcd: the gcd: the greatest common divisor x"),
+        ("least-common-multiple", "lcm: the lcm: the least common multiple x"),
+
+        ("absolute-value", "absolute value: the absolute value: the absolute value x end absolute value"),
+
+        ("complex-conjugate", "complex conjugate x"),
+        ("complex-arg", "arg x"),
+        ("real-part", "the real part x"),
+        ("imaginary-part", "imaginary part: the imaginary part: the imaginary part x"),
+
+        ("polar-coordinate", "polar coordinate x comma y"),
+        ("spherical-coordinate", "spherical coordinate x comma y comma z"),
+        ("cartesian-coordinate", "cartesian coordinate x comma y"),
+        ("coordinate", "coordinate x comma y"),
+
+        ("floor", "floor x"),
+        ("ceiling", "ceiling x"),
+        ("round", "rounded-value x"),
+        ("fractional-part", "fractional part x"),
+
+        
+    ];
+
+    for (intent, expected) in tests {
+        let expr = match intent {
+            
+            "max"
+            | "min"
+            | "greatest-common-divisor"
+            | "least-common-multiple"
+            | "spherical-coordinate"
+            | "cartesian-coordinate"
+            | "coordinate" => {
+                format!(
+                    "<math>
+                        <mrow intent='{}($a,$b,$c)'>
+                            <mi arg='a'>x</mi>
+                            <mi arg='b'>y</mi>
+                            <mi arg='c'>z</mi>
+                        </mrow>
+                    </math>",
+                    intent
+                )
+            }
+
+            "power"
+            | "mixed-fraction"
+            | "quotient"
+            | "evaluated-at"
+            | "remainder"
+            | "closed-interval"
+            | "closed-open-interval"
+            | "open-closed-interval"
+            | "open-interval" 
+            | "polar-coordinate" => {
+                format!(
+                    "<math>
+                        <mrow intent='{}($a,$b)'>
+                            <mi arg='a'>x</mi>
+                            <mi arg='b'>y</mi>
+                        </mrow>
+                    </math>",
+                    intent
+                )
+            }
+
+            _ => {
+                format!(
+                    "<math>
+                        <mrow intent='{}($x)'>
+                            <mi arg='x'>x</mi>
+                        </mrow>
+                    </math>",
+                    intent
+                )
+            }
+        };
+
+        test("pt", "ClearSpeak", &expr, expected)?;
+    }
+
+    Ok(())
+}
+
+
+#[test]
+fn calculus_tests() -> Result<()> {
+    let tests = vec![
+        //("derivative", "the derivative of x with respect to x"),
+        //"definite-integral", "integral over x from x to x"),
+
+        // prefix
+        ("limit", "limit as x"),
+
+        // infix
+        ("tends-to", "x tends to y"),
+        ("tends-to-from-above", "x tends to from above y"),
+        ("tends-to-from-below", "x tends to from below y"),
+    ];
+
+    for (intent, expected) in tests {
+        let expr = match intent {
+            "limit" => {
+                format!(
+                    "<math>
+                        <mrow intent='{}($x)'>
+                            <mi arg='x'>x</mi>
+                        </mrow>
+                    </math>",
+                    intent
+                )
+            }
+
+            _ => {
+                // infix cases
+                format!(
+                    "<math>
+                        <mrow intent='{}($a,$b)'>
+                            <mi arg='a'>x</mi>
+                            <mi arg='b'>y</mi>
+                        </mrow>
+                    </math>",
+                    intent
+                )
+            }
+        };
+
+        test("pt", "ClearSpeak", &expr, expected)?;
+    }
+
+    Ok(())
+}
+
+
+#[test]
+fn set_tests() -> Result<()> {
+    let tests = vec![
+        ("set", "the set of x"),
+        // ("set-difference", "set difference of x and y"),
+        ("complement", "complement of x"),
+        //("empty-set", "empty set"),
+        ("cardinality", "cardinality of x"),
+        ("list", "list of x"),
+        ("tuple", "the tuple of x"),
+    ];
+
+    for (intent, expected) in tests {
+        let expr = format!(
+            "<math>
+                <mrow intent='{}($x)'>
+                    <mi arg='x'>x</mi>
+                </mrow>
+            </math>",
+            intent
+        );
+
+        test("pt", "ClearSpeak", &expr, expected)?;
+    }
+
+    Ok(())
+}
+
+
+#[test]
+fn sequence_and_series_intents() -> Result<()> {
+    let tests = [
+        (
+            "sum-1",
+            r#"
+            <mrow intent="sum($x)">
+                <mo>&#x2211;</mo>
+                <mi arg="x">x</mi>
+            </mrow>
+            "#,
+            "sum of x",
+        ),
+        (
+            "sum-2",
+            r#"
+            <mrow intent="sum($i,$x)">
+                <mo>&#x2211;</mo>
+                <mi arg="i">i</mi>
+                <mi arg="x">x</mi>
+            </mrow>
+            "#,
+            "sum over i of x",
+        ),
+        (
+            "sum-3",
+            r#"
+            <mrow intent="sum($i,$n,$x)">
+                <mo>&#x2211;</mo>
+                <mi arg="i">i</mi>
+                <mi arg="n">n</mi>
+                <mi arg="x">x</mi>
+            </mrow>
+            "#,
+            "sum from i to n of x",
+        ),
+        (
+            "product-1",
+            r#"
+            <mrow intent="product($x)">
+                <mo>&#x220F;</mo>
+                <mi arg="x">x</mi>
+            </mrow>
+            "#,
+            "product of x",
+        ),
+        (
+            "product-2",
+            r#"
+            <mrow intent="product($i,$x)">
+                <mo>&#x220F;</mo>
+                <mi arg="i">i</mi>
+                <mi arg="x">x</mi>
+            </mrow>
+            "#,
+            "product over i of x",
+        ),
+        (
+            "product-3",
+            r#"
+            <mrow intent="product($i,$n,$x)">
+                <mo>&#x220F;</mo>
+                <mi arg="i">i</mi>
+                <mi arg="n">n</mi>
+                <mi arg="x">x</mi>
+            </mrow>
+            "#,
+            "product from i to n of x",
+        ),
+    ];
+
+    for (_, body, expected) in tests {
+        let expr = format!(
+            r#"
+            <math>
+                {}
+            </math>
+            "#,
+            body
+        );
+
+        test("pt", "ClearSpeak", &expr, expected)?;
+    }
+
+    Ok(())
+}
+
+#[test]
+fn elementary_classical_tests() -> Result<()> {
+    let tests = vec![
+        // Trig
+        ("sine", "sine of x"),
+        ("cosine", "cosine of x"),
+        ("tangent", "tangent of x"),
+        ("secant", "secant of x"),
+        ("cosecant", "cosecant of x"),
+        ("cotangent", "cotangent of x"),
+
+        // Inverse trig
+        ("arcsine", "arcsine of x"),
+        ("arccosine", "arccosine of x"),
+        ("arctangent", "arctangent of x"),
+        ("arcsecant", "arcsecant of x"),
+        ("arccosecant", "arc-cosecant of x"),
+        ("arccotangent", "arc-cotangent of x"),
+
+        // Hyperbolic trig
+        ("hyperbolic-sine", "shine of x"),
+        ("hyperbolic-cosine", "cosh of x"),
+        ("hyperbolic-tangent", "tanch of x"),
+        ("hyperbolic-secant", "sech of x"),
+        ("hyperbolic-cosecant", "cosech of x"),
+        ("hyperbolic-cotangent", "coth of x"),
+
+        // Inverse hyperbolic trig
+        ("arc-hyperbolic-sine", "arc shine of x"),
+        ("arc-hyperbolic-cosine", "arc cosh of x"),
+        ("arc-hyperbolic-tangent", "arc tanch of x"),
+        ("arc-hyperbolic-secant", "arc sech of x"),
+        ("arc-hyperbolic-cosecant", "arc cosech of x"),
+        ("arc-hyperbolic-cotangent", "arc coth of x"),
+    ];
+
+    for (intent, expected) in tests {
+        let expr = format!(
+            "<math>
+                <mrow intent='{}($x)'>
+                    <mi arg='x'>x</mi>
+                </mrow>
+            </math>",
+            intent
+        );
+
+        test("pt", "ClearSpeak", &expr, expected)?;
+    }
+
+    Ok(())
+}
+
+#[test]
+fn statistics_and_probability_tests() -> Result<()> {
+    let tests = vec![
+        ("mean", "mean of x"),
+        ("standard-deviation", "standard deviation of x"),
+        ("variance", "variance of x"),
+        ("median", "median of x"),
+        ("mode", "mode of x"),
+
+        // conditional probability typically two arguments
+        // ("conditional-probability", "probability of x given y"),
+    ];
+
+    for (intent, expected) in tests {
+        let expr = match intent {
+            "conditional-probability" => format!(
+                "<math>
+                    <mrow intent='{}($A,$B)'>
+                        <mi>P</mi>
+                        <mo>(</mo>
+                        <mrow>
+                          <mi arg='x'>x</mi>
+                          <mo>|</mo>
+                          <mi arg='y'>y</mi>
+                        </mrow>
+                        <mo>)</mo>
+                    </mrow>
+                </math>",
+                intent
+            ),
+            _ => format!(
+                "<math>
+                    <mrow intent='{}($x)'>
+                        <mi arg='x'>x</mi>
+                    </mrow>
+                </math>",
+                intent
+            ),
+        };
+
+        test("pt", "ClearSpeak", &expr, expected)?;
+    }
+
+    Ok(())
+}
+
+#[test]
+fn linear_algebra_tests() -> Result<()> {
+    let tests = vec![
+        ("vector", "vector of x"),
+        // ("matrix", "matrix of x"),
+        ("determinant", "determinant of x"),
+        ("adjugate", "adjugate of x"),
+        ("magnitude", "magnitude of x"),
+        ("norm", "norm of x"),
+        ("span", "span of x"),
+
+        // transpose supports both postfix and function; we test function explicitly
+        ("transpose", "transpose of x"),
+
+        // dimensional product is infix
+        ("dimensional-product", "x by y"),
+
+        // unit-vector is prefix
+        ("unit-vector", "unit vector x")
+    ];
+
+    for (intent, expected) in tests {
+        let expr: String = match intent {
+          "dimensional-product" => {
+              "<math>
+                  <mrow intent='dimensional-product($x,$y)'>
+                      <mi arg='x'>x</mi>
+                      <mi arg='y'>y</mi>
+                  </mrow>
+              </math>"
+              .to_string()
+          }
+          _ => format!(
+              "<math>
+                  <mrow intent='{intent}($x)'>
+                      <mi arg='x'>x</mi>
+                  </mrow>
+              </math>"
+          ),
+      };
+
+        test("pt", "ClearSpeak", &expr, expected)?;
+    }
+
+    Ok(())
+}
+
+#[test]
+fn nofix_set_tests() -> Result<()> {
+    let tests = vec![
+        ("set-of-integers", "â„¤", "set of all integers"),
+        ("set-of-reals", "â„", "set of all real numbers"),
+        ("set-of-rationals", "â„š", "set of all rational numbers"),
+        ("set-of-natural-numbers", "â„•", "set of all natural numbers"),
+        ("set-of-complex-numbers", "â„‚", "set of all complex numbers"),
+        ("set-of-primes", "â„™", "set of all prime numbers"),
+    ];
+
+    for (intent, symbol, expected) in tests {
+        let expr = format!(
+            "<math>
+                <mi intent='{}:nofix'>{}</mi>
+            </math>",
+            intent,
+            symbol
+        );
+
+        test("pt", "ClearSpeak", &expr, expected)?;
+    }
+
+    Ok(())
+}
+
+#[test]
+fn geometry_prefix_multi_value_tests() -> Result<()> {
+    let tests = vec![
+        ("line-segment", "line segment x y"),
+        ("directed-line-segment", "directed line segment x y"),
+        ("line", "line x y"),
+        ("ray", "ray x y"),
+        ("arc", "arc x y"),
+        ("point", "point x y z"),
+    ];
+
+    for (intent, expected) in tests {
+        let expr = match intent{
+            "point" => {
+                format!(
+                    "<math>
+                        <mrow intent='{intent}($x,$y,$z)'>
+                            <mi arg='x'>x</mi>
+                            <mi arg='y'>y</mi>
+                            <mi arg='z'>z</mi>
+                        </mrow>
+                    </math>"
+                )
+            }
+
+            _ => { 
+                format!(
+                    "<math>
+                        <mrow intent='{intent}($x,$y)'>
+                            <mi arg='x'>x</mi>
+                            <mi arg='y'>y</mi>
+                        </mrow>
+                    </math>"
+                )
+            }
+        };
+
+        test("pt", "ClearSpeak", &expr, expected)?;
+    }
+
+    Ok(())
+}
+
+#[test]
+fn geometry_prefix_tests() -> Result<()> {
+    let tests = vec![
+        ("length", "length of x"),
+        ("area", "area of x"),
+        ("volume", "volume of x"),
+    ];
+
+    for (intent, expected) in tests {
+        let expr = format!(
+            "<math>
+                <mrow intent='{intent}:function($x)'>
+                    <mi arg='x'>x</mi>
+                </mrow>
+            </math>"
+        );
+
+        test("pt", "ClearSpeak", &expr, expected)?;
+    }
+
+    Ok(())
+}
+
+#[test]
+fn separator_tests() -> Result<()> {
+  let expr = format!(
+        "<math>
+            <mrow intent='time-separator($x,$y)'>
+                <mi arg='x'>x</mi>
+                <mi arg='y'>y</mi>
+            </mrow>
+        </math>"
+    );
+
+    test("pt", "ClearSpeak", &expr, "x y")?;
+    Ok(())
+}
+
+#[test]
+fn general_concepts_tests() -> Result<()> {
+    let tests = vec![
+        // Unary structural
+        ("fenced-group", "fenced-group of x"),
+        ("highlight", "x highlighted"),
+        ("least-common-denominator", "least common denominator of x comma, y comma, z"), // add x, y , z ...
+        ("pochhammer", "permutation of x"),
+        ("permutation-cycle", "permutation cycle of x"),
+
+        // Binary structural / infix-style
+        // ("ordered-pair", "the pair of x and y"),
+        ("rate", "x per y"),
+        
+        ("binomial-coefficient", "x choose y"),
+        ("embellished-name", "x with annotation y"),
+        ("indexed-by", "x indexed by y"),
+        // ("translation", "translation by x comma, y"), // Changes translation to comma
+        ("constraint", "x with constraint y"),
+    ];
+
+    for (intent, expected) in tests {
+        let expr = match intent {
+            "ordered-pair"
+            | "rate"
+            | "constraint"
+            | "binomial-coefficient"
+            | "embellished-name"
+            | "translation"
+            | "indexed-by" => {
+                format!(
+                    "<math>
+                        <mrow intent='{}($a,$b)'>
+                            <mi arg='a'>x</mi>
+                            <mi arg='b'>y</mi>
+                        </mrow>
+                    </math>",
+                    intent
+                )
+            }
+            "least-common-denominator" => {
+                format!(
+                    "<math>
+                        <mrow intent='{}($x,$y,$z)'>
+                            <mi arg='x'>x</mi>
+                            <mi arg='y'>y</mi>
+                            <mi arg='z'>z</mi>
+                        </mrow>
+                    </math>",
+                    intent
+                )
+            }
+
+            // unary cases
+            _ => {
+                format!(
+                    "<math>
+                        <mrow intent='{}($x)'>
+                            <mi arg='x'>x</mi>
+                        </mrow>
+                    </math>",
+                    intent
+                )
+            }
+        };
+
+        test("pt", "ClearSpeak", &expr, expected)?;
+    }
+
+    Ok(())
+}
+
+#[test]
+fn grouping_tests() -> Result<()> {
+    let tests = vec![
+        ("annotation", "x which is y"),
+        // ("braced-group", "grouped x end-grouped"),
+        // ("repeating-decimal", "repeating decimal of x"),
+    ];
+
+    for (intent, expected) in tests {
+        let expr = match intent {
+            "annotation" => {
+                format!(
+                    "<math>
+                        <mrow intent='{}($x,$y)'>
+                            <mi arg='x'>x</mi>
+                            <mi arg='y'>y</mi>
+                        </mrow>
+                    </math>",
+                    intent
+                )
+            }
+            _ => {
+                format!(
+                    "<math>
+                        <mrow intent='{}($x)'>
+                            <mi arg='x'>x</mi>
+                        </mrow>
+                    </math>",
+                    intent
+                )
+            } 
+        };
+
+        test("pt", "ClearSpeak", &expr, expected)?;
+    }
+
+    Ok(())
+}
+
+#[test]
+fn function_default_fixity_tests() -> Result<()> {
+    let tests = vec![
+        ("curl", "curl of x"),
+        ("divergence", "divergence of x"),
+        ("gradient", "gradient of x"),
+        ("laplacian", "laplacian of x"),
+    ];
+
+    for (intent, expected) in tests {
+        let expr = format!(
+            "<math>
+                <mrow intent='{}($x)'>
+                    <mi arg='x'>x</mi>
+                </mrow>
+            </math>",
+            intent
+        );
+
+        test("pt", "ClearSpeak", &expr, expected)?;
+    }
+
+    Ok(())
+}
+
+#[test]
+fn prefix_default_fixity_tests() -> Result<()> {
+    let tests = vec![
+        ("angle", "angle x"),
+        ("angle-measure", "angle measure x"),
+        ("change", "change in x"),
+        ("for-all", "for all x"),
+        ("measured-angle", "measured angle x"),
+        ("not", "not x"),
+        ("number-of", "number of x"),
+        ("partial-derivative", "partial x"),
+        ("right-angle", "right angle x"),
+        ("square-root-of", "square root of x"),
+        ("there-does-not-exist", "there does not exist x"),
+        ("there-exists", "there exists x"),
+    ];
+
+    for (intent, expected) in tests {
+        let expr = format!(
+            "<math>
+                <mrow intent='{}($x)'>
+                    <mi arg='x'>x</mi>
+                </mrow>
+            </math>",
+            intent
+        );
+
+        test("pt", "ClearSpeak", &expr, expected)?;
+    }
+
+    Ok(())
+}
+
+#[test]
+fn infix_default_fixity_tests() -> Result<()> {
+    let tests = vec![
+        ("and", "x and y"),
+        ("applied-to", "x applied to y"),
+        ("approximately", "x approximately y"),
+        ("congruent", "x congruent to y"),
+        ("cartesian-product", "x cartesian product y"),
+        ("composed-with", "x composed with y"),
+        ("cross-product", "x cross product y"),
+        ("defined-as", "x defined as y"),
+        ("divided-by", "x divided by y"),
+        ("divides", "x divides y"),
+        ("does-not-belong-to", "x does not belong to y"),
+        ("does-not-divide", "x does not divide y"),
+        ("dot-product", "x dot product y"),
+        ("downwards-diagonal-ellipsis", "x downwards diagonal ellipsis y"),
+        ("direct-product", "x direct product y"),
+        ("element-of", "x element of y"),
+        ("ellipsis", "x ellipsis y"),
+        ("equals", "x equals y"),
+        ("equivalent-to", "x equivalent to y"),
+        ("evaluates-to", "x evaluates to y"),
+        ("given", "x given y"),
+        ("greater-than", "x greater than y"),
+        ("greater-than-or-equal-to", "x greater than or equal to y"),
+        ("identically-equals", "x identically equals y"),
+        ("if-and-only-if", "x if and only if y"),
+        ("implies", "x implies y"),
+        ("inner-product", "x inner product y"),
+        ("intersection", "x intersection y"),
+        ("less-than", "x less than y"),
+        ("less-than-or-equal-to", "x less than or equal to y"),
+        ("list-separator", "x comma y"),
+        ("maps-to", "x maps to y"),
+        ("member-of", "x member of y"),
+        ("minus", "x minus y"),
+        ("minus-or-plus", "x minus or plus y"),
+        ("not-subset", "x not subset of y"),
+        ("not-superset", "x not superset of y"),
+        ("not-equal-to", "x not equal to y"),
+        ("not-member-of", "x not member of y"),
+        ("not-parallel-to", "x not parallel to y"),
+        ("obtained-from", "x obtained from y"),
+        ("or", "x or y"),
+        ("outer-product", "x outer product y"),
+        ("parallel-to", "x parallel to y"),
+        ("perpendicular", "x perpendicular to y"),
+        ("plus", "x plus y"),
+        ("plus-or-minus", "x plus or minus y"),
+        ("precedes", "x precedes y"),
+        ("proportional", "x proportional to y"),
+        ("range-separator", "x through y"),
+        ("ratio", "x ratio y"),
+        ("similar", "x similar to y"),
+        ("subset", "x subset of y"),
+        ("subset-or-equal", "x subset or equal to y"),
+        ("succeeds", "x succeeds y"),
+        ("such-that", "x such that y"),
+        ("superset", "x superset of y"),
+        ("superset-or-equal", "x superset or equal to y"),
+        ("tilde", "x tilde y"),
+        ("times", "x times y"),
+        ("union", "x union y"),
+        ("upwards-diagonal-ellipsis", "x upwards diagonal ellipsis y"),
+        ("vertical-ellipsis", "x vertical ellipsis y"),
+        ("xor", "x exclusive or y"),
+    ];
+    
+    for (intent, expected) in tests {
+        let expr = format!(
+            "<math>
+                <mrow intent='{}($a,$b)'>
+                    <mi arg='a'>x</mi>
+                    <mi arg='b'>y</mi>
+                </mrow>
+            </math>",
+            intent
+        );
+
+        test("pt", "ClearSpeak", &expr, expected)?;
+    }
+
+    Ok(())
+}
+
+#[test]
+fn postfix_default_fixity_tests() -> Result<()> {
+    let tests = vec![
+        ("factorial", "x factorial"),
+        ("percent", "x percent"),
+    ];
+
+    for (intent, expected) in tests {
+        let expr = format!(
+            "<math>
+                <mrow intent='{}($x)'>
+                    <mi arg='x'>x</mi>
+                </mrow>
+            </math>",
+            intent
+        );
+
+        test("pt", "ClearSpeak", &expr, expected)?;
+    }
+
+    Ok(())
+}
+
+#[test]
+fn nofix_default_fixity_tests() -> Result<()> {
+    let tests = vec![
+        ("diameter", "d", "diameter"),
+        ("distance", "D", "distance"),
+        ("probability", "P", "probability"),
+        ("radius", "r", "radius"),
+        ("volume", "V", "volume"),
+        ("exponential-e", "e", "e"),
+        ("imaginary-i", "i", "i"),
+        ("differential-d", "d", "d"),
+        ("golden-ratio", "Ï†", "golden ratio"),
+    ];
+
+    for (intent, symbol, expected) in tests {
+        let expr = format!(
+            "<math>
+                <mi intent='{}:nofix'>{}</mi>
+            </math>",
+            intent,
+            symbol
+        );
+
+        test("pt", "ClearSpeak", &expr, expected)?;
+    }
+
+    Ok(())
+}

--- a/tests/Languages/pt/intent.rs
+++ b/tests/Languages/pt/intent.rs
@@ -1,0 +1,145 @@
+﻿/// Tests for rules shared between various speech styles:
+/// *  this has tests focused on the various alphabets
+use crate::common::*;
+use anyhow::Result;
+
+
+#[test]
+fn silent_intent() -> Result<()> {
+    let expr = "<math> <mrow intent='testing:silent($arg1, $arg2)'><mn arg='arg1'>2</mn> <mi arg='arg2'>x</mi></mrow> </math>";
+    test("pt", "SimpleSpeak", expr, "2 x")?;
+    test("pt", "LiteralSpeak", expr, "2 x")?;
+    return Ok(());
+
+}
+
+#[test]
+fn prefix_intent() -> Result<()> {
+    let expr = r#"<math><msup intent='testing:prefix($x)'> <mi arg='x'>x</mi> <mi>T</mi> </msup> </math>"#;
+    test("pt", "SimpleSpeak", expr, "testing x")?;
+    return Ok(());
+
+}
+
+#[test]
+fn postfix_intent() -> Result<()> {
+    let expr = r#"<math><msup intent='testing:postfix($x)'> <mi arg='x'>x</mi> <mi>T</mi> </msup> </math>"#;
+    test("pt", "SimpleSpeak", expr, "x testing")?;
+    return Ok(());
+
+}
+
+#[test]
+fn infix_intent() -> Result<()> {
+    let expr = r#"<math><mrow intent='testing:infix($x, $y, $z, 2)'>
+        <mi arg='x'>x</mi>
+        <mi arg='y'>y</mi>
+        <mi arg='z'>z</mi>
+    </mrow> </math>"#;
+    test("pt", "SimpleSpeak", expr, "x testing y testing z testing 2")?;
+    return Ok(());
+
+}
+
+#[test]
+fn infix_intent_no_args() -> Result<()> {
+    // this is illegal intent, so it is just an mrow with one child
+    let expr = r#"<math><mrow intent='testing:infix()'>
+        <mi arg='x'>x</mi>
+    </mrow> </math>"#;
+    test("pt", "SimpleSpeak", expr, "x")?;
+    return Ok(());
+
+}
+
+#[test]
+fn infix_intent_one_arg() -> Result<()> {
+    let expr = r#"<math><mrow intent='testing:infix($x)'>
+        <mi arg='x'>x</mi>
+    </mrow> </math>"#;
+    // Note: we say the intent name because there are infix plus/minus with a single arg due to continued rows or combined columns
+    test("pt", "SimpleSpeak", expr, "testing x")?;
+    return Ok(());
+
+}
+
+#[test]
+fn function_intent() -> Result<()> {
+    let expr = r#"<math><mrow intent='testing:function($x, $y, $z, 2)'>
+        <mi arg='x'>x</mi>
+        <mi arg='y'>y</mi>
+        <mi arg='z'>z</mi>
+    </mrow> </math>"#;
+    test("pt", "SimpleSpeak", expr, "testing of x comma, y comma, z comma, 2")?;
+    return Ok(());
+
+}
+
+#[test]
+fn function_no_args_intent() -> Result<()> {
+    // this is illegal intent, so it is just an mrow with one child
+    let expr = r#"<math><mrow intent='testing:function()'>
+        <mi arg='x'>x</mi>
+    </mrow> </math>"#;
+    test("pt", "SimpleSpeak", expr, "x")?;
+    return Ok(());
+
+}
+
+#[test]
+fn function_one_arg_intent() -> Result<()> {
+    let expr = r#"<math><mrow intent='testing:function($x)'>
+        <mi arg='x'>x</mi>
+    </mrow> </math>"#;
+    test("pt", "SimpleSpeak", expr, "testing of x")?;
+    return Ok(());
+
+}
+
+#[test]
+fn silent_intent_mi() -> Result<()> {
+    let expr = "<math> <mn>2</mn> <mi intent=':silent'>x</mi></math>";
+    test("pt", "SimpleSpeak", expr, "2")?;
+    test("pt", "ClearSpeak", expr, "2")?;
+    return Ok(());
+
+}
+
+#[test]
+fn silent_intent_msup() -> Result<()> {
+    let expr = "<math>
+        <msup intent='index:silent($H,$n)'>
+            <mi arg='H' mathvariant='normal'>H</mi>
+            <mn arg='n'>2</mn>
+        </msup></math>";
+    test("pt", "SimpleSpeak", expr, "cap h 2")?;
+    test("pt", "ClearSpeak", expr, "cap h 2")?;
+    return Ok(());
+
+}
+
+#[test]
+fn silent_intent_underscore() -> Result<()> {
+    let expr = "<math>
+        <msup intent='_($H,$n)'>
+            <mi arg='H' mathvariant='normal'>H</mi>
+            <mn arg='n'>2</mn>
+        </msup></math>";
+    test("pt", "SimpleSpeak", expr, "cap h 2")?;
+    test("pt", "ClearSpeak", expr, "cap h 2")?;
+    return Ok(());
+
+}
+
+#[test]
+fn intent_prob_x() -> Result<()> {
+    init_logger();
+    let expr = "<math>
+    <msup intent='$op($arg)'>
+        <mi arg='arg'>x</mi>
+        <mi arg='op' intent='probability' mathvariant='normal'>P</mi>
+    </msup></math>";
+    test("pt", "ClearSpeak", expr, "probability of x")?;
+    return Ok(());
+
+}

--- a/tests/Languages/pt/mtable.rs
+++ b/tests/Languages/pt/mtable.rs
@@ -1,0 +1,1331 @@
+﻿use crate::common::*;
+use anyhow::Result;
+
+#[test]
+fn matrix_1x1() -> Result<()> {
+    let expr = "
+    <math xmlns='http://www.w3.org/1998/Math/MathML'>
+      <mrow>
+      <mrow><mo>(</mo>
+        <mtable><mtr><mtd>
+        <mn>3</mn>
+      </mtd> </mtr></mtable>
+        <mo>)</mo></mrow></mrow>
+    </math>
+                                ";
+    test("pt", "ClearSpeak",  expr, "the 1 by 1 matrix with entry 3")?;
+    test("pt", "SimpleSpeak", expr, "the 1 by 1 matrix with entry 3")?;
+    return Ok(());
+
+}
+
+#[test]
+fn determinant_1x1() -> Result<()> {
+    let expr = "
+    <math xmlns='http://www.w3.org/1998/Math/MathML'>
+      <mrow>
+      <mrow><mo>|</mo>
+        <mtable><mtr><mtd>
+        <mn>3</mn>
+      </mtd> </mtr></mtable>
+        <mo>|</mo></mrow></mrow>
+    </math>
+                                ";
+    test("pt", "ClearSpeak",  expr, "the 1 by 1 determinant with entry 3")?;
+    test("pt", "SimpleSpeak", expr, "the 1 by 1 determinant with entry 3")?;
+    return Ok(());
+
+}
+
+
+#[test]
+fn matrix_1x2() -> Result<()> {
+    let expr = "
+    <math xmlns='http://www.w3.org/1998/Math/MathML'>
+      <mrow>
+      <mrow><mo>(</mo>
+        <mtable>
+          <mtr>
+          <mtd>
+            <mn>3</mn>
+          </mtd>
+          <mtd>
+            <mn>5</mn>
+          </mtd>
+          </mtr>
+        </mtable>
+      <mo>)</mo></mrow></mrow>
+    </math>
+                                ";
+    test("pt", "ClearSpeak",  expr, "the 1 by 2 row matrix; 3, 5")?;
+    test("pt", "SimpleSpeak", expr, "the 1 by 2 row matrix; 3, 5")?;
+    return Ok(());
+
+}
+
+
+#[test]
+fn matrix_1x3() -> Result<()> {
+    let expr = "
+    <math xmlns='http://www.w3.org/1998/Math/MathML'>
+      <mrow>
+      <mrow><mo>(</mo>
+        <mtable>
+          <mtr>
+          <mtd>
+            <mrow><mo>-</mo><mi>x</mi></mrow>
+          </mtd>
+          <mtd>
+            <mn>5</mn>
+          </mtd>
+          <mtd>
+            <mn>12</mn>
+          </mtd>
+          </mtr>
+        </mtable>
+      <mo>)</mo></mrow></mrow>
+    </math>
+                                ";
+    test("pt", "ClearSpeak", expr, "the 1 by 3 row matrix; negative x, 5, 12")?;
+    test("pt", "SimpleSpeak", expr, "the 1 by 3 row matrix; negative x, 5, 12")?;
+    return Ok(());
+
+}
+
+#[test]
+fn matrix_2x1_not_simple() -> Result<()> {
+    let expr = "
+    <math xmlns='http://www.w3.org/1998/Math/MathML'>
+      <mrow>
+      <mrow><mo>(</mo>
+        <mtable>
+          <mtr>
+          <mtd>
+            <mrow>
+            <mi>x</mi><mo>+</mo><mn>1</mn>
+            </mrow>
+          </mtd>
+          </mtr>
+          <mtr>
+          <mtd>
+            <mrow>
+            <mi>x</mi><mo>-</mo><mn>1</mn></mrow>
+          </mtd>
+          </mtr>
+        </mtable>
+      <mo>)</mo></mrow></mrow>
+    </math>
+                                ";
+    test("pt", "ClearSpeak", expr, "the 2 by 1 column matrix; row 1; x plus 1; row 2; x minus 1")?;
+    test("pt", "SimpleSpeak", expr, "the 2 by 1 column matrix; row 1; x plus 1; row 2; x minus 1")?;
+    return Ok(());
+
+}
+#[test]
+fn matrix_3x1_not_simple() -> Result<()> {
+    let expr = "
+    <math xmlns='http://www.w3.org/1998/Math/MathML'>
+      <mrow>
+      <mrow><mo>(</mo>
+        <mtable>
+          <mtr>
+          <mtd>
+            <mrow>
+            <mi>x</mi>
+            </mrow>
+          </mtd>
+          </mtr>
+          <mtr>
+          <mtd>
+            <mrow>
+            <mi>a</mi>
+            </mrow>
+          </mtd>
+          </mtr>
+          <mtr>
+          <mtd>
+            <mfrac>
+              <mi>x</mi>
+              <mrow>
+                <mi>x</mi><mo>+</mo><mn>1</mn>
+              </mrow>
+            </mfrac>
+          </mtd>
+          </mtr>
+        </mtable>
+      <mo>)</mo></mrow></mrow>
+    </math>";
+    test("pt", "SimpleSpeak", expr, "the 3 by 1 column matrix; \
+            row 1; x; \
+            row 2; eigh; \
+            row 3; fraction, x over, x plus 1, end fraction")?;
+    test("pt", "ClearSpeak",  expr, "the 3 by 1 column matrix; \
+            row 1; x; \
+            row 2; eigh; \
+            row 3; the fraction with numerator x; and denominator x plus 1")?;
+            return Ok(());
+
+}
+
+#[test]
+fn determinant_2x2() -> Result<()> {
+    let expr = "<math>
+      <mrow>
+      <mrow><mo>|</mo>
+        <mtable>
+          <mtr>
+          <mtd>
+            <mn>2</mn>
+          </mtd>
+          <mtd>
+            <mn>1</mn>
+          </mtd>
+          </mtr>
+          <mtr>
+          <mtd>
+            <mn>7</mn>
+          </mtd>
+          <mtd>
+            <mn>5</mn>
+          </mtd>
+          </mtr>
+          
+        </mtable>
+      <mo>|</mo></mrow></mrow>
+                        </math>";
+    test("pt", "ClearSpeak",  expr, "the 2 by 2 determinant; row 1; 2, 1; row 2; 7, 5")?;
+    test("pt", "SimpleSpeak", expr, "the 2 by 2 determinant; row 1; 2, 1; row 2; 7, 5")?;
+    return Ok(());
+
+}
+
+#[test]
+fn matrix_2x3() -> Result<()> {
+    let expr = "
+    <math display='block' xmlns='http://www.w3.org/1998/Math/MathML'>
+      <mrow>
+      <mrow><mo>[</mo>
+        <mtable>
+          <mtr>
+          <mtd>
+            <mn>3</mn>
+          </mtd>
+          <mtd>
+            <mn>1</mn>
+          </mtd>
+          <mtd>
+            <mn>4</mn>
+          </mtd>
+          </mtr>
+          <mtr>
+          <mtd>
+            <mn>0</mn>
+          </mtd>
+          <mtd>
+            <mn>2</mn>
+          </mtd>
+          <mtd>
+            <mn>6</mn>
+          </mtd>
+          </mtr>
+        </mtable>
+      <mo>]</mo></mrow></mrow>
+    </math>
+                                ";
+    test("pt", "ClearSpeak",  expr, "the 2 by 3 matrix; row 1; 3, 1, 4; row 2; 0, 2, 6")?;
+    test("pt", "SimpleSpeak", expr, "the 2 by 3 matrix; row 1; 3, 1, 4; row 2; 0, 2, 6")?;
+    return Ok(());
+
+}
+
+#[test]
+fn augmented_matrix_2x3() -> Result<()> {
+    let expr = "
+    <math display='block' xmlns='http://www.w3.org/1998/Math/MathML'>
+      <mrow>
+      <mrow><mo>[</mo>
+        <mtable columnlines='none solid'>
+          <mtr>
+          <mtd>
+            <mn>3</mn>
+          </mtd>
+          <mtd>
+            <mn>1</mn>
+          </mtd>
+          <mtd>
+            <mn>4</mn>
+          </mtd>
+          </mtr>
+          <mtr>
+          <mtd>
+            <mn>0</mn>
+          </mtd>
+          <mtd>
+            <mn>2</mn>
+          </mtd>
+          <mtd>
+            <mn>6</mn>
+          </mtd>
+          </mtr>
+        </mtable>
+      <mo>]</mo></mrow></mrow>
+    </math>
+                                ";
+    test("pt", "ClearSpeak",  expr, "the 2 by 3 augmented matrix; row 1; 3, 1, 4; row 2; 0, 2, 6")?;
+    test("pt", "SimpleSpeak", expr, "the 2 by 3 augmented matrix; row 1; 3, 1, 4; row 2; 0, 2, 6")?;
+    Ok(())
+}
+
+#[test]
+fn matrix_2x3_labeled() -> Result<()> {
+    let expr = "
+    <math display='block' xmlns='http://www.w3.org/1998/Math/MathML'>
+      <mrow>
+      <mrow><mo>[</mo>
+        <mtable>
+          <mlabeledtr>
+          <mtd>
+            <mtext>(3.1)</mtext>
+          </mtd>
+          <mtd>
+            <mn>3</mn>
+          </mtd>
+          <mtd>
+            <mn>1</mn>
+          </mtd>
+          <mtd>
+            <mn>4</mn>
+          </mtd>
+          </mlabeledtr>
+          <mtr>
+          <mtd>
+            <mn>0</mn>
+          </mtd>
+          <mtd>
+            <mn>2</mn>
+          </mtd>
+          <mtd>
+            <mn>6</mn>
+          </mtd>
+          </mtr>
+        </mtable>
+      <mo>]</mo></mrow></mrow>
+    </math>
+                                ";
+    test("pt", "ClearSpeak",  expr,
+        "the 2 by 3 matrix; row 1 with label (3.1); column 1; 3, column 2; 1, column 3; 4; \
+                                   row 2; column 1; 0, column 2; 2, column 3; 6")?;
+    test("pt", "SimpleSpeak", expr,
+        "the 2 by 3 matrix; row 1 with label (3.1); column 1; 3, column 2; 1, column 3; 4; \
+                                   row 2; column 1; 0, column 2; 2, column 3; 6")?;
+                                   return Ok(());
+
+}
+
+#[test]
+fn matrix_3x1() -> Result<()> {
+    let expr = "
+    <math xmlns='http://www.w3.org/1998/Math/MathML'>
+      <mrow>
+      <mrow><mo>[</mo>
+        <mtable>
+        <mtr>
+          <mtd>
+          <mn>1</mn>
+          </mtd>
+        </mtr>
+        <mtr>
+          <mtd>
+          <mn>2</mn>
+          </mtd>
+        </mtr>
+        <mtr>
+          <mtd>
+          <mn>3</mn>
+          </mtd>
+        </mtr>           
+        </mtable> <mo>]</mo></mrow></mrow>
+    </math>
+                                ";
+    test("pt", "ClearSpeak",  expr, "the 3 by 1 column matrix; 1; 2; 3")?;
+    test("pt", "SimpleSpeak", expr, "the 3 by 1 column matrix; 1; 2; 3")?;
+    return Ok(());
+
+}
+
+#[test]
+fn matrix_4x1() -> Result<()> {
+    let expr = "
+    <math xmlns='http://www.w3.org/1998/Math/MathML'>
+      <mrow>
+      <mrow><mo>(</mo>
+        <mtable>
+          <mtr>
+          <mtd>
+            <mn>3</mn>
+          </mtd>
+          </mtr>
+          <mtr>
+          <mtd>
+            <mn>6</mn>
+          </mtd>
+          </mtr>
+          <mtr>
+          <mtd>
+            <mn>1</mn>
+          </mtd>
+          </mtr>
+          <mtr>
+          <mtd>
+            <mn>2</mn>
+          </mtd>
+          </mtr>            
+        </mtable>
+      <mo>)</mo></mrow></mrow>
+    </math>
+                                ";
+    test("pt", "ClearSpeak",  expr, "the 4 by 1 column matrix; row 1; 3; row 2; 6; row 3; 1; row 4; 2")?;
+    test("pt", "SimpleSpeak", expr, "the 4 by 1 column matrix; row 1; 3; row 2; 6; row 3; 1; row 4; 2")?;
+    return Ok(());
+
+}
+
+#[test]
+fn matrix_4x1_labeled() -> Result<()> {
+    let expr = "
+    <math xmlns='http://www.w3.org/1998/Math/MathML'>
+      <mrow>
+      <mrow><mo>(</mo>
+        <mtable>
+          <mtr>
+          <mtd>
+            <mn>3</mn>
+          </mtd>
+          </mtr>
+          <mtr>
+          <mtd>
+            <mn>6</mn>
+          </mtd>
+          </mtr>
+          <mtr>
+          <mtd>
+            <mn>1</mn>
+          </mtd>
+          </mtr>
+          <mlabeledtr>
+          <mtd>
+            <mtext>(3.1)</mtext>
+          </mtd>
+          <mtd>
+            <mn>2</mn>
+          </mtd>
+          </mlabeledtr>            
+        </mtable>
+      <mo>)</mo></mrow></mrow>
+    </math>
+                                ";
+    test("pt", "ClearSpeak",  expr,
+        "the 4 by 1 column matrix; row 1; 3; row 2; 6; row 3; 1; row 4 with label (3.1); 2")?;
+    test("pt", "SimpleSpeak", expr,
+        "the 4 by 1 column matrix; row 1; 3; row 2; 6; row 3; 1; row 4 with label (3.1); 2")?;
+        return Ok(());
+
+}
+
+#[test]
+fn matrix_1x4() -> Result<()> {
+    let expr = "
+    <math xmlns='http://www.w3.org/1998/Math/MathML'>
+      <mrow>
+      <mrow><mo>(</mo>
+        <mtable>
+          <mtr>
+          <mtd>
+            <mn>3</mn>
+          </mtd>
+          <mtd>
+            <mn>6</mn>
+          </mtd>
+          <mtd>
+            <mn>1</mn>
+          </mtd>
+          <mtd>
+            <mn>2</mn>
+          </mtd>
+          </mtr>
+        </mtable>
+      <mo>)</mo></mrow></mrow>
+    </math>
+                                ";
+    test("pt", "ClearSpeak",  expr, "the 1 by 4 row matrix; column 1; 3, column 2; 6, column 3; 1, column 4; 2")?;
+    test("pt", "SimpleSpeak", expr, "the 1 by 4 row matrix; column 1; 3, column 2; 6, column 3; 1, column 4; 2")?;
+    return Ok(());
+
+}
+
+#[test]
+fn matrix_4x4() -> Result<()> {
+    let expr = "
+    <math xmlns='http://www.w3.org/1998/Math/MathML'>
+      <mrow>
+      <mrow><mo>(</mo>
+        <mtable>
+          <mtr>
+          <mtd>
+            <mn>0</mn>
+          </mtd>
+          <mtd>
+            <mn>3</mn>
+          </mtd>
+          <mtd>
+            <mn>4</mn>
+          </mtd>
+          <mtd>
+            <mn>3</mn>
+          </mtd>
+          </mtr>
+          <mtr>
+          <mtd>
+            <mn>2</mn>
+          </mtd>
+          <mtd>
+            <mn>1</mn>
+          </mtd>
+          <mtd>
+            <mn>0</mn>
+          </mtd>
+          <mtd>
+            <mn>9</mn>
+          </mtd>
+          </mtr>
+          <mtr>
+          <mtd>
+            <mn>3</mn>
+          </mtd>
+          <mtd>
+            <mn>0</mn>
+          </mtd>
+          <mtd>
+            <mn>2</mn>
+          </mtd>
+          <mtd>
+            <mn>1</mn>
+          </mtd>
+          </mtr>
+          <mtr>
+          <mtd>
+            <mn>6</mn>
+          </mtd>
+          <mtd>
+            <mn>2</mn>
+          </mtd>
+          <mtd>
+            <mn>9</mn>
+          </mtd>
+          <mtd>
+            <mn>0</mn>
+          </mtd>
+          </mtr>
+        </mtable>
+      <mo>)</mo></mrow></mrow>
+    </math>
+                                ";
+    test("pt", "ClearSpeak",  expr, "the 4 by 4 matrix; \
+          row 1; column 1; 0, column 2; 3, column 3; 4, column 4; 3; \
+          row 2; column 1; 2, column 2; 1, column 3; 0, column 4; 9; \
+          row 3; column 1; 3, column 2; 0, column 3; 2, column 4; 1; \
+          row 4; column 1; 6, column 2; 2, column 3; 9, column 4; 0")?;
+    test("pt", "SimpleSpeak", expr, "the 4 by 4 matrix; \
+          row 1; column 1; 0, column 2; 3, column 3; 4, column 4; 3; \
+          row 2; column 1; 2, column 2; 1, column 3; 0, column 4; 9; \
+          row 3; column 1; 3, column 2; 0, column 3; 2, column 4; 1; \
+          row 4; column 1; 6, column 2; 2, column 3; 9, column 4; 0")?;
+    return Ok(());
+}
+
+#[test]
+fn matrix_4x2() -> Result<()> {
+    let expr = "
+    <math xmlns='http://www.w3.org/1998/Math/MathML'>
+    <mrow>
+      <mrow><mo>(</mo>
+        <mtable>
+        <mtr>
+          <mtd>
+          <mn>1</mn>
+          </mtd>
+          <mtd>
+          <mn>3</mn>
+          </mtd>
+        </mtr>
+        <mtr>
+          <mtd>
+          <mn>4</mn>
+          </mtd>
+          <mtd>
+          <mn>2</mn>
+          </mtd>
+        </mtr>
+        <mtr>
+          <mtd>
+          <mn>2</mn>
+          </mtd>
+          <mtd>
+          <mn>1</mn>
+          </mtd>
+        </mtr>
+        <mtr>
+          <mtd>
+          <mn>0</mn>
+          </mtd>
+          <mtd>
+          <mn>5</mn>
+          </mtd>
+        </mtr>
+        
+        </mtable>
+      <mo>)</mo></mrow></mrow>
+    </math>
+      ";
+    test("pt", "ClearSpeak",  expr, "the 4 by 2 matrix; \
+              row 1; column 1; 1, column 2; 3; \
+              row 2; column 1; 4, column 2; 2; \
+              row 3; column 1; 2, column 2; 1; \
+              row 4; column 1; 0, column 2; 5\
+    ")?;
+    test("pt", "SimpleSpeak", expr, "the 4 by 2 matrix; \
+              row 1; column 1; 1, column 2; 3; \
+              row 2; column 1; 4, column 2; 2; \
+              row 3; column 1; 2, column 2; 1; \
+              row 4; column 1; 0, column 2; 5\
+    ")?;
+    return Ok(());
+}
+
+// put absolute value test here since it is related to determinate and is small for its own file
+#[test]
+fn simple_absolute_value() -> Result<()> {
+  let expr = "<math>
+    <mrow><mrow><mo>|</mo> <mi>x</mi> <mo>|</mo></mrow></mrow>
+  </math>";
+  test("pt", "SimpleSpeak", expr, "the absolute value of x")?;
+  test("pt", "ClearSpeak",  expr, "the absolute value of x")?;
+  test_prefs("pt", "ClearSpeak", vec![("Verbosity", "Terse"), ("ClearSpeak_AbsoluteValue", "Auto")], expr, "absolute value of x")?;
+  test_prefs("pt", "ClearSpeak", vec![("Verbosity", "Verbose"), ("ClearSpeak_AbsoluteValue", "AbsEnd")],
+             expr, "the absolute value of x, end absolute value")?;
+  return Ok(());
+}
+  
+#[test]
+fn absolute_value_plus_1() -> Result<()> {
+let expr = "<math>
+    <mrow><mrow><mo>|</mo>
+      <mrow><mi>x</mi><mo>+</mo><mn>1</mn> </mrow>
+    <mo>|</mo></mrow></mrow>
+  </math>";
+  test("pt", "ClearSpeak", expr, "the absolute value of x plus 1")?;
+  test_prefs("pt", "ClearSpeak", vec![("Verbosity", "Terse"), ("ClearSpeak_AbsoluteValue", "AbsEnd")],
+             expr, "absolute value of x plus 1, end absolute value")?;
+  return Ok(());
+}
+
+#[test]
+fn simple_cardinality_value() -> Result<()> {
+  let expr = "<math>
+    <mrow><mrow><mo>|</mo> <mi>S</mi> <mo>|</mo></mrow></mrow>
+  </math>";
+  test_prefs("pt", "ClearSpeak", vec![("Verbosity", "Medium"), ("ClearSpeak_AbsoluteValue", "Cardinality")], expr,
+             "the cardinality of cap s")?;
+    return Ok(());
+}
+  
+// Test preferences
+#[test]
+fn simple_matrix_speak_col_num() -> Result<()> {
+let expr = "<math display='block' xmlns='http://www.w3.org/1998/Math/MathML'>
+  <mrow>
+    <mrow><mo>(</mo>
+    <mrow>
+      <mtable>
+      <mtr>
+        <mtd> <mn>2</mn> </mtd>
+        <mtd><mn>1</mn> </mtd>
+      </mtr>
+      <mtr>
+        <mtd><mn>7</mn> </mtd>
+        <mtd><mn>5</mn> </mtd>
+      </mtr>
+      </mtable></mrow>
+    <mo>)</mo></mrow></mrow>
+  </math>";
+  test_ClearSpeak("pt", "ClearSpeak_Matrix", "SpeakColNum",
+        expr, "the 2 by 2 matrix; row 1; column 1; 2, column 2; 1; row 2; column 1; 7, column 2; 5")?;
+    return Ok(());
+}
+
+#[test]
+fn col_matrix_3x1_speak_col_num() -> Result<()> {
+let expr = "<math display='block' xmlns='http://www.w3.org/1998/Math/MathML'>
+  <mrow>
+    <mrow><mo>(</mo>
+    <mrow>
+      <mtable>
+      <mtr>
+        <mtd><mn>1</mn> </mtd>
+      </mtr>
+      <mtr>
+        <mtd><mn>2</mn> </mtd>
+      </mtr>
+      <mtr>
+        <mtd><mn>3</mn> </mtd>
+      </mtr>
+      </mtable></mrow>
+    <mo>)</mo></mrow></mrow>
+  </math>";
+test_ClearSpeak("pt", "ClearSpeak_Matrix", "SpeakColNum",
+        expr, "the 3 by 1 column matrix; row 1; 1; row 2; 2; row 3; 3")?;
+    return Ok(());
+}
+
+#[test]
+fn row_matrix_1x2_speak_col_num() -> Result<()> {
+let expr = "<math display='block' xmlns='http://www.w3.org/1998/Math/MathML'>
+  <mrow>
+    <mrow><mo>[</mo>
+    <mrow>
+      <mtable>
+      <mtr>
+        <mtd><mn>1</mn> </mtd> <mtd><mn>2</mn> </mtd>
+      </mtr>
+      </mtable></mrow>
+    <mo>]</mo></mrow></mrow>
+  </math>";
+test_ClearSpeak("pt", "ClearSpeak_Matrix", "SpeakColNum",
+        expr, "the 1 by 2 row matrix; column 1; 1, column 2; 2")?;
+    return Ok(());
+}
+
+#[test]
+fn matrix_2x2_speak_col_num() -> Result<()> {
+let expr = "<math><mrow><mrow><mo>(</mo><mrow>
+    <mtable>
+    <mtr>
+        <mtd><mrow><msub><mi>b</mi><mrow><mn>1</mn><mn>1</mn></mrow></msub></mrow></mtd>
+        <mtd><mrow><msub><mi>b</mi><mrow><mn>1</mn><mn>2</mn></mrow></msub></mrow></mtd>
+    </mtr>
+    <mtr>
+        <mtd><mrow><msub><mi>b</mi><mrow><mn>2</mn><mn>1</mn></mrow></msub></mrow></mtd>
+        <mtd><mrow><msub><mi>b</mi><mrow><mn>2</mn><mn>2</mn></mrow></msub></mrow></mtd>
+    </mtr>
+    </mtable>
+    </mrow><mo>)</mo></mrow></mrow></math>";
+test_ClearSpeak("pt", "ClearSpeak_Matrix", "SpeakColNum",
+        expr, "the 2 by 2 matrix; row 1; column 1; b sub 1 1; column 2; b sub 1 2; \
+                                                row 2; column 1; b sub 2 1; column 2; b sub 2 2")?;
+    return Ok(());
+}
+
+
+#[test]
+fn simple_matrix_silent_col_num() -> Result<()> {
+let expr = "<math display='block' xmlns='http://www.w3.org/1998/Math/MathML'>
+  <mrow>
+    <mrow><mo>(</mo>
+    <mrow>
+      <mtable>
+      <mtr>
+        <mtd> <mn>2</mn> </mtd>
+        <mtd><mn>1</mn> </mtd>
+      </mtr>
+      <mtr>
+        <mtd><mn>7</mn> </mtd>
+        <mtd><mn>5</mn> </mtd>
+      </mtr>
+      </mtable></mrow>
+    <mo>)</mo></mrow></mrow>
+  </math>";
+  test_ClearSpeak("pt", "ClearSpeak_Matrix", "SilentColNum",
+        expr, "the 2 by 2 matrix; row 1; 2, 1; row 2; 7, 5")?;
+    return Ok(());
+}
+
+#[test]
+fn col_matrix_3x1_silent_col_num() -> Result<()> {
+let expr = "<math display='block' xmlns='http://www.w3.org/1998/Math/MathML'>
+  <mrow>
+    <mrow><mo>(</mo>
+    <mrow>
+      <mtable>
+      <mtr>
+        <mtd><mn>1</mn> </mtd>
+      </mtr>
+      <mtr>
+        <mtd><mn>2</mn> </mtd>
+      </mtr>
+      <mtr>
+        <mtd><mn>3</mn> </mtd>
+      </mtr>
+      </mtable></mrow>
+    <mo>)</mo></mrow></mrow>
+  </math>";
+test_ClearSpeak("pt", "ClearSpeak_Matrix", "SilentColNum",
+        expr, "the 3 by 1 column matrix; 1; 2; 3")?;
+    return Ok(());
+}
+
+#[test]
+fn row_matrix_1x2_silent_col_num() -> Result<()> {
+let expr = "<math display='block' xmlns='http://www.w3.org/1998/Math/MathML'>
+  <mrow>
+    <mrow><mo>[</mo>
+    <mrow>
+      <mtable>
+      <mtr>
+        <mtd><mn>1</mn> </mtd> <mtd><mn>2</mn> </mtd>
+      </mtr>
+      </mtable></mrow>
+    <mo>]</mo></mrow></mrow>
+  </math>";
+test_ClearSpeak("pt", "ClearSpeak_Matrix", "SilentColNum",
+        expr, "the 1 by 2 row matrix; 1, 2")?;
+    return Ok(());
+}
+
+#[test]
+fn matrix_2x2_silent_col_num() -> Result<()> {
+let expr = "<math><mrow><mrow><mo>(</mo><mrow>
+    <mtable>
+    <mtr>
+        <mtd><mrow><msub><mi>b</mi><mrow><mn>1</mn><mn>1</mn></mrow></msub></mrow></mtd>
+        <mtd><mrow><msub><mi>b</mi><mrow><mn>1</mn><mn>2</mn></mrow></msub></mrow></mtd>
+    </mtr>
+    <mtr>
+        <mtd><mrow><msub><mi>b</mi><mrow><mn>2</mn><mn>1</mn></mrow></msub></mrow></mtd>
+        <mtd><mrow><msub><mi>b</mi><mrow><mn>2</mn><mn>2</mn></mrow></msub></mrow></mtd>
+    </mtr>
+    </mtable>
+    </mrow><mo>)</mo></mrow></mrow></math>";
+test_ClearSpeak("pt", "ClearSpeak_Matrix", "SilentColNum",
+        expr, "the 2 by 2 matrix; row 1; b sub 1 1; b sub 1 2; \
+                                                row 2; b sub 2 1; b sub 2 2")?;
+    return Ok(());
+  }
+
+
+#[test]
+fn simple_matrix_end_matrix() -> Result<()> {
+let expr = "<math display='block' xmlns='http://www.w3.org/1998/Math/MathML'>
+  <mrow>
+    <mrow><mo>(</mo>
+    <mrow>
+      <mtable>
+      <mtr>
+        <mtd> <mn>2</mn> </mtd>
+        <mtd><mn>1</mn> </mtd>
+      </mtr>
+      <mtr>
+        <mtd><mn>7</mn> </mtd>
+        <mtd><mn>5</mn> </mtd>
+      </mtr>
+      </mtable></mrow>
+    <mo>)</mo></mrow></mrow>
+  </math>";
+  test_ClearSpeak("pt", "ClearSpeak_Matrix", "EndMatrix",
+        expr, "the 2 by 2 matrix; row 1; 2, 1; row 2; 7, 5; end matrix")?;
+    return Ok(());
+  }
+
+#[test]
+fn col_matrix_3x1_end_matrix() -> Result<()> {
+let expr = "<math display='block' xmlns='http://www.w3.org/1998/Math/MathML'>
+  <mrow>
+    <mrow><mo>(</mo>
+    <mrow>
+      <mtable>
+      <mtr>
+        <mtd><mn>1</mn> </mtd>
+      </mtr>
+      <mtr>
+        <mtd><mn>2</mn> </mtd>
+      </mtr>
+      <mtr>
+        <mtd><mn>3</mn> </mtd>
+      </mtr>
+      </mtable></mrow>
+    <mo>)</mo></mrow></mrow>
+  </math>";
+test_ClearSpeak("pt", "ClearSpeak_Matrix", "EndMatrix",
+        expr, "the 3 by 1 column matrix; 1; 2; 3; end matrix")?;
+    return Ok(());
+  }
+
+#[test]
+fn row_matrix_1x2_end_matrix() -> Result<()> {
+let expr = "<math display='block' xmlns='http://www.w3.org/1998/Math/MathML'>
+  <mrow>
+    <mrow><mo>[</mo>
+    <mrow>
+      <mtable>
+      <mtr>
+        <mtd><mn>1</mn> </mtd> <mtd><mn>2</mn> </mtd>
+      </mtr>
+      </mtable></mrow>
+    <mo>]</mo></mrow></mrow>
+  </math>";
+test_ClearSpeak("pt", "ClearSpeak_Matrix", "EndMatrix",
+        expr, "the 1 by 2 row matrix; 1, 2; end matrix")?;
+    return Ok(());
+  }
+
+#[test]
+fn matrix_2x2_end_matrix() -> Result<()> {
+let expr = "<math><mrow><mrow><mo>(</mo><mrow>
+    <mtable>
+    <mtr>
+        <mtd><mrow><msub><mi>b</mi><mrow><mn>1</mn><mn>1</mn></mrow></msub></mrow></mtd>
+        <mtd><mrow><msub><mi>b</mi><mrow><mn>1</mn><mn>2</mn></mrow></msub></mrow></mtd>
+    </mtr>
+    <mtr>
+        <mtd><mrow><msub><mi>b</mi><mrow><mn>2</mn><mn>1</mn></mrow></msub></mrow></mtd>
+        <mtd><mrow><msub><mi>b</mi><mrow><mn>2</mn><mn>2</mn></mrow></msub></mrow></mtd>
+    </mtr>
+    </mtable>
+    </mrow><mo>)</mo></mrow></mrow></math>";
+test_ClearSpeak("pt", "ClearSpeak_Matrix", "EndMatrix",
+        expr, "the 2 by 2 matrix; row 1; column 1; b sub 1 1; column 2; b sub 1 2; \
+                                                row 2; column 1; b sub 2 1; column 2; b sub 2 2; end matrix")?;
+    return Ok(());
+  }
+
+#[test]
+fn augmented_matrix_3x4_end_matrix() -> Result<()> {
+let expr = "<math display='block' xmlns='http://www.w3.org/1998/Math/MathML'>
+  <mrow>
+    <mrow><mo>[</mo>
+      <mtable columnalign='right right right right' columnlines='none none solid'>
+        <mtr>
+          <mtd><mn>1</mn></mtd>
+          <mtd><mn>2</mn></mtd>
+          <mtd><mrow><mo>-</mo><mn>1</mn></mrow></mtd>
+          <mtd><mn>3</mn></mtd>
+        </mtr>
+        <mtr>
+          <mtd><mrow><mo>-</mo><mn>3</mn></mrow></mtd>
+          <mtd><mn>3</mn></mtd>
+          <mtd><mrow><mo>-</mo><mn>1</mn></mrow></mtd>
+          <mtd><mn>2</mn></mtd>
+        </mtr>
+        <mtr>
+          <mtd><mn>2</mn></mtd>
+          <mtd><mn>3</mn></mtd>
+          <mtd><mn>2</mn></mtd>
+          <mtd><mrow><mo>-</mo><mn>1</mn></mrow></mtd>
+        </mtr>
+      </mtable>
+    <mo>]</mo></mrow>
+  </mrow>
+</math>";
+test_ClearSpeak("pt", "ClearSpeak_Matrix", "EndMatrix",
+        expr, "the 3 by 4 augmented matrix; row 1; column 1; 1, column 2; 2, column 3; negative 1, column 4; 3; \
+               row 2; column 1; negative 3, column 2; 3, column 3; negative 1, column 4; 2; \
+               row 3; column 1; 2, column 2; 3, column 3; 2, column 4; negative 1; end matrix")?;
+    test("pt", "SimpleSpeak",
+        expr, "the 3 by 4 augmented matrix; row 1; column 1; 1, column 2; 2, column 3; negative 1, column 4; 3; \
+               row 2; column 1; negative 3, column 2; 3, column 3; negative 1, column 4; 2; \
+               row 3; column 1; 2, column 2; 3, column 3; 2, column 4; negative 1; end matrix")?;
+    Ok(())
+  }
+
+
+#[test]
+fn simple_matrix_vector() -> Result<()> {
+let expr = "<math display='block' xmlns='http://www.w3.org/1998/Math/MathML'>
+  <mrow>
+    <mrow><mo>(</mo>
+    <mrow>
+      <mtable>
+      <mtr>
+        <mtd> <mn>2</mn> </mtd>
+        <mtd><mn>1</mn> </mtd>
+      </mtr>
+      <mtr>
+        <mtd><mn>7</mn> </mtd>
+        <mtd><mn>5</mn> </mtd>
+      </mtr>
+      </mtable></mrow>
+    <mo>)</mo></mrow></mrow>
+  </math>";
+  test_ClearSpeak("pt", "ClearSpeak_Matrix", "Vector",
+        expr, "the 2 by 2 matrix; row 1; 2, 1; row 2; 7, 5")?;
+    return Ok(());
+  }
+
+#[test]
+fn col_matrix_3x1_vector() -> Result<()> {
+let expr = "<math display='block' xmlns='http://www.w3.org/1998/Math/MathML'>
+  <mrow>
+    <mrow><mo>(</mo>
+    <mrow>
+      <mtable>
+      <mtr>
+        <mtd><mn>1</mn> </mtd>
+      </mtr>
+      <mtr>
+        <mtd><mn>2</mn> </mtd>
+      </mtr>
+      <mtr>
+        <mtd><mn>3</mn> </mtd>
+      </mtr>
+      </mtable></mrow>
+    <mo>)</mo></mrow></mrow>
+  </math>";
+test_ClearSpeak("pt", "ClearSpeak_Matrix", "Vector",
+        expr, "the 3 by 1 column vector; 1; 2; 3")?;
+    return Ok(());
+  }
+
+#[test]
+fn row_matrix_1x2_vector() -> Result<()> {
+let expr = "<math display='block' xmlns='http://www.w3.org/1998/Math/MathML'>
+  <mrow>
+    <mrow><mo>[</mo>
+    <mrow>
+      <mtable>
+      <mtr>
+        <mtd><mn>1</mn> </mtd> <mtd><mn>2</mn> </mtd>
+      </mtr>
+      </mtable></mrow>
+    <mo>]</mo></mrow></mrow>
+  </math>";
+test_ClearSpeak("pt", "ClearSpeak_Matrix", "Vector",
+        expr, "the 1 by 2 row vector; 1, 2")?;
+    return Ok(());
+  }
+
+#[test]
+fn matrix_2x2_vector() -> Result<()> {
+let expr = "<math><mrow><mrow><mo>(</mo><mrow>
+    <mtable>
+    <mtr>
+        <mtd><mrow><msub><mi>b</mi><mrow><mn>1</mn><mn>1</mn></mrow></msub></mrow></mtd>
+        <mtd><mrow><msub><mi>b</mi><mrow><mn>1</mn><mn>2</mn></mrow></msub></mrow></mtd>
+    </mtr>
+    <mtr>
+        <mtd><mrow><msub><mi>b</mi><mrow><mn>2</mn><mn>1</mn></mrow></msub></mrow></mtd>
+        <mtd><mrow><msub><mi>b</mi><mrow><mn>2</mn><mn>2</mn></mrow></msub></mrow></mtd>
+    </mtr>
+    </mtable>
+    </mrow><mo>)</mo></mrow></mrow></math>";
+test_ClearSpeak("pt", "ClearSpeak_Matrix", "Vector",
+        expr, "the 2 by 2 matrix; row 1; column 1; b sub 1 1; column 2; b sub 1 2; \
+                                                row 2; column 1; b sub 2 1; column 2; b sub 2 2")?;
+    return Ok(());
+  }
+
+
+#[test]
+fn simple_matrix_end_vector() -> Result<()> {
+let expr = "<math display='block' xmlns='http://www.w3.org/1998/Math/MathML'>
+  <mrow>
+    <mrow><mo>(</mo>
+    <mrow>
+      <mtable>
+      <mtr>
+        <mtd> <mn>2</mn> </mtd>
+        <mtd><mn>1</mn> </mtd>
+      </mtr>
+      <mtr>
+        <mtd><mn>7</mn> </mtd>
+        <mtd><mn>5</mn> </mtd>
+      </mtr>
+      </mtable></mrow>
+    <mo>)</mo></mrow></mrow>
+  </math>";
+  test_ClearSpeak("pt", "ClearSpeak_Matrix", "EndVector",
+        expr, "the 2 by 2 matrix; row 1; 2, 1; row 2; 7, 5; end matrix")?;
+    return Ok(());
+  }
+
+#[test]
+fn col_matrix_3x1_end_vector() -> Result<()> {
+let expr = "<math display='block' xmlns='http://www.w3.org/1998/Math/MathML'>
+  <mrow>
+    <mrow><mo>(</mo>
+    <mrow>
+      <mtable>
+      <mtr>
+        <mtd><mn>1</mn> </mtd>
+      </mtr>
+      <mtr>
+        <mtd><mn>2</mn> </mtd>
+      </mtr>
+      <mtr>
+        <mtd><mn>3</mn> </mtd>
+      </mtr>
+      </mtable></mrow>
+    <mo>)</mo></mrow></mrow>
+  </math>";
+test_ClearSpeak("pt", "ClearSpeak_Matrix", "EndVector",
+        expr, "the 3 by 1 column vector; 1; 2; 3; end vector")?;
+    return Ok(());
+  }
+
+#[test]
+fn row_matrix_1x2_end_vector() -> Result<()> {
+let expr = "<math display='block' xmlns='http://www.w3.org/1998/Math/MathML'>
+  <mrow>
+    <mrow><mo>[</mo>
+    <mrow>
+      <mtable>
+      <mtr>
+        <mtd><mn>1</mn> </mtd> <mtd><mn>2</mn> </mtd>
+      </mtr>
+      </mtable></mrow>
+    <mo>]</mo></mrow></mrow>
+  </math>";
+test_ClearSpeak("pt", "ClearSpeak_Matrix", "EndVector",
+        expr, "the 1 by 2 row vector; 1, 2; end vector")?;
+    return Ok(());
+  }
+
+#[test]
+fn matrix_2x2_end_vector() -> Result<()> {
+let expr = "<math><mrow><mrow><mo>(</mo><mrow>
+    <mtable>
+    <mtr>
+        <mtd><mrow><msub><mi>b</mi><mrow><mn>1</mn><mn>1</mn></mrow></msub></mrow></mtd>
+        <mtd><mrow><msub><mi>b</mi><mrow><mn>1</mn><mn>2</mn></mrow></msub></mrow></mtd>
+    </mtr>
+    <mtr>
+        <mtd><mrow><msub><mi>b</mi><mrow><mn>2</mn><mn>1</mn></mrow></msub></mrow></mtd>
+        <mtd><mrow><msub><mi>b</mi><mrow><mn>2</mn><mn>2</mn></mrow></msub></mrow></mtd>
+    </mtr>
+    </mtable>
+    </mrow><mo>)</mo></mrow></mrow></math>";
+test_ClearSpeak("pt", "ClearSpeak_Matrix", "EndVector",
+        expr, "the 2 by 2 matrix; row 1; column 1; b sub 1 1; column 2; b sub 1 2; \
+                                                 row 2; column 1; b sub 2 1; column 2; b sub 2 2; end matrix")?;
+  return Ok(());
+}
+
+
+#[test]
+fn matrix_binomial() -> Result<()> {
+  let expr = "<math>
+      <mo>(</mo><mrow>
+        <mtable><mtr><mtd><mn>3</mn></mtd></mtr><mtr><mtd><mn>2</mn></mtd></mtr></mtable>
+      </mrow><mo>)</mo>
+    </math>";
+  test_ClearSpeak("pt", "ClearSpeak_Matrix", "Combinatorics", expr, "3 choose 2")?;
+  return Ok(());
+}
+
+#[test]
+fn matrix_simple_table() -> Result<()> {
+  let expr = "<math>
+        <mtable><mtr><mtd><mn>3</mn></mtd></mtr><mtr><mtd><mn>2</mn></mtd></mtr></mtable>
+    </math>";
+  test("pt", "ClearSpeak", expr, "table with 2 rows and 1 column; row 1; column 1; 3; row 2; column 1; 2")
+}
+
+#[test]
+fn mtable_prefix_op() -> Result<()>{
+    // When a table is prefixed with a non-blank operator, assume it is something besides array intent
+    for (op, speech) in [("(", "open paren"),
+			 ("[", "open bracket"),
+			 ("|", "vertical line"),
+			 ("f", "f")] {
+	let expr = format!("<math>
+        <mo>{op}</mo><mtable><mtr><mtd><mn>3</mn></mtd></mtr><mtr><mtd><mn>2</mn></mtd></mtr></mtable>
+    </math>");
+	test("pt", "ClearSpeak", &expr, &format!("{speech}, 2 lines; line 1; 3; line 2; 2"))?;
+    }
+    Ok(())
+}
+
+#[test]
+fn mtable_blank_op() -> Result<()>{
+    // When a table is prefixed with a blank operator, still assume array intent
+    let expr = "<math>
+        <mo>\u{2062}</mo><mtable><mtr><mtd><mn>3</mn></mtd></mtr><mtr><mtd><mn>2</mn></mtd></mtr></mtable>
+    </math>";
+    test("pt", "ClearSpeak", expr, "; table with 2 rows and 1 column; row 1; column 1; 3; row 2; column 1; 2")
+}
+
+
+
+#[test]
+fn mtable_colspan_table() -> Result<()>{
+  let expr = "<math>
+        <mtable><mtr><mtd colspan=\"2\"><mn>3</mn></mtd></mtr><mtr><mtd><mn>2</mn></mtd><mtd><mn>4</mn></mtd></mtr></mtable>
+    </math>";
+  test("pt", "ClearSpeak", expr, "table with 2 rows and 2 columns; row 1; column 1; 3; row 2; column 1; 2, column 2; 4")
+}
+
+#[test]
+fn bug_mtable_rowspan_colspan() -> Result<()>{
+  // Currently, the code correctly computes the number of rows and
+  // columns, but it does not correctly compute the column number whnen
+  // colspans are involved.
+  let expr = "<math>
+        <mtable>
+           <mtr>
+             <mtd rowspan=\"2\" colspan=\"2\"><mi>a</mi></mtd>
+             <mtd rowspan=\"2\"><mi>b</mi></mtd>
+             <mtd colspan=\"2\"><mi>c</mi></mtd>
+           </mtr>
+           <mtr>
+             <mtd><mi>d</mi></mtd><mtd><mi>e</mi></mtd>
+           </mtr>
+        </mtable>
+    </math>";
+    test("pt", "ClearSpeak", expr,
+	 "table with 2 rows and 5 columns; row 1; column 1; eigh, column 2; b, column 3; c; row 2; column 1; d, column 2; e")
+}
+
+
+
+#[test]
+fn matrix_times() {
+  let expr = "<math>
+    <mfenced><mtable><mtr><mtd><mn>1</mn></mtd><mtd><mn>2</mn></mtd></mtr><mtr><mtd><mn>3</mn></mtd><mtd><mn>4</mn></mtd></mtr></mtable></mfenced>
+    <mfenced><mtable><mtr><mtd><mi>a</mi></mtd><mtd><mi>b</mi></mtd></mtr><mtr><mtd><mi>c</mi></mtd><mtd><mi>d</mi></mtd></mtr></mtable></mfenced>
+  </math>";
+  let _ = test("pt", "SimpleSpeak", expr,
+    "the 2 by 2 matrix; row 1; 1, 2; row 2; 3, 4; times, the 2 by 2 matrix; row 1; eigh, b; row 2; c, d");
+}
+
+#[test]
+fn unknown_mtable_property() -> Result<()> {
+  let expr = "<math display='block'>
+      <mtable intent=':system-of-equations:prefix($e1,$e1x)'>
+        <mtr arg='e1'>
+        <mtd columnalign='right'>
+          <mi>a</mi>
+        </mtd>
+        <mtd columnalign='center'>
+          <mo>=</mo>
+        </mtd>
+        <mtd intent='_($lhs)' columnalign='left'>
+          <mrow arg='lhs'>
+          <mi>b</mi>
+          <mo>+</mo>
+          <mi>c</mi>
+          <mo>&#x2212;</mo>
+          <mi>d</mi>
+        </mrow>
+        </mtd>
+        </mtr>
+        <mtr arg='e1x'>
+        <mtd intent='_' columnalign='right'></mtd>
+        <mtd intent='_' columnalign='center'></mtd>
+        <mtd arg='rhs' columnalign='left'>
+          <mo form='infix'>+</mo>
+          <mi>e</mi>
+          <mo>&#x2212;</mo>
+          <mi>f</mi>
+        </mtd>
+        </mtr>
+      </mtable>
+    </math>";
+    test("pt", "ClearSpeak",  expr,
+         "2 lines; line 1; eigh is equal to, b plus c minus d; line 2; plus e minus f")?;
+    return Ok(());
+  }
+
+
+#[test]
+fn zero_matrix() -> Result<()> {
+  let expr = "<math>
+      <mo>[</mo>
+      <mtable>
+        <mtr><mtd><mn>0</mn></mtd><mtd><mn>0</mn></mtd></mtr>
+        <mtr><mtd><mn>0</mn></mtd><mtd><mn>0</mn></mtd></mtr>
+      </mtable>
+      <mo>]</mo>
+  </math>";
+  test("pt", "SimpleSpeak", expr,
+    "the 2 by 2 zero matrix")?;
+    return Ok(());
+  }
+
+#[test]
+fn identity_matrix() -> Result<()> {
+  let expr = "<math>
+      <mo>(</mo>
+      <mtable>
+        <mtr><mtd><mn>1</mn></mtd><mtd><mn>0</mn></mtd><mtd><mn>0</mn></mtd></mtr>
+        <mtr><mtd><mn>0</mn></mtd><mtd><mn>1</mn></mtd><mtd><mn>0</mn></mtd></mtr>
+        <mtr><mtd><mn>0</mn></mtd><mtd><mn>0</mn></mtd><mtd><mn>1</mn></mtd></mtr>
+      </mtable>
+      <mo>)</mo>
+  </math>";
+  test("pt", "SimpleSpeak", expr,
+    "the 3 by 3 identity matrix")?;
+    return Ok(());
+  }
+
+#[test]
+fn identity_matrix_false_positive_negative_one() -> Result<()> {
+  let expr = "<math>
+      <mo>[</mo>
+      <mtable>
+        <mtr><mtd><mn>1</mn></mtd><mtd><mn>0</mn></mtd></mtr>
+        <mtr><mtd><mn>0</mn></mtd><mtd><mn>-1</mn></mtd></mtr>
+      </mtable>
+      <mo>]</mo>
+  </math>";
+  test_prefs("pt", "SimpleSpeak", vec![("Verbosity", "Terse")],
+      expr, "the 2 by 2 diagonal matrix; column 1; 1; column 2; negative 1")?;
+  Ok(())
+}
+
+#[test]
+fn identity_matrix_false_positive_zero_diagonal() -> Result<()> {
+  let expr = "<math>
+      <mo>[</mo>
+      <mtable>
+        <mtr><mtd><mn>1</mn></mtd><mtd><mn>0</mn></mtd></mtr>
+        <mtr><mtd><mn>0</mn></mtd><mtd><mn>0</mn></mtd></mtr>
+      </mtable>
+      <mo>]</mo>
+  </math>";
+  test_prefs("pt", "SimpleSpeak", vec![("Verbosity", "Terse")],
+      expr, "the 2 by 2 diagonal matrix; column 1; 1")?;
+  Ok(())
+}
+
+#[test]
+fn diagonal_matrix() -> Result<()> {
+  let expr = "<math>
+      <mo>(</mo>
+      <mtable>
+        <mtr><mtd><mn>2</mn></mtd><mtd><mn>0</mn></mtd><mtd><mn>0</mn></mtd></mtr>
+        <mtr><mtd><mn>0</mn></mtd><mtd><mn>1</mn></mtd><mtd><mn>0</mn></mtd></mtr>
+        <mtr><mtd><mn>0</mn></mtd><mtd><mn>0</mn></mtd><mtd><msup><mi>x</mi><mn>2</mn></msup></mtd></mtr>
+      </mtable>
+      <mo>)</mo>
+  </math>";
+  test_prefs("pt", "SimpleSpeak", vec![("Verbosity", "Terse")],
+      expr, "the 3 by 3 diagonal matrix; column 1; 2; column 2; 1; column 3; x squared")?;
+  // test_prefs("pt", "SimpleSpeak", vec![("Verbosity", "Verbose")],
+  //     expr, "the 3 by 3 diagonal matrix; row 1, column 1, 2; row 2, column 2, 1; row 3, column 3, x squared");
+    return Ok(());
+  }
+
+#[test]
+fn single_line_with_label() -> Result<()> {
+  let expr = r#"<math>
+  <mtable class="gather" displaystyle="true" intent=":system-of-equations">
+    <mtr>
+      <mtd intent=":equation-label"> <mtext>(2)</mtext> </mtd>
+      <mtd> <mi>ð‘</mi> <mo>=</mo> <mn>2</mn> </mtd>
+    </mtr>
+  </mtable>
+  </math>"#;
+  test_prefs("pt", "ClearSpeak", vec![("Verbosity", "Terse")],
+      expr, "1 line, with label 2; b equals 2")?;
+  test_prefs("pt", "SimpleSpeak", vec![("Verbosity", "Terse")],
+      expr, "1 equation, with label 2; b equals 2")?;
+    return Ok(());
+  }

--- a/tests/Languages/pt/shared.rs
+++ b/tests/Languages/pt/shared.rs
@@ -1,0 +1,610 @@
+﻿/// Tests for rules shared between various speech styles:
+/// *  modified var
+use crate::common::*;
+use anyhow::Result;
+
+#[test]
+fn modified_vars() -> Result<()> {
+    let expr = "<math> <mrow>
+        <mover> <mi>a</mi> <mo>`</mo> </mover>
+        <mover> <mi>b</mi> <mo>~</mo> </mover>
+        <mover> <mi>c</mi> <mo>&#x0306;</mo> </mover>
+        <mover> <mi>b</mi> <mo>&#x030c;</mo> </mover>
+        <mover> <mi>c</mi> <mo>`</mo> </mover>  <mo>+</mo>
+        <mover> <mi>r</mi> <mo>Ë‡</mo> </mover>  <mo>+</mo>
+        <mover> <mi>x</mi> <mo>.</mo> </mover>
+        <mover> <mi>y</mi> <mo>&#x2D9;</mo> </mover>
+        <mover> <mi>z</mi> <mo>&#x00A8;</mo> </mover>
+        <mover> <mi>u</mi> <mo>&#x20DB;</mo> </mover>
+        <mover> <mi>v</mi> <mo>&#x20DC;</mo> </mover> <mo>+</mo>
+        <mover> <mi>x</mi> <mo>^</mo> </mover> <mo>+</mo>
+        <mover> <mi>t</mi> <mo>â†’</mo> </mover>
+        </mrow> </math>";
+    test("pt", "SimpleSpeak", expr, 
+        "eigh grave, b tilde, c breve, b check, c grave; plus \
+            r check, plus; x dot, y dot, z double dot, u triple dot, v quadruple dot; plus x hat, plus vector t")?;
+            return Ok(());
+
+}
+
+#[test]
+fn limit() -> Result<()> {
+    let expr = "<math>
+            <munder>
+            <mo>lim</mo>
+            <mrow>  <mi>x</mi> <mo>&#x2192;</mo>  <mn>0</mn>  </mrow>
+            </munder>
+            <mrow>
+            <mfrac>
+                <mrow>  <mi>sin</mi>  <mo>&#x2061;</mo> <mi>x</mi> </mrow>
+                <mi>x</mi>
+            </mfrac>
+            </mrow>
+        </math>";
+    test("pt", "SimpleSpeak", expr, "the limit as x approaches 0, of, fraction, sine of x, over x, end fraction")?;
+    test_prefs("pt", "SimpleSpeak", vec![("Impairment", "LearningDisability")], expr,
+            "the limit as x approaches 0, of; sine of x, over x")?;
+            return Ok(());
+
+}
+
+#[test]
+fn limit_from_below() -> Result<()> {
+    let expr = "<math>
+            <munder>
+            <mo>lim</mo>
+            <mrow>  <mi>x</mi> <mo>â†—</mo>  <mn>0</mn>  </mrow>
+            </munder>
+            <mrow>
+                <mrow>  <mi>sin</mi>  <mo>&#x2061;</mo> <mi>x</mi> </mrow>
+            </mrow>
+        </math>";
+    test("pt", "SimpleSpeak", expr, "the limit as x approaches from below 0, of sine of x")?;
+    return Ok(());
+
+}
+
+
+#[test]
+fn binomial_mmultiscripts() -> Result<()> {
+    let expr = "<math><mmultiscripts><mi>C</mi><mi>m</mi><none/><mprescripts/><mi>n</mi><none/></mmultiscripts></math>";
+    test("pt", "SimpleSpeak", expr, "n choose m")?;
+    return Ok(());
+
+}
+
+#[test]
+fn binomial_mmultiscripts_other() -> Result<()> {
+    let expr = "<math><mmultiscripts><mi>C</mi><mi>m</mi><none/><mprescripts/><none/><mi>n</mi></mmultiscripts></math>";
+    test("pt", "SimpleSpeak", expr, "n choose m")?;
+    return Ok(());
+
+}
+
+#[test]
+fn binomial_subscript() -> Result<()> {  // C_{n,k}
+    let expr = "<math><msub><mi>C</mi><mrow><mi>n</mi><mo>,</mo><mi>m</mi></mrow></msub></math>";
+    test("pt", "SimpleSpeak", expr, "n choose m")?;
+    return Ok(());
+
+}
+
+#[test]
+fn permutation_mmultiscripts() -> Result<()> {
+    let expr = "<math><mmultiscripts><mi>P</mi><mi>k</mi><none/><mprescripts/><mi>n</mi><none/></mmultiscripts></math>";
+    test("pt", "SimpleSpeak", expr, "k permutations of n")?;
+    return Ok(());
+
+}
+
+#[test]
+fn permutation_mmultiscripts_sup() -> Result<()> {
+    let expr = "<math><mmultiscripts><mi>P</mi><mi>k</mi><none/><mprescripts/><none/><mi>n</mi></mmultiscripts></math>";
+    test("pt", "SimpleSpeak", expr, "k permutations of n")?;
+    return Ok(());
+
+}
+
+#[test]
+fn permutation_msubsup() -> Result<()> {
+    let expr = "<math><msubsup><mi>P</mi><mi>k</mi><mi>n</mi></msubsup></math>";
+    test("pt", "SimpleSpeak", expr, "k permutations of n")?;
+    return Ok(());
+
+}
+
+#[test]
+fn tensor_mmultiscripts() -> Result<()> {
+    let expr = "<math><mmultiscripts>
+            <mi>R</mi> <mi>i</mi><none/> <none/><mi>j</mi> <mi>k</mi><none/> <mi>l</mi><none/> 
+        </mmultiscripts></math>";
+    test_prefs("pt", "SimpleSpeak", vec![("Verbosity", "Verbose")], expr,
+            "cap r with 4 postscripts, subscript i superscript j subscript k subscript l")?;
+    test_prefs("pt", "SimpleSpeak", vec![("Verbosity", "Medium")], expr,
+            "cap r with 4 postscripts, sub i super j sub k sub l")?;
+            return Ok(());
+
+}
+
+#[test]
+fn huge_num_mmultiscripts() -> Result<()> {
+    let expr = "<math><mmultiscripts>
+            <mi>R</mi> <mi>i</mi><none/> <none/><mi>j</mi> <mi>k</mi><none/> <mi>l</mi><none/> <mi>m</mi><none/>
+            <mprescripts/> <mi>I</mi><none/> <none/><mi>J</mi> <mi>K</mi><none/> <mi>L</mi><none/>
+        </mmultiscripts></math>";
+    test_prefs("pt", "SimpleSpeak", vec![("Verbosity", "Verbose")], expr,
+            "cap r with 4 prescripts, pre subscript cap i, pre superscript cap j and alternating prescripts cap k none cap l none end prescripts and with 5 postscripts, subscript i superscript j subscript k subscript l and alternating scripts m none end scripts")?;
+            return Ok(());
+
+}
+
+#[test]
+fn prime() -> Result<()> {
+    let expr = "<math> <msup><mi>x</mi><mo >&#x2032;</mo></msup> </math>";
+    test("pt", "SimpleSpeak", expr, "x prime")?;
+    return Ok(());
+
+}
+
+#[test]
+fn given() -> Result<()> {
+    let expr = "<math><mi>P</mi><mo>(</mo><mi>A</mi><mo>|</mo><mi>B</mi><mo>)</mo></math>";
+    test("pt", "SimpleSpeak", expr, "cap p, open paren, cap eigh given cap b, close paren")?;
+    test("pt", "ClearSpeak", expr,  "cap p, open paren, cap eigh given cap b, close paren")?; // not good, but follows the spec
+    return Ok(());
+
+}
+
+#[test]
+fn simple_msubsup() -> Result<()> {
+    let expr = "<math>
+            <mstyle displaystyle='true' scriptlevel='0'>
+            <msubsup>
+                <mi>x</mi>
+                <mrow>
+                <mi>k</mi>
+                </mrow>
+                <mrow>
+                <mi>i</mi>
+                </mrow>
+            </msubsup>
+            </mstyle>
+        </math>";
+    test("pt", "ClearSpeak", expr, "x sub k, to the i-th power")?;
+    return Ok(());
+
+}
+
+#[test]
+fn non_simple_msubsup() -> Result<()> {
+  let expr = "<math><msubsup><mi>i</mi><mrow><mi>j</mi><mo>&#x2212;</mo><mn>2</mn></mrow><mi>k</mi></msubsup></math>";
+  test("pt", "SimpleSpeak", expr, "i sub j minus 2 end sub, to the k-th")?;
+  test("pt", "ClearSpeak", expr, "i sub j minus 2 end sub, to the k-th power")?;
+  test_prefs("pt", "SimpleSpeak", vec![("Impairment", "LearningDisability")], expr,
+          "i sub j minus 2, to the k-th")?;
+          return Ok(());
+
+}
+
+#[test]
+fn presentation_mathml_in_semantics() -> Result<()> {
+    let expr = "<math>
+        <semantics>
+            <annotation encoding='application/x-tex'>{\\displaystyle x_k^i}</annotation>
+            <annotation-xml encoding='MathML-Presentation'>
+                <msubsup>
+                    <mi>x</mi>
+                    <mrow>
+                    <mi>k</mi>
+                    </mrow>
+                    <mrow>
+                    <mi>i</mi>
+                    </mrow>
+                </msubsup>
+            </annotation-xml>
+        </semantics>
+    </math>";
+    test("pt", "ClearSpeak", expr, "x sub k, to the i-th power")?;
+    return Ok(());
+
+}
+
+#[test]
+fn roman_like_superscript_identifier_is_not_chemistry() -> Result<()> {
+    // Regression test for https://github.com/daisy/MathCAT/issues/528
+    let expr = "<math>
+        <mi>I</mi>
+        <mo>=</mo>
+        <mo>âˆ’</mo>
+        <mi>b</mi>
+        <mi>r</mi>
+        <mo>+</mo>
+        <msup>
+            <mi>z</mi>
+            <mi>I</mi>
+        </msup>
+    </math>";
+    test("pt", "ClearSpeak", expr, "cap i is equal to, negative b r, plus z to the cap i-th power")?;
+    Ok(())
+}
+
+#[test]
+fn roman_like_identifier_sequence_is_not_number() -> Result<()> {
+    // Regression test for https://github.com/daisy/MathCAT/issues/528
+    let expr = "<math>
+        <mi>C</mi>
+        <mo>+</mo>
+        <mi>I</mi>
+        <mo>+</mo>
+        <mi>X</mi>
+    </math>";
+    test("pt", "ClearSpeak", expr, "cap c plus cap i plus cap x")?;
+    Ok(())
+}
+
+
+#[test]
+fn ignore_period() -> Result<()> {
+    // from https://en.wikipedia.org/wiki/Probability
+    let expr = "<math>
+    <semantics>
+    <annotation encoding='application/x-tex'>{\\displaystyle x_k^i}</annotation>
+    <annotation-xml encoding='MathML-Presentation'>
+      <mrow>
+        <mstyle displaystyle='true' scriptlevel='0'>
+          <mi>P</mi>
+          <mo stretchy='false'>(</mo>
+          <mi>A</mi>
+          <mrow>
+            <mstyle displaystyle='false' scriptlevel='0'>
+              <mtext>&nbsp;and&nbsp;</mtext>
+            </mstyle>
+          </mrow>
+          <mi>B</mi>
+          <mo stretchy='false'>)</mo>
+          <mo>=</mo>
+          <mi>P</mi>
+          <mo stretchy='false'>(</mo>
+          <mi>A</mi>
+          <mo>âˆ©<!-- âˆ© --></mo>
+          <mi>B</mi>
+          <mo stretchy='false'>)</mo>
+          <mo>=</mo>
+          <mi>P</mi>
+          <mo stretchy='false'>(</mo>
+          <mi>A</mi>
+          <mo stretchy='false'>)</mo>
+          <mi>P</mi>
+          <mo stretchy='false'>(</mo>
+          <mi>B</mi>
+          <mo stretchy='false'>)</mo>
+          <mo>.</mo>
+        </mstyle>
+      </mrow>
+      </annotation-xml>
+    </semantics>  
+  </math>";
+    test("pt", "SimpleSpeak", expr, "cap p; open paren, cap eigh and cap b; close paren; is equal to; cap p, open paren, cap eigh intersection cap b; close paren; is equal to, cap p of cap eigh, cap p of cap b")?;
+    return Ok(());
+
+}
+
+#[test]
+fn ignore_mtext_period() -> Result<()> {
+    let expr = "<math><mrow><mrow><mo>{</mo><mn>2</mn><mo>}</mo></mrow><mtext>.</mtext></mrow></math>";
+    test("pt", "SimpleSpeak", expr, "the set 2")?;
+    return Ok(());
+
+}
+
+#[test]
+fn ignore_comma() -> Result<()> {
+    // from https://en.wikipedia.org/wiki/Probability
+    let expr = "<math>
+    <mrow>
+      <mstyle displaystyle='true' scriptlevel='0'>
+        <mi>Ï•<!-- Ï• --></mi>
+        <mo stretchy='false'>(</mo>
+        <mi>x</mi>
+        <mo stretchy='false'>)</mo>
+        <mo>=</mo>
+        <mi>c</mi>
+        <msup>
+          <mi>e</mi>
+          <mrow>
+            <mo>âˆ’<!-- âˆ’ --></mo>
+            <msup>
+              <mi>h</mi>
+              <mrow>
+                <mn>2</mn>
+              </mrow>
+            </msup>
+            <msup>
+              <mi>x</mi>
+              <mrow>
+                <mn>2</mn>
+              </mrow>
+            </msup>
+          </mrow>
+        </msup>
+        <mo>,</mo>
+      </mstyle>
+    </mrow>
+</math>";
+    test("pt", "SimpleSpeak", expr, "phi of x is equal to; c times, e raised to the negative h squared, x squared power")?;
+    return Ok(());
+
+}
+
+#[test]
+#[ignore] // issue #14
+fn ignore_period_and_space() -> Result<()> {
+    // from https://en.wikipedia.org/wiki/Probability
+    let expr = "<math>
+      <mrow>
+        <mstyle displaystyle='true' scriptlevel='0'>
+          <mi>P</mi>
+          <mo stretchy='false'>(</mo>
+          <mi>A</mi>
+          <mo>âˆ£<!-- âˆ£ --></mo>
+          <mi>B</mi>
+          <mo stretchy='false'>)</mo>
+          <mo>=</mo>
+          <mrow>
+            <mfrac>
+              <mrow>
+                <mi>P</mi>
+                <mo stretchy='false'>(</mo>
+                <mi>A</mi>
+                <mo>âˆ©<!-- âˆ© --></mo>
+                <mi>B</mi>
+                <mo stretchy='false'>)</mo>
+              </mrow>
+              <mrow>
+                <mi>P</mi>
+                <mo stretchy='false'>(</mo>
+                <mi>B</mi>
+                <mo stretchy='false'>)</mo>
+              </mrow>
+            </mfrac>
+          </mrow>
+          <mo>.</mo>
+          <mspace width='thinmathspace'></mspace>
+        </mstyle>
+      </mrow>
+</math>";
+    test("pt", "ClearSpeak", expr, "cap p, open paren, cap eigh divides cap b, close paren; is equal to; the fraction with numerator; cap p, open paren, cap eigh intersection cap b; close paren; and denominator cap p of cap b")?;
+    return Ok(());
+
+}
+
+
+#[test]
+fn bug_199_2pi() -> Result<()> {
+  let expr = "<math>
+      <mrow>
+        <mo stretchy=\"false\" form=\"prefix\">[</mo>
+        <mspace width=\"0.333em\"></mspace>
+        <mn>0</mn>
+        <mspace width=\"0.333em\"></mspace>
+        <mo>,</mo>
+        <mspace width=\"0.333em\"></mspace>
+        <mn>2</mn>
+        <mi>Ï€</mi>
+        <mspace width=\"0.333em\"></mspace>
+        <mo stretchy=\"false\" form=\"postfix\">)</mo>
+      </mrow>
+    </math>";
+  test("pt", "SimpleSpeak",expr, "the closed open interval from 0 to 2 pi")?;
+  return Ok(());
+
+}
+
+#[test]
+fn caret_and_hat() -> Result<()> {
+  let expr = "<math><mi>x</mi><mo>^</mo><mn>2</mn><mo>+</mo><mover><mi>y</mi><mo>^</mo></mover></math>";
+  test("pt", "SimpleSpeak",expr, "x caret 2 plus y hat")?;
+  return Ok(());
+
+}
+
+#[test]
+fn dots() -> Result<()> {
+  let expr = "<math>
+         <mover><mi>x</mi><mo>.</mo></mover><mo>+</mo>
+         <mover><mi>x</mi><mo>..</mo></mover><mo>+</mo>
+         <mover><mi>x</mi><mo>...</mo></mover>
+    </math>";
+  test("pt", "SimpleSpeak",expr, "x dot, plus x double dot, plus x triple dot")?;
+  return Ok(());
+}
+
+#[test]
+fn mn_with_space() -> Result<()> {
+  let expr = "<math><mn>1 234 567</mn></math>";
+  test_prefs("pt", "SimpleSpeak", vec![("DecimalSeparators", "."), ("BlockSeparators", " ,")], expr, "1234567")?;
+  return Ok(());
+
+}
+
+#[test]
+fn ignore_bold() -> Result<()> {
+  let expr = r#"<math>
+				<mi mathvariant="bold-italic">x</mi>
+				<mo>=</mo>
+				<mn>2</mn>
+				<mrow>
+				<mi>ð’”ð’Šð’</mi>
+				<mo>&#x2061;</mo>
+				<mrow><mi mathvariant="bold-italic">t</mi></mrow>
+				</mrow>
+				<mo>-</mo>
+				<mn>1</mn>
+			</math>"#; 
+  test_prefs("pt", "SimpleSpeak", vec![("IgnoreBold", "false")],
+             expr, "bold x is equal to, 2 sine of bold t, minus 1")?;
+  test_prefs("pt", "SimpleSpeak", vec![("IgnoreBold", "true")],
+             expr, "x is equal to, 2 sine of t, minus 1")?;
+             return Ok(());
+
+}
+
+#[test]
+fn mn_with_block_and_decimal_separators() -> Result<()> {
+  let expr = "<math><mn>1,234.56</mn></math>";                                       // may want to change this for another language
+  test_prefs("pt", "SimpleSpeak", vec![("DecimalSeparators", "."), ("BlockSeparators", " ,")], expr, "1234.56")?;
+  return Ok(());
+
+}
+
+#[test]
+fn divergence() -> Result<()> {
+  let expr = "<math><mo>&#x2207;</mo><mo>&#xB7;</mo><mi mathvariant='normal'>F</mi></math>";                                       // may want to change this for another language
+  test_prefs("pt", "SimpleSpeak", vec![("Verbosity", "Terse")], expr, "div cap f")?;
+  test_prefs("pt", "SimpleSpeak", vec![("Verbosity", "Verbose")], expr, "divergence of cap f")?;
+  return Ok(());
+
+}
+
+#[test]
+fn curl() -> Result<()> {
+  let expr = "<math><mo>&#x2207;</mo><mo>&#xD7;</mo><mi mathvariant='normal'>F</mi></math>";          
+  // may want to change this for another language
+  test_prefs("pt", "SimpleSpeak", vec![("Verbosity", "Terse")], expr, "curl cap f")?;
+  test_prefs("pt", "SimpleSpeak", vec![("Verbosity", "Verbose")], expr, "curl of cap f")?;
+  return Ok(());
+
+}
+
+#[test]
+fn gradient() -> Result<()> {
+  let expr = "<math><mo>&#x2207;</mo><mi mathvariant='normal'>F</mi></math>";          
+  // may want to change this for another language
+  test_prefs("pt", "SimpleSpeak", vec![("Verbosity", "Terse")], expr, "del cap f")?;
+  test_prefs("pt", "SimpleSpeak", vec![("Verbosity", "Verbose")], expr, "gradient of cap f")?;
+  return Ok(());
+
+}
+
+#[test]
+fn literal_speak_perpendicular() -> Result<()> {
+  let expr = r#"<math data-latex='\vec{A} \perp \vec{B}' display='block'>
+  <mrow data-changed='added'>
+    <mover data-latex='\vec{A}'>
+      <mi data-latex='A'>A</mi>
+      <mo stretchy='false'>â†’</mo>
+    </mover>
+    <mo intent='perpendicular-to'>âŠ¥</mo>
+    <mover data-latex='\vec{B}'>
+      <mi data-latex='B'>B</mi>
+      <mo stretchy='false'>â†’</mo>
+    </mover>
+  </mrow>
+ </math>"#; 
+  test("pt", "LiteralSpeak", expr, "cap eigh right arrow; perpendicular to, cap b right arrow")?;
+  return Ok(());
+
+}
+
+#[test]
+fn literal_speak_chars() -> Result<()> {
+  let expr = r#"<math>
+        <mfenced open="|" close="|">
+            <mrow>
+                <mi>x</mi><mo>&#xD7;</mo><mi>y</mi>
+                <mo>&#xB7;</mo>
+                <mi>z</mi><mo>/</mo><mn>2</mn>
+                <mo>+</mo>
+                <mi>a</mi><mo>&#x2225;</mo><mi>b</mi>
+                <mo>+</mo>
+                <mi>x</mi><mo>!</mo>
+            </mrow>
+        </mfenced>
+    </math>"#; 
+  test("pt", "LiteralSpeak", expr, "vertical line; x cross, y dot z slash 2; plus eigh; double vertical line, b plus x exclamation point; vertical line")?;
+  return Ok(());
+
+}
+
+#[test]
+fn literal_speak_with_name() -> Result<()> {
+  let expr = r#"<math intent='forced($x)'>
+      <mrow arg="x">
+        <mi>f</mi>
+        <mo data-changed='added'>&#x2061;</mo>
+        <mrow data-changed='added'>
+          <mo>(</mo>
+          <mrow data-changed='added'>
+            <mi>x</mi>
+            <mo>!</mo>
+          </mrow>
+          <mo>)</mo>
+        </mrow>
+      </mrow>
+    </math>"#;
+  test("pt", "LiteralSpeak", expr, "forced f, left paren x exclamation point, right paren")?;
+  return Ok(());
+
+}
+
+#[test]
+fn literal_speak_with_property() -> Result<()> {
+  let expr = r#"<math intent=':prefix'>
+      <mrow arg="x">
+        <mi>f</mi>
+        <mo data-changed='added'>&#x2061;</mo>
+        <mrow data-changed='added'>
+          <mo>(</mo>
+          <mrow data-changed='added'>
+            <mi>x</mi>
+            <mo>!</mo>
+          </mrow>
+          <mo>)</mo>
+        </mrow>
+      </mrow>
+    </math>"#; 
+  test("pt", "LiteralSpeak", expr, "f, left paren x exclamation point, right paren")?;
+  return Ok(());
+
+}
+
+#[test]
+fn literal_intent_property() -> Result<()> {
+  let expr = r#"<math data-latex='\vec{A} \perp \vec{B}' display='block'>
+  <mrow intent=":literal">
+    <mover data-latex='\vec{A}'>
+      <mi data-latex='A'>A</mi>
+      <mo stretchy='false'>â†’</mo>
+    </mover>
+    <mo intent='perpendicular-to'>âŠ¥</mo>
+    <mover data-latex='\vec{B}'>
+      <mi data-latex='B'>B</mi>
+      <mo stretchy='false'>â†’</mo>
+    </mover>
+  </mrow>
+ </math>"#; 
+  test("pt", "SimpleSpeak", expr, "cap eigh right arrow; perpendicular to, cap b right arrow")?;
+  return Ok(());
+
+}
+
+#[test]
+fn literal_intent_property_with_name() -> Result<()> {
+  let expr = r#"<math intent='forced:literal($x)'>
+      <mrow arg="x">
+        <mi>f</mi>
+        <mo data-changed='added'>&#x2061;</mo>
+        <mrow data-changed='added'>
+          <mo>(</mo>
+          <mrow data-changed='added'>
+            <mi>x</mi>
+            <mo>!</mo>
+          </mrow>
+          <mo>)</mo>
+        </mrow>
+      </mrow>
+    </math>"#; 
+  test("pt", "SimpleSpeak", expr, "forced f, open paren x exclamation point, close paren")?;
+  return Ok(());
+
+}

--- a/tests/Languages/pt/units.rs
+++ b/tests/Languages/pt/units.rs
@@ -1,0 +1,549 @@
+﻿/// Tests for rules shared between various speech styles:
+/// *  modified var
+use crate::common::*;
+use anyhow::Result;
+
+// The basic layout of the tests is:
+// 1. Sweep through all the SI prefixes
+// 2. Sweep through each group of SI units
+//    a) with both singular and plural without prefixes
+//    b) with both singular and plural with one prefix
+// 3. Sweep through each group of units that don't take SI prefixes
+// These are broken into chunks so it is easier to see errors, when there are errors
+
+#[test]
+fn prefix_sweep() -> Result<()> {
+    let expr = r#"<math>
+        <mi intent=":unit">Qg</mi><mo>,</mo>
+        <mi intent=":unit">Rg</mi><mo>,</mo>
+        <mi intent=":unit">Yg</mi><mo>,</mo>
+        <mi intent=":unit">Zg</mi><mo>,</mo>
+        <mi intent=":unit">Eg</mi><mo>,</mo>
+        <mi intent=":unit">Pg</mi><mo>,</mo>
+        <mi intent=":unit">Tg</mi><mo>,</mo>
+        <mi intent=":unit">Gg</mi><mo>,</mo>
+        <mi intent=":unit">Mg</mi><mo>,</mo>
+        <mi intent=":unit">kg</mi><mo>,</mo>
+        <mi intent=":unit">hg</mi><mo>,</mo>
+        <mi intent=":unit">dag</mi><mo>,</mo>
+        <mi intent=":unit">dg</mi><mo>,</mo>
+        <mi intent=":unit">cg</mi><mo>,</mo>
+        <mi intent=":unit">mg</mi><mo>,</mo>
+        <mi intent=":unit">Âµg</mi><mo>,</mo>
+        <mi intent=":unit">ng</mi><mo>,</mo>
+        <mi intent=":unit">pg</mi><mo>,</mo>
+        <mi intent=":unit">fg</mi><mo>,</mo>
+        <mi intent=":unit">ag</mi><mo>,</mo>
+        <mi intent=":unit">zg</mi><mo>,</mo>
+        <mi intent=":unit">yg</mi><mo>,</mo>
+        <mi intent=":unit">rg</mi><mo>,</mo>
+        <mi intent=":unit">qg</mi>
+        </math>"#;
+    test("pt", "SimpleSpeak", expr, 
+        "quetta-grams, comma, \
+                ronna-grams, comma, \
+                yotta-grams, comma, \
+                zetta-grams, comma, \
+                exa-grams, comma, \
+                peta-grams, comma, \
+                tera-grams, comma, \
+                giga-grams, comma, \
+                mega-grams, comma, \
+                kilo-grams, comma, \
+                hecto-grams, comma, \
+                deka-grams, comma, \
+                deci-grams, comma, \
+                centi-grams, comma, \
+                milli-grams, comma, \
+                micro-grams, comma, \
+                nano-grams, comma, \
+                pico-grams, comma, \
+                femto-grams, comma, \
+                atto-grams, comma, \
+                zepto-grams, comma, \
+                yocto-grams, comma, \
+                ronto-grams, comma, \
+                quecto-grams")?;
+                return Ok(());
+
+}
+
+#[test]
+fn si_base() -> Result<()> {
+    let expr = r#"<math>
+        <mn>1</mn><mi intent=":unit">A</mi><mo>,</mo><mn>2</mn><mi intent=":unit">A</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">cd</mi><mo>,</mo><mn>2</mn><mi intent=":unit">cd</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">K</mi><mo>,</mo><mn>2</mn><mi intent=":unit">K</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">â„ª</mi><mo>,</mo><mn>2</mn><mi intent=":unit">â„ª</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">g</mi><mo>,</mo><mn>2</mn><mi intent=":unit">g</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">m</mi><mo>,</mo><mn>2</mn><mi intent=":unit">m</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">mol</mi><mo>,</mo><mn>2</mn><mi intent=":unit">mol</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">s</mi><mo>,</mo><mn>2</mn><mi intent=":unit">s</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">â€³</mi><mo>,</mo><mn>2</mn><mi intent=":unit">â€³</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">&quot;</mi><mo>,</mo><mn>2</mn><mi intent=":unit">&quot;</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">sec</mi><mo>,</mo><mn>2</mn><mi intent=":unit">sec</mi>
+    </math>"#;
+    test("pt", "SimpleSpeak", expr, 
+        "1 amp, comma, 2 amps, comma, \
+                1 candela, comma; 2 candelas, comma, \
+                1 kelvin, comma, 2 kelvins, comma, \
+                1 kelvin, comma, 2 kelvins, comma, \
+                1 gram, comma, 2 grams, comma, \
+                1 metre, comma, 2 metres, comma, \
+                1 mole, comma, 2 moles, comma, \
+                1 second, comma, 2 seconds, comma, \
+                1 second, comma, 2 seconds, comma, \
+                1 second, comma, 2 seconds, comma, \
+                1 second, comma, 2 seconds")?;
+                return Ok(());
+
+}
+
+#[test]
+fn si_base_with_prefixes() -> Result<()> {
+    let expr = r#"<math>
+        <mn>1</mn><mi intent=":unit">QA</mi><mo>,</mo><mn>2</mn><mi intent=":unit">RA</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">Ycd</mi><mo>,</mo><mn>2</mn><mi intent=":unit">Zcd</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">EK</mi><mo>,</mo><mn>2</mn><mi intent=":unit">PK</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">Tâ„ª</mi><mo>,</mo><mn>2</mn><mi intent=":unit">Gâ„ª</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">Mg</mi><mo>,</mo><mn>2</mn><mi intent=":unit">kg</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">hm</mi><mo>,</mo><mn>2</mn><mi intent=":unit">dam</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">dmol</mi><mo>,</mo><mn>2</mn><mi intent=":unit">cmol</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">ms</mi><mo>,</mo><mn>2</mn><mi intent=":unit">Âµs</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">nsec</mi><mo>,</mo><mn>2</mn><mi intent=":unit">psec</mi>
+    </math>"#;
+    test("pt", "SimpleSpeak", expr, 
+        "1 quetta-amp, comma; 2 ronna-amps, comma; \
+                1 yotta-candela, comma; 2 zetta-candelas, comma; \
+                1 exa-kelvin, comma; 2 peta-kelvins, comma; \
+                1 tera-kelvin, comma; 2 giga-kelvins, comma; \
+                1 mega-gram, comma; 2 kilo-grams, comma; \
+                1 hecto-metre, comma; 2 deka-metres, comma; \
+                1 deci-mole, comma; 2 centi-moles, comma; \
+                1 milli-second, comma; 2 micro-seconds, comma; \
+                1 nano-second, comma; 2 pico-seconds")?;
+                return Ok(());
+
+}
+
+
+#[test]
+fn si_derived_1() -> Result<()> {
+    let expr = r#"<math>
+        <mn>1</mn><mi intent=":unit">Bq</mi><mo>,</mo><mn>2</mn><mi intent=":unit">Bq</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">C</mi><mo>,</mo><mn>2</mn><mi intent=":unit">C</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">Â°C</mi><mo>,</mo><mn>2</mn><mi intent=":unit">Â°C</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">â„ƒ</mi><mo>,</mo><mn>2</mn><mi intent=":unit">â„ƒ</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">F</mi><mo>,</mo><mn>2</mn><mi intent=":unit">F</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">Gy</mi><mo>,</mo><mn>2</mn><mi intent=":unit">Gy</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">H</mi><mo>,</mo><mn>2</mn><mi intent=":unit">H</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">Hz</mi><mo>,</mo><mn>2</mn><mi intent=":unit">Hz</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">J</mi><mo>,</mo><mn>2</mn><mi intent=":unit">J</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">kat</mi><mo>,</mo><mn>2</mn><mi intent=":unit">kat</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">lm</mi><mo>,</mo><mn>2</mn><mi intent=":unit">lm</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">lx</mi><mo>,</mo><mn>2</mn><mi intent=":unit">lx</mi>
+    </math>"#;
+    test("pt", "SimpleSpeak", expr, 
+        "1 becquerel, comma; 2 becquerels, comma, \
+                1 coulomb, comma; 2 coulombs, comma; \
+                1 degree celsius, comma; 2 degrees celsius, comma; \
+                1 degree celsius, comma; 2 degrees celsius, comma, \
+                1 farad, comma, 2 farads, comma, \
+                1 gray, comma, 2 grays, comma, \
+                1 henry, comma, 2 henries, comma, \
+                1 hertz, comma, 2 hertz, comma, \
+                1 joule, comma, 2 joules, comma, \
+                1 katal, comma, 2 katals, comma, \
+                1 lumen, comma, 2 lumens, comma, \
+                1 lux, comma, 2 lux")?;
+                return Ok(());
+
+}
+
+#[test]
+fn si_derived_1_with_prefixes() -> Result<()> {
+    let expr = r#"<math>
+        <mn>1</mn><mi intent=":unit">QBq</mi><mo>,</mo><mn>2</mn><mi intent=":unit">RBq</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">YC</mi><mo>,</mo><mn>2</mn><mi intent=":unit">ZC</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">EF</mi><mo>,</mo><mn>2</mn><mi intent=":unit">PF</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">TGy</mi><mo>,</mo><mn>2</mn><mi intent=":unit">GGy</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">MH</mi><mo>,</mo><mn>2</mn><mi intent=":unit">kH</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">daHz</mi><mo>,</mo><mn>2</mn><mi intent=":unit">dHz</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">cJ</mi><mo>,</mo><mn>2</mn><mi intent=":unit">mJ</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">Âµkat</mi><mo>,</mo><mn>2</mn><mi intent=":unit">nkat</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">plm</mi><mo>,</mo><mn>2</mn><mi intent=":unit">flm</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">alx</mi><mo>,</mo><mn>2</mn><mi intent=":unit">zlx</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">mÂ°C</mi><mo>,</mo><mn>2</mn><mi intent=":unit">ÂµÂ°C</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">pâ„ƒ</mi><mo>,</mo><mn>2</mn><mi intent=":unit">nâ„ƒ</mi>
+    </math>"#;
+    test("pt", "SimpleSpeak", expr, 
+        "1 quetta-becquerel, comma; 2 ronna-becquerels; comma; \
+                1 yotta-coulomb, comma; 2 zetta-coulombs, comma; \
+                1 exa-farad, comma; 2 peta-farads, comma; \
+                1 tera-gray, comma; 2 giga-grays, comma; \
+                1 mega-henry, comma; 2 kilo-henries, comma; \
+                1 deka-hertz, comma; 2 deci-hertz, comma; \
+                1 centi-joule, comma; 2 milli-joules, comma; \
+                1 micro-katal, comma; 2 nano-katals, comma; \
+                1 pico-lumen, comma; 2 femto-lumens, comma; \
+                1 atto-lux, comma; 2 zepto-lux, comma; \
+                1 milli-degree celsius; comma; 2 micro-degrees celsius; comma; \
+                1 pico-degree celsius; comma; 2 nano-degrees celsius")?;
+                return Ok(());
+
+}
+
+#[test]
+fn si_derived_2() -> Result<()> {
+    let expr = r#"<math>
+        <mn>1</mn><mi intent=":unit">N</mi><mo>,</mo><mn>2</mn><mi intent=":unit">N</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">Î©</mi><mo>,</mo><mn>2</mn><mi intent=":unit">Î©</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">â„¦</mi><mo>,</mo><mn>2</mn><mi intent=":unit">â„¦</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">Pa</mi><mo>,</mo><mn>2</mn><mi intent=":unit">Pa</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">S</mi><mo>,</mo><mn>2</mn><mi intent=":unit">S</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">Sv</mi><mo>,</mo><mn>2</mn><mi intent=":unit">Sv</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">T</mi><mo>,</mo><mn>2</mn><mi intent=":unit">T</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">V</mi><mo>,</mo><mn>2</mn><mi intent=":unit">V</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">W</mi><mo>,</mo><mn>2</mn><mi intent=":unit">W</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">Wb</mi><mo>,</mo><mn>2</mn><mi intent=":unit">Wb</mi>
+    </math>"#;
+    test("pt", "SimpleSpeak", expr, 
+        "1 newton, comma, 2 newtons, comma, \
+                1 ohm, comma, 2 ohms, comma, \
+                1 ohm, comma, 2 ohms, comma, \
+                1 pascal, comma, 2 pascals, comma, \
+                1 siemens, comma, 2 siemens, comma, \
+                1 sievert, comma; 2 sieverts, comma, \
+                1 tesla, comma, 2 teslas, comma, \
+                1 volt, comma, 2 volts, comma, \
+                1 watt, comma, 2 watts, comma, \
+                1 weber, comma, 2 webers")?;
+                return Ok(());
+
+}
+
+#[test]
+fn si_derived_2_with_prefixes() -> Result<()> {
+    let expr = r#"<math>
+        <mn>1</mn><mi intent=":unit">qN</mi><mo>,</mo><mn>2</mn><mi intent=":unit">rN</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">yÎ©</mi><mo>,</mo><mn>2</mn><mi intent=":unit">zÎ©</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">aâ„¦</mi><mo>,</mo><mn>2</mn><mi intent=":unit">fâ„¦</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">pPa</mi><mo>,</mo><mn>2</mn><mi intent=":unit">nPa</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">ÂµS</mi><mo>,</mo><mn>2</mn><mi intent=":unit">mS</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">cSv</mi><mo>,</mo><mn>2</mn><mi intent=":unit">dSv</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">daT</mi><mo>,</mo><mn>2</mn><mi intent=":unit">hT</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">kV</mi><mo>,</mo><mn>2</mn><mi intent=":unit">MV</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">GW</mi><mo>,</mo><mn>2</mn><mi intent=":unit">TW</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">PWb</mi><mo>,</mo><mn>2</mn><mi intent=":unit">EWb</mi>
+    </math>"#;
+    test("pt", "SimpleSpeak", expr, 
+        "1 quecto-newton, comma; 2 ronto-newtons, comma; \
+                1 yocto-ohm, comma; 2 zepto-ohms, comma; \
+                1 atto-ohm, comma; 2 femto-ohms, comma; \
+                1 pico-pascal, comma; 2 nano-pascals, comma; \
+                1 micro-siemens, comma; 2 milli-siemens, comma; \
+                1 centi-sievert, comma; 2 deci-sieverts, comma; \
+                1 deka-tesla, comma; 2 hecto-teslas, comma; \
+                1 kilo-volt, comma; 2 mega-volts, comma; \
+                1 giga-watt, comma; 2 tera-watts, comma; \
+                1 peta-weber, comma; 2 exa-webers")?;
+                return Ok(());
+
+}
+
+
+#[test]
+fn si_accepted() -> Result<()> {
+    let expr = r#"<math>
+        <mn>1</mn><mi intent=":unit">l</mi><mo>,</mo><mn>2</mn><mi intent=":unit">l</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">L</mi><mo>,</mo><mn>2</mn><mi intent=":unit">L</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">â„“</mi><mo>,</mo><mn>2</mn><mi intent=":unit">â„“</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">t</mi><mo>,</mo><mn>2</mn><mi intent=":unit">t</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">Da</mi><mo>,</mo><mn>2</mn><mi intent=":unit">Da</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">Np</mi><mo>,</mo><mn>2</mn><mi intent=":unit">Np</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">u</mi><mo>,</mo><mn>2</mn><mi intent=":unit">u</mi><mo>,</mo> 
+        <mn>1</mn><mi intent=":unit">eV</mi><mo>,</mo><mn>2</mn><mi intent=":unit">eV</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">rad</mi><mo>,</mo><mn>2</mn><mi intent=":unit">rad</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">sr</mi><mo>,</mo><mn>2</mn><mi intent=":unit">sr</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">a</mi><mo>,</mo><mn>2</mn><mi intent=":unit">a</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">as</mi><mo>,</mo><mn>2</mn><mi intent=":unit">as</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">b</mi><mo>,</mo><mn>2</mn><mi intent=":unit">b</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">B</mi><mo>,</mo><mn>2</mn><mi intent=":unit">B</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">Bd</mi><mo>,</mo><mn>2</mn><mi intent=":unit">Bd</mi>
+    </math>"#;
+    test("pt", "SimpleSpeak", expr, 
+        "1 litre, comma, 2 litres, comma, \
+                1 litre, comma, 2 litres, comma, \
+                1 litre, comma, 2 litres, comma, \
+                1 metric ton, comma; 2 metric tons, comma, \
+                1 dalton, comma, 2 daltons, comma, \
+                1 neper, comma, 2 nepers, comma; \
+                1 atomic mass unit, comma; 2 atomic mass units, comma; \
+                1 electronvolt, comma; 2 electronvolts, comma, \
+                1 radian, comma, 2 radians, comma, \
+                1 steradian, comma; 2 steradians, comma, \
+                1 annum, comma, 2 annums, comma, \
+                1 arcsecond, comma; 2 arcseconds, comma, \
+                1 bit, comma, 2 bits, comma, \
+                1 byte, comma, 2 bytes, comma, \
+                1 baud, comma, 2 bauds")?;
+                return Ok(());
+
+}
+
+#[test]
+fn si_accepted_with_prefixes() -> Result<()> {
+    let expr = r#"<math>
+        <mn>1</mn><mi intent=":unit">Ql</mi><mo>,</mo><mn>2</mn><mi intent=":unit">Rl</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">YL</mi><mo>,</mo><mn>2</mn><mi intent=":unit">ZL</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">Eâ„“</mi><mo>,</mo><mn>2</mn><mi intent=":unit">Pâ„“</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">Tt</mi><mo>,</mo><mn>2</mn><mi intent=":unit">Gt</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">MDa</mi><mo>,</mo><mn>2</mn><mi intent=":unit">kDa</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">dNp</mi><mo>,</mo><mn>2</mn><mi intent=":unit">cNp</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">hu</mi><mo>,</mo><mn>2</mn><mi intent=":unit">dau</mi><mo>,</mo> 
+        <mn>1</mn><mi intent=":unit">meV</mi><mo>,</mo><mn>2</mn><mi intent=":unit">ÂµeV</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">nrad</mi><mo>,</mo><mn>2</mn><mi intent=":unit">prad</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">fsr</mi><mo>,</mo><mn>2</mn><mi intent=":unit">asr</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">Ga</mi><mo>,</mo><mn>2</mn><mi intent=":unit">Ma</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">zas</mi><mo>,</mo><mn>2</mn><mi intent=":unit">yas</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">kb</mi><mo>,</mo><mn>2</mn><mi intent=":unit">Mb</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">GB</mi><mo>,</mo><mn>2</mn><mi intent=":unit">TB</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">TBd</mi><mo>,</mo><mn>2</mn><mi intent=":unit">EBd</mi>
+    </math>"#;
+    test("pt", "SimpleSpeak", expr, 
+        "1 quetta-litre, comma; 2 ronna-litres, comma; \
+                1 yotta-litre, comma; 2 zetta-litres, comma; \
+                1 exa-litre, comma; 2 peta-litres, comma; \
+                1 tera-metric ton, comma; 2 giga-metric tons; comma; \
+                1 mega-dalton, comma; 2 kilo-daltons, comma; \
+                1 deci-neper, comma; 2 centi-nepers, comma; \
+                1 hecto-atomic mass unit; comma; 2 deka-atomic mass units; comma; \
+                1 milli-electronvolt, comma; 2 micro-electronvolts; comma; \
+                1 nano-radian, comma; 2 pico-radians, comma; \
+                1 femto-steradian, comma; 2 atto-steradians; comma; \
+                1 giga-annum, comma; 2 mega-annums, comma; \
+                1 zepto-arcsecond, comma; 2 yocto-arcseconds; comma; \
+                1 kilo-bit, comma; 2 mega-bits, comma; \
+                1 giga-byte, comma; 2 tera-bytes, comma; \
+                1 tera-baud, comma; 2 exa-bauds")?;
+                return Ok(());
+
+}
+
+#[test]
+fn without_prefix_time() -> Result<()> {
+    let expr = r#"<math>
+        <mn>1</mn><mi intent=":unit">â€³</mi><mo>,</mo><mn>2</mn><mi intent=":unit">â€³</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">&quot;</mi><mo>,</mo><mn>2</mn><mi intent=":unit">&quot;</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">â€²</mi><mo>,</mo><mn>2</mn><mi intent=":unit">â€²</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">'</mi><mo>,</mo><mn>2</mn><mi intent=":unit">'</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">min</mi><mo>,</mo><mn>2</mn><mi intent=":unit">min</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">h</mi><mo>,</mo><mn>2</mn><mi intent=":unit">h</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">hr</mi><mo>,</mo><mn>2</mn><mi intent=":unit">hr</mi><mo>,</mo> 
+        <mn>1</mn><mi intent=":unit">Hr</mi><mo>,</mo><mn>2</mn><mi intent=":unit">Hr</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">d</mi><mo>,</mo><mn>2</mn><mi intent=":unit">d</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">dy</mi><mo>,</mo><mn>2</mn><mi intent=":unit">dy</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">w</mi><mo>,</mo><mn>2</mn><mi intent=":unit">w</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">wk</mi><mo>,</mo><mn>2</mn><mi intent=":unit">wk</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">y</mi><mo>,</mo><mn>2</mn><mi intent=":unit">y</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">yr</mi><mo>,</mo><mn>2</mn><mi intent=":unit">yr</mi>
+    </math>"#;
+    test("pt", "SimpleSpeak", expr, 
+        "1 second, comma, 2 seconds, comma, \
+                1 second, comma, 2 seconds, comma, \
+                1 minute, comma, 2 minutes, comma, \
+                1 minute, comma, 2 minutes, comma, \
+                1 minute, comma, 2 minutes, comma, \
+                1 hour, comma, 2 hours, comma, \
+                1 hour, comma, 2 hours, comma, \
+                1 hour, comma, 2 hours, comma, \
+                1 day, comma, 2 days, comma, \
+                1 day, comma, 2 days, comma, \
+                1 week, comma, 2 weeks, comma, \
+                1 week, comma, 2 weeks, comma, \
+                1 year, comma, 2 years, comma, \
+                1 year, comma, 2 years")?;
+                return Ok(());
+
+}
+
+#[test]
+fn without_prefix_angles() -> Result<()> {
+    let expr = r#"<math>
+        <mn>1</mn><mi intent=":unit">Â°</mi><mo>,</mo><mn>2</mn><mi intent=":unit">Â°</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">deg</mi><mo>,</mo><mn>2</mn><mi intent=":unit">deg</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">arcmin</mi><mo>,</mo><mn>2</mn><mi intent=":unit">arcmin</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">amin</mi><mo>,</mo><mn>2</mn><mi intent=":unit">amin</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">am</mi><mo>,</mo><mn>2</mn><mi intent=":unit">am</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">MOA</mi><mo>,</mo><mn>2</mn><mi intent=":unit">MOA</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">arcsec</mi><mo>,</mo><mn>2</mn><mi intent=":unit">arcsec</mi><mo>,</mo> 
+        <mn>1</mn><mi intent=":unit">asec</mi><mo>,</mo><mn>2</mn><mi intent=":unit">asec</mi>
+    </math>"#;
+    test("pt", "SimpleSpeak", expr, 
+        "1 degree, comma, 2 degrees, comma, \
+                1 degree, comma, 2 degrees, comma, \
+                1 arcminute, comma; 2 arcminutes, comma, \
+                1 arcminute, comma; 2 arcminutes, comma, \
+                1 arcminute, comma; 2 arcminutes, comma, \
+                1 arcminute, comma; 2 arcminutes, comma, \
+                1 arcsecond, comma; 2 arcseconds, comma, \
+                1 arcsecond, comma; 2 arcseconds")?;
+                return Ok(());
+
+}
+
+#[test]
+fn without_prefix_distance() -> Result<()> {
+    let expr = r#"<math>
+        <mn>1</mn><mi intent=":unit">au</mi><mo>,</mo><mn>2</mn><mi intent=":unit">au</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">ltyr</mi><mo>,</mo><mn>2</mn><mi intent=":unit">ltyr</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">pc</mi><mo>,</mo><mn>2</mn><mi intent=":unit">pc</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">Ã…</mi><mo>,</mo><mn>2</mn><mi intent=":unit">Ã…</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">â„«</mi><mo>,</mo><mn>2</mn><mi intent=":unit">â„«</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">fm</mi><mo>,</mo><mn>2</mn><mi intent=":unit">fm</mi>
+    </math>"#;
+    test("pt", "SimpleSpeak", expr, 
+        "1 astronomical unit, comma; 2 astronomical units, comma, \
+                1 light year, comma; 2 light years, comma, \
+                1 parsec, comma, 2 parsecs, comma, \
+                1 angstrom, comma; 2 angstroms, comma, \
+                1 angstrom, comma; 2 angstroms, comma, \
+                1 fermi, comma, 2 fermis")?;
+                return Ok(());
+
+}
+
+#[test]
+fn without_prefix_other() -> Result<()> {
+    let expr = r#"<math>
+        <mn>1</mn><mi intent=":unit">ha</mi><mo>,</mo><mn>2</mn><mi intent=":unit">ha</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">dB</mi><mo>,</mo><mn>2</mn><mi intent=":unit">dB</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">atm</mi><mo>,</mo><mn>2</mn><mi intent=":unit">atm</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">amu</mi><mo>,</mo><mn>2</mn><mi intent=":unit">amu</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">bar</mi><mo>,</mo><mn>2</mn><mi intent=":unit">bar</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">cal</mi><mo>,</mo><mn>2</mn><mi intent=":unit">cal</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">Ci</mi><mo>,</mo><mn>2</mn><mi intent=":unit">Ci</mi><mo>,</mo> 
+        <mn>1</mn><mi intent=":unit">grad</mi><mo>,</mo><mn>2</mn><mi intent=":unit">grad</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">M</mi><mo>,</mo><mn>2</mn><mi intent=":unit">M</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">R</mi><mo>,</mo><mn>2</mn><mi intent=":unit">R</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">rpm</mi><mo>,</mo><mn>2</mn><mi intent=":unit">rpm</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">fl dr</mi><mo>,</mo><mn>2</mn><mi intent=":unit">fl dr</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">â„§</mi><mo>,</mo><mn>2</mn><mi intent=":unit">â„§</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">dyn</mi><mo>,</mo><mn>2</mn><mi intent=":unit">dyn</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">erg</mi><mo>,</mo><mn>2</mn><mi intent=":unit">erg</mi>
+    </math>"#;
+    test("pt", "SimpleSpeak", expr, 
+        "1 hectare, comma; 2 hectares, comma, \
+                1 decibel, comma; 2 decibels, comma, \
+                1 atmosphere, comma; 2 atmospheres, comma; \
+                1 atomic mass unit, comma; 2 atomic mass units, comma, \
+                1 bar, comma, 2 bars, comma, \
+                1 calorie, comma; 2 calories, comma, \
+                1 curie, comma, 2 curies, comma, \
+                1 gradian, comma; 2 gradians, comma, \
+                1 molar, comma, 2 molars, comma, \
+                1 roentgen, comma; 2 roentgens, comma; \
+                1 revolution per minute, comma; 2 revolutions per minute, comma, \
+                1 fluid dram, comma; 2 fluid drams, comma, \
+                1 m-h-o, comma, 2 m-h-os, comma, \
+                1 dyne, comma, 2 dynes, comma, \
+                1 erg, comma, 2 ergs")?;
+                return Ok(());
+
+}
+
+#[test]
+fn without_prefix_powers_of_2() -> Result<()> {
+    let expr = r#"<math>
+        <mn>1</mn><mi intent=":unit">Kib</mi><mo>,</mo><mn>2</mn><mi intent=":unit">Kib</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">Mib</mi><mo>,</mo><mn>2</mn><mi intent=":unit">Mib</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">Gib</mi><mo>,</mo><mn>2</mn><mi intent=":unit">Gib</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">Tib</mi><mo>,</mo><mn>2</mn><mi intent=":unit">Tib</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">Pib</mi><mo>,</mo><mn>2</mn><mi intent=":unit">Pib</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">Eib</mi><mo>,</mo><mn>2</mn><mi intent=":unit">Eib</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">Zib</mi><mo>,</mo><mn>2</mn><mi intent=":unit">Zib</mi><mo>,</mo> 
+        <mn>1</mn><mi intent=":unit">Yib</mi><mo>,</mo><mn>2</mn><mi intent=":unit">Yib</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">KiB</mi><mo>,</mo><mn>2</mn><mi intent=":unit">KiB</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">MiB</mi><mo>,</mo><mn>2</mn><mi intent=":unit">MiB</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">GiB</mi><mo>,</mo><mn>2</mn><mi intent=":unit">GiB</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">TiB</mi><mo>,</mo><mn>2</mn><mi intent=":unit">TiB</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">PiB</mi><mo>,</mo><mn>2</mn><mi intent=":unit">PiB</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">EiB</mi><mo>,</mo><mn>2</mn><mi intent=":unit">EiB</mi><mo>,</mo>
+        <mn>1</mn><mi intent=":unit">ZiB</mi><mo>,</mo><mn>2</mn><mi intent=":unit">ZiB</mi><mo>,</mo> 
+        <mn>1</mn><mi intent=":unit">YiB</mi><mo>,</mo><mn>2</mn><mi intent=":unit">YiB</mi>
+    </math>"#;
+    test("pt", "SimpleSpeak", expr, 
+        "1 kibi-bit, comma; 2 kibi-bits, comma, \
+                1 mebi-bit, comma; 2 mebi-bits, comma, \
+                1 gibi-bit, comma; 2 gibi-bits, comma, \
+                1 tebi-bit, comma; 2 tebi-bits, comma, \
+                1 pebi-bit, comma; 2 pebi-bits, comma, \
+                1 exbi-bit, comma; 2 exbi-bits, comma, \
+                1 zebi-bit, comma; 2 zebi-bits, comma, \
+                1 yobi-bit, comma; 2 yobi-bits, comma, \
+                1 kibi-byte, comma; 2 kibi-bytes, comma, \
+                1 mebi-byte, comma; 2 mebi-bytes, comma, \
+                1 gibi-byte, comma; 2 gibi-bytes, comma, \
+                1 tebi-byte, comma; 2 tebi-bytes, comma, \
+                1 pebi-byte, comma; 2 pebi-bytes, comma, \
+                1 exbi-byte, comma; 2 exbi-bytes, comma, \
+                1 zebi-byte, comma; 2 zebi-bytes, comma, \
+                1 yobi-byte, comma; 2 yobi-bytes")?;
+                return Ok(());
+
+}
+
+
+#[test]
+fn si_other_numbers() -> Result<()> {
+    let expr = r#"<math><mn>1.0</mn><mi intent=":unit">l</mi><mo>,</mo>
+                            <mn>2.0</mn><mo>&#xA0;</mo><mi intent=":unit">m</mi><mo>,</mo>
+                            <mi>x</mi><mo>&#xA0;</mo><mi intent=":unit">ms</mi><mo>,</mo>
+                            <mi>y</mi><mi intent=":unit">Âµs</mi><mo>,</mo>
+                            <mi intent=":unit">dag</mi><mo>,</mo>
+                            <mn>1235</mn><mi intent=":unit">daN</mi><mo>,</mo>
+                            <mn>2.5</mn><mi intent=":unit">&#xB5;sec</mi><mo>,</mo>
+                            <mn>32.34</mn><mi intent=":unit">mol</mi></math>"#;
+    test_prefs("pt", "SimpleSpeak", vec![("Verbosity", "Terse")], expr,
+            "1.0 l comma, 2.0 m comma; x milli-seconds, comma; y micro-seconds, comma, \
+                    deka-grams, comma; 1235 deka-newtons; comma; 2.5 micro-seconds; comma; 32.34 moles")?;
+    test_prefs("pt", "ClearSpeak", vec![("Verbosity", "Medium")], expr,
+            "1.0 litre, comma; 2.0 metres, comma; x milli-seconds, comma; y micro-seconds, comma, \
+                    deka-grams, comma; 1235 deka-newtons; comma; 2.5 micro-seconds; comma; 32.34 moles")?;
+    test_prefs("pt", "SimpleSpeak", vec![("Verbosity", "Verbose")], expr,
+            "1.0 litre, comma; 2.0 metres, comma; x milli-seconds, comma; y micro-seconds, comma, \
+                    deka-grams, comma; 1235 deka-newtons; comma; 2.5 micro-seconds; comma; 32.34 moles")?;
+                    return Ok(());
+
+}
+
+
+#[test]
+fn test_mtext_inference() -> Result<()> {
+    let expr = r#"<math><mo>[</mo>
+                <mn>1</mn><mtext>t</mtext><mo>,</mo>
+                <mn>2</mn><mtext>PA</mtext><mo>,</mo>
+                <mn>3</mn><mtext>Pa</mtext><mo>,</mo>
+                <mn>4.5</mn><mtext>mT</mtext>
+            <mo>]</mo></math>"#;
+    test("pt", "SimpleSpeak", expr, 
+        "open bracket; 1 metric ton, comma; 2 peta-amps, comma, \
+                3 pascals, comma; 4.5 milli-teslas; close bracket")?;
+                return Ok(());
+
+}
+
+    #[test]
+    fn infer_unit() -> Result<()> {
+        let expr = r#"<math>
+            <mn>3</mn><mi mathvariant="normal">m</mi><mo>,</mo>
+            <mn>1</mn><mi>km</mi><mo>,</mo>
+            <mn>3</mn><mtext>m</mtext><mo>,</mo>
+            <mfrac><mn>3</mn><mn>10</mn></mfrac><mi mathvariant="normal">F</mi><mo>,</mo>
+            <msub><mi>m</mi><mi>min</mi></msub>
+            </math>"#;
+        test("pt", "SimpleSpeak", expr, 
+            "3 metres, comma; 1 kilo-metre, comma, 3 metres, comma; 3 tenths farads, comma; m sub min end sub")?;
+            return Ok(());
+
+    }

--- a/tests/languages.rs
+++ b/tests/languages.rs
@@ -15,6 +15,7 @@ mod Languages {
     mod nb;
     mod de;
     mod fr;
+    mod pt;
     mod vi {
         mod vi;
     }


### PR DESCRIPTION
## Summary

Adds a full Brazilian Portuguese (pt-BR) translation of MathCAT's speech rules, following the steps in `docs/new_translators_guide_MathCAT_revised.md`.

## What's included

- **`Rules/Languages/pt/`** — 12 new rule files: `SimpleSpeak_Rules.yaml`, `ClearSpeak_Rules.yaml`, `navigate.yaml`, `overview.yaml`, `definitions.yaml`, `unicode.yaml`, `unicode-full.yaml`, and `SharedRules/` (calculus, default, general, geometry, linear-algebra).
- **Tests** — `tests/Languages/pt.rs` plus the `tests/Languages/pt/` suite copied from English with language set to `"pt"`, and `mod pt;` registered in `tests/languages.rs`.

## Translation notes

- Reviewed with `audit-translations`: all 12 files parse; rule coverage matches the English reference.
- Letter ranges merged to `"a-z"`/`"A-Z"` as instructed by the file header comment (pt has a single pronunciation of "a"), matching the `es` convention.
- Fixed Google-translate artifacts: Greek letter spellings (`nu`, `xi`, `ômicron`, `rô`, `qui`, `ômega`), math font names (fratura→gótica, double-struck→dupla escrita, script→cursiva), fraction/root speech in `SharedRules/default.yaml`, and navigation strings in `navigate.yaml`.

Note: `cargo test Languages::pt` has not been run locally (no Rust toolchain available); the test files are copied from the English suite and are expected to need expected-output updates in a first run, per the guide.
